### PR TITLE
fix: make gemini-review reusable workflow self-contained

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -58,9 +58,106 @@ jobs:
           submodules: false
 
       - name: 'Setup safe shell wrappers'
-        run: |-
+        run: &setup_safe_shell_wrappers |-
           set -euo pipefail
-          ./.github/scripts/setup-gemini-safe-bin.sh
+
+          # Create safe wrappers for the limited shell tools enabled in gemini-cli settings.
+          # These wrappers refuse large/binary payloads to prevent prompt/context explosions.
+          mkdir -p .gemini/safe-bin
+
+          cat > .gemini/safe-bin/_validate_file.sh <<'SH'
+          #!/usr/bin/env sh
+          set -eu
+
+          max_bytes="${GEMINI_MAX_READ_BYTES:-200000}"
+
+          is_blocked_ext() {
+            case "$1" in
+              *.bin|*.ko|*.deb|*.tar|*.tar.gz|*.tgz|*.zip|*.gz|*.xz|*.7z|*.exe|*.so|*.a|*.o)
+                return 0
+                ;;
+            esac
+            return 1
+          }
+
+          is_text_file() {
+            mime=$(file -b --mime-type "$1" 2>/dev/null || true)
+            case "$mime" in
+              text/*|application/json|application/xml)
+                return 0
+                ;;
+            esac
+            return 1
+          }
+
+          validate_file() {
+            f="$1"
+
+            if [ "$f" = "-" ]; then
+              echo "ERROR: refusing to read from stdin" >&2
+              exit 2
+            fi
+
+            if is_blocked_ext "$f"; then
+              echo "ERROR: refusing to read blocked file type: $f" >&2
+              exit 2
+            fi
+
+            if [ ! -f "$f" ]; then
+              echo "ERROR: file not found or not a regular file: $f" >&2
+              exit 2
+            fi
+
+            size=$(wc -c < "$f" | tr -d ' ')
+            if [ "$size" -gt "$max_bytes" ]; then
+              echo "ERROR: refusing to read large file ($size bytes): $f" >&2
+              exit 2
+            fi
+
+            if ! is_text_file "$f"; then
+              echo "ERROR: refusing to read non-text file: $f" >&2
+              exit 2
+            fi
+          }
+
+          for arg in "$@"; do
+            if [ -f "$arg" ]; then
+              validate_file "$arg"
+            fi
+          done
+          SH
+
+          chmod +x .gemini/safe-bin/_validate_file.sh
+
+          cat > .gemini/safe-bin/cat <<'SH'
+          #!/usr/bin/env sh
+          set -eu
+          "${0%/*}/_validate_file.sh" "$@"
+          exec /bin/cat "$@"
+          SH
+
+          cat > .gemini/safe-bin/head <<'SH'
+          #!/usr/bin/env sh
+          set -eu
+          "${0%/*}/_validate_file.sh" "$@"
+          exec /usr/bin/head "$@"
+          SH
+
+          cat > .gemini/safe-bin/tail <<'SH'
+          #!/usr/bin/env sh
+          set -eu
+          "${0%/*}/_validate_file.sh" "$@"
+          exec /usr/bin/tail "$@"
+          SH
+
+          cat > .gemini/safe-bin/grep <<'SH'
+          #!/usr/bin/env sh
+          set -eu
+          "${0%/*}/_validate_file.sh" "$@"
+          exec /usr/bin/grep "$@"
+          SH
+
+          chmod +x .gemini/safe-bin/cat .gemini/safe-bin/head .gemini/safe-bin/tail .gemini/safe-bin/grep
 
       - name: 'Setup authentication'
         id: 'auth'
@@ -169,9 +266,7 @@ jobs:
 
       - name: 'Setup safe shell wrappers (retry)'
         if: steps.gemini_pr_review_1.outcome != 'success'
-        run: |-
-          set -euo pipefail
-          ./.github/scripts/setup-gemini-safe-bin.sh
+        run: *setup_safe_shell_wrappers
 
       - name: 'Run Gemini pull request review (primary, attempt 2)'
         if: steps.gemini_pr_review_1.outcome != 'success'
@@ -208,9 +303,7 @@ jobs:
 
       - name: 'Setup safe shell wrappers (fallback)'
         if: steps.gemini_pr_review_1.outcome != 'success' && steps.gemini_pr_review_2.outcome != 'success'
-        run: |-
-          set -euo pipefail
-          ./.github/scripts/setup-gemini-safe-bin.sh
+        run: *setup_safe_shell_wrappers
 
       - name: 'Run Gemini pull request review (fallback model)'
         if: steps.gemini_pr_review_1.outcome != 'success' && steps.gemini_pr_review_2.outcome != 'success'
@@ -247,7 +340,7 @@ jobs:
       - name: 'Notify on failure'
         if: always() && steps.gemini_pr_review_1.outcome != 'success' && steps.gemini_pr_review_2.outcome != 'success' && steps.gemini_pr_review_fallback.outcome != 'success'
         env:
-          GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
+          GH_TOKEN: '${{ github.token }}'
           ISSUE_NUMBER: '${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'
         run: |-


### PR DESCRIPTION
## What
- Inline the safe wrapper setup directly in the reusable workflow so it works in the caller repo workspace.
- Keep retry/fallback behavior, and reset `.gemini/` between attempts.
- Use `GH_TOKEN: ${{ github.token }}` for failure notifications so the notify step doesn't depend on the auth step.

## Why
The previous v1.12 change referenced `./.github/scripts/setup-gemini-safe-bin.sh`, which exists in the automation repo but not in the calling repository's workspace (reusable workflows run in the caller repo checkout). This caused runs to fail before auth/review.