### PR TITLE
fix: add step timeout for gemini review

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -52,6 +52,7 @@ jobs:
       - name: 'Run Gemini pull request review (primary, attempt 1)'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'gemini_pr_review_1'
+        timeout-minutes: 4
         continue-on-error: true
         env: &gemini_review_env
           GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
@@ -142,6 +143,7 @@ jobs:
         if: steps.gemini_pr_review_1.outcome != 'success'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'gemini_pr_review_2'
+        timeout-minutes: 4
         continue-on-error: true
         env: *gemini_review_env
         with:
@@ -169,6 +171,7 @@ jobs:
         if: steps.gemini_pr_review_1.outcome != 'success' && steps.gemini_pr_review_2.outcome != 'success'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'gemini_pr_review_fallback'
+        timeout-minutes: 4
         continue-on-error: true
         env: *gemini_review_env
         with:


### PR DESCRIPTION
Add per-step `timeout-minutes` to the run-gemini-cli steps inside the shared `gemini-review` workflow.

Why:
- We observed `gemini-3-pro-preview` sometimes hangs without returning an error.
- Without a step timeout, the job hits the overall timeout and gets cancelled, skipping retry/fallback logic.

This keeps the existing retry/backoff + fallback behavior but ensures we actually progress to attempt 2 / fallback.