### PR TITLE
fix: add gemini review context guardrails

### DIFF
--- a/.github/scripts/setup-gemini-safe-bin.sh
+++ b/.github/scripts/setup-gemini-safe-bin.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env sh
+set -eu
+
+# Create safe wrappers for the limited shell tools enabled in gemini-cli settings.
+# These wrappers refuse large/binary payloads to prevent prompt/context explosions.
+
+max_bytes="${GEMINI_MAX_READ_BYTES:-200000}"
+
+mkdir -p .gemini/safe-bin
+
+cat > .gemini/safe-bin/_validate_file.sh <<'SH'
+#!/usr/bin/env sh
+set -eu
+
+max_bytes="${GEMINI_MAX_READ_BYTES:-200000}"
+
+is_blocked_ext() {
+  case "$1" in
+    *.bin|*.ko|*.deb|*.tar|*.tar.gz|*.tgz|*.zip|*.gz|*.xz|*.7z|*.exe|*.so|*.a|*.o)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+is_text_file() {
+  mime=$(file -b --mime-type "$1" 2>/dev/null || true)
+  case "$mime" in
+    text/*|application/json|application/xml)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+validate_file() {
+  f="$1"
+
+  if [ "$f" = "-" ]; then
+    echo "ERROR: refusing to read from stdin" >&2
+    exit 2
+  fi
+
+  if is_blocked_ext "$f"; then
+    echo "ERROR: refusing to read blocked file type: $f" >&2
+    exit 2
+  fi
+
+  if [ ! -f "$f" ]; then
+    echo "ERROR: file not found or not a regular file: $f" >&2
+    exit 2
+  fi
+
+  size=$(wc -c < "$f" | tr -d ' ')
+  if [ "$size" -gt "$max_bytes" ]; then
+    echo "ERROR: refusing to read large file ($size bytes): $f" >&2
+    exit 2
+  fi
+
+  if ! is_text_file "$f"; then
+    echo "ERROR: refusing to read non-text file: $f" >&2
+    exit 2
+  fi
+}
+
+# Validate any arg that is an existing file.
+for arg in "$@"; do
+  if [ -f "$arg" ]; then
+    validate_file "$arg"
+  fi
+done
+SH
+
+chmod +x .gemini/safe-bin/_validate_file.sh
+
+cat > .gemini/safe-bin/cat <<'SH'
+#!/usr/bin/env sh
+set -eu
+
+"${0%/*}/_validate_file.sh" "$@"
+exec /bin/cat "$@"
+SH
+
+cat > .gemini/safe-bin/head <<'SH'
+#!/usr/bin/env sh
+set -eu
+
+"${0%/*}/_validate_file.sh" "$@"
+exec /usr/bin/head "$@"
+SH
+
+cat > .gemini/safe-bin/tail <<'SH'
+#!/usr/bin/env sh
+set -eu
+
+"${0%/*}/_validate_file.sh" "$@"
+exec /usr/bin/tail "$@"
+SH
+
+cat > .gemini/safe-bin/grep <<'SH'
+#!/usr/bin/env sh
+set -eu
+
+"${0%/*}/_validate_file.sh" "$@"
+exec /usr/bin/grep "$@"
+SH
+
+chmod +x .gemini/safe-bin/cat .gemini/safe-bin/head .gemini/safe-bin/tail .gemini/safe-bin/grep
+
+# Quick sanity check that wrappers are discoverable.
+command -v cat >/dev/null 2>&1
+command -v grep >/dev/null 2>&1
+command -v head >/dev/null 2>&1
+command -v tail >/dev/null 2>&1

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -38,8 +38,29 @@ jobs:
       issues: 'write'
       pull-requests: 'write'
     steps:
-      - name: 'Checkout repository'
+      - name: 'Checkout repository (sparse)'
+        if: vars.GEMINI_SPARSE_CHECKOUT == 'true' && vars.GEMINI_SPARSE_CHECKOUT_PATTERNS != ''
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          fetch-depth: 1
+          lfs: false
+          submodules: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |-
+            ${{ vars.GEMINI_SPARSE_CHECKOUT_PATTERNS }}
+
+      - name: 'Checkout repository'
+        if: vars.GEMINI_SPARSE_CHECKOUT != 'true'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          fetch-depth: 1
+          lfs: false
+          submodules: false
+
+      - name: 'Setup safe shell wrappers'
+        run: |-
+          set -euo pipefail
+          ./.github/scripts/setup-gemini-safe-bin.sh
 
       - name: 'Setup authentication'
         id: 'auth'
@@ -55,6 +76,8 @@ jobs:
         timeout-minutes: 4
         continue-on-error: true
         env: &gemini_review_env
+          PATH: '${{ github.workspace }}/.gemini/safe-bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+          GEMINI_MAX_READ_BYTES: '${{ vars.GEMINI_MAX_READ_BYTES || 200000 }}'
           GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
           ISSUE_TITLE: '${{ inputs.issue_title || github.event.pull_request.title || github.event.issue.title }}'
           ISSUE_BODY: '${{ inputs.issue_body || github.event.pull_request.body || github.event.issue.body }}'
@@ -139,6 +162,17 @@ jobs:
         if: steps.gemini_pr_review_1.outcome != 'success'
         run: sleep 20
 
+      - name: 'Reset Gemini workspace before retry'
+        if: steps.gemini_pr_review_1.outcome != 'success'
+        run: |-
+          rm -rf .gemini
+
+      - name: 'Setup safe shell wrappers (retry)'
+        if: steps.gemini_pr_review_1.outcome != 'success'
+        run: |-
+          set -euo pipefail
+          ./.github/scripts/setup-gemini-safe-bin.sh
+
       - name: 'Run Gemini pull request review (primary, attempt 2)'
         if: steps.gemini_pr_review_1.outcome != 'success'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
@@ -166,6 +200,17 @@ jobs:
       - name: 'Backoff before fallback'
         if: steps.gemini_pr_review_1.outcome != 'success' && steps.gemini_pr_review_2.outcome != 'success'
         run: sleep 20
+
+      - name: 'Reset Gemini workspace before fallback'
+        if: steps.gemini_pr_review_1.outcome != 'success' && steps.gemini_pr_review_2.outcome != 'success'
+        run: |-
+          rm -rf .gemini
+
+      - name: 'Setup safe shell wrappers (fallback)'
+        if: steps.gemini_pr_review_1.outcome != 'success' && steps.gemini_pr_review_2.outcome != 'success'
+        run: |-
+          set -euo pipefail
+          ./.github/scripts/setup-gemini-safe-bin.sh
 
       - name: 'Run Gemini pull request review (fallback model)'
         if: steps.gemini_pr_review_1.outcome != 'success' && steps.gemini_pr_review_2.outcome != 'success'


### PR DESCRIPTION
## What
- Add optional sparse-checkout mode (controlled by repo vars) to reduce workspace exposure.
- Add safe wrappers for `cat/head/tail/grep` to refuse large/binary inputs (prevents context/token explosions).
- Reset `.gemini/` between retry/fallback attempts to avoid cross-attempt accumulation.

## Why
We observed intermittent Gemini review failures caused by the model reading large/binary artifacts (or accumulating state across attempts), leading to token-limit errors and noisy CI.

## How to use (repo vars)
- `GEMINI_SPARSE_CHECKOUT=true` + `GEMINI_SPARSE_CHECKOUT_PATTERNS=<multiline patterns>` to enable sparse checkout.
- `GEMINI_MAX_READ_BYTES` (default 200000) to control max readable file size.