### PR TITLE
feat: add auto review toggle and @gemini alias

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
+      auto_enabled: ${{ steps.auto_mode.outputs.auto_enabled }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,9 +39,26 @@ jobs:
           workflow-name: claude-code-review
           force-run: ${{ inputs.force_run && 'true' || 'false' }}
 
+      - name: Check auto review mode
+        id: auto_mode
+        env:
+          FORCE_RUN: ${{ inputs.force_run && 'true' || 'false' }}
+        run: |-
+          CONFIG_FILE=".github/workflow-config.yml"
+          if [[ "$FORCE_RUN" == 'true' ]]; then
+            echo "auto_enabled=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          auto_enabled="true"
+          if [[ -f "$CONFIG_FILE" ]]; then
+            auto_enabled="$(ruby -ryaml -e 'cfg = (YAML.load_file(ARGV[0]) rescue {}) || {}; v = cfg.dig("review", "auto"); v = true if v.nil?; puts(v ? "true" : "false")' "$CONFIG_FILE" 2>/dev/null || echo true)"
+          fi
+          echo "auto_enabled=${auto_enabled}" >> "$GITHUB_OUTPUT"
+
   claude-review:
     needs: check-enabled
-    if: needs.check-enabled.outputs.enabled == 'true'
+    if: needs.check-enabled.outputs.enabled == 'true' && needs.check-enabled.outputs.auto_enabled == 'true'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -94,7 +112,7 @@ jobs:
   skipped:
     name: Workflow Skipped
     needs: check-enabled
-    if: needs.check-enabled.outputs.enabled != 'true'
+    if: needs.check-enabled.outputs.enabled != 'true' || needs.check-enabled.outputs.auto_enabled != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Notice

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
+      auto_enabled: ${{ steps.auto_mode.outputs.auto_enabled }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,9 +33,26 @@ jobs:
           workflow-name: gemini-auto-review
           force-run: ${{ inputs.force_run && 'true' || 'false' }}
 
+      - name: Check auto review mode
+        id: auto_mode
+        env:
+          FORCE_RUN: ${{ inputs.force_run && 'true' || 'false' }}
+        run: |-
+          CONFIG_FILE=".github/workflow-config.yml"
+          if [[ "$FORCE_RUN" == 'true' ]]; then
+            echo "auto_enabled=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          auto_enabled="true"
+          if [[ -f "$CONFIG_FILE" ]]; then
+            auto_enabled="$(ruby -ryaml -e 'cfg = (YAML.load_file(ARGV[0]) rescue {}) || {}; v = cfg.dig("review", "auto"); v = true if v.nil?; puts(v ? "true" : "false")' "$CONFIG_FILE" 2>/dev/null || echo true)"
+          fi
+          echo "auto_enabled=${auto_enabled}" >> "$GITHUB_OUTPUT"
+
   gemini-review:
     needs: check-enabled
-    if: needs.check-enabled.outputs.enabled == 'true'
+    if: needs.check-enabled.outputs.enabled == 'true' && needs.check-enabled.outputs.auto_enabled == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -68,6 +68,7 @@ jobs:
       review_enabled: '${{ steps.check_config.outputs.review_enabled }}'
       triage_enabled: '${{ steps.check_config.outputs.triage_enabled }}'
       invoke_enabled: '${{ steps.check_config.outputs.invoke_enabled }}'
+      auto_pr_review_enabled: '${{ steps.check_config.outputs.auto_pr_review_enabled }}'
     steps:
       - name: 'Checkout for config'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
@@ -92,6 +93,13 @@ jobs:
           echo "triage_enabled=$(get_enabled 'gemini-triage')" >> $GITHUB_OUTPUT
           echo "invoke_enabled=$(get_enabled 'gemini-invoke')" >> $GITHUB_OUTPUT
 
+          # Global auto-review toggle. Defaults to true if missing.
+          auto_pr_review_enabled="true"
+          if [[ -f "$CONFIG_FILE" ]]; then
+            auto_pr_review_enabled="$(ruby -ryaml -e 'cfg = (YAML.load_file(ARGV[0]) rescue {}) || {}; v = cfg.dig("review", "auto"); v = true if v.nil?; puts(v ? "true" : "false")' "$CONFIG_FILE" 2>/dev/null || echo true)"
+          fi
+          echo "auto_pr_review_enabled=${auto_pr_review_enabled}" >> $GITHUB_OUTPUT
+
       - name: 'Mint identity token'
         id: 'mint_identity_token'
         if: |-
@@ -107,19 +115,27 @@ jobs:
       - name: 'Extract command'
         id: 'extract_command'
         uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
+        env:
+          AUTO_PR_REVIEW_ENABLED: '${{ steps.check_config.outputs.auto_pr_review_enabled }}'
         with:
           script: |
             const eventType = `${context.eventName}.${context.payload.action || ''}`;
-            const request =
+            let request =
               context.payload?.comment?.body ??
               context.payload?.review?.body ??
               context.payload?.issue?.body ??
               '';
 
+            // Alias: allow `@gemini` to behave like `@gemini-cli`.
+            // We only normalize when the mention is at the start of the request (after whitespace).
+            const trimmed = request.trimStart();
+            request = trimmed.replace(/^@gemini(?!-cli)\b/, '@gemini-cli');
+
             core.setOutput('request', request);
 
             if (eventType === 'pull_request.opened') {
-              core.setOutput('command', 'review');
+              const autoEnabled = (process.env.AUTO_PR_REVIEW_ENABLED || 'true') === 'true';
+              core.setOutput('command', autoEnabled ? 'review' : 'noop');
             } else if (['issues.opened', 'issues.reopened'].includes(eventType)) {
               core.setOutput('command', 'triage');
             } else if (request.startsWith("@gemini-cli /review")) {


### PR DESCRIPTION
## What
- Add a global auto-review toggle via `.github/workflow-config.yml`:
  - `review.auto: true|false` (default true)
- Gate automatic PR reviewers:
  - `gemini-auto-review` skips when `review.auto=false`
  - `claude-code-review` skips when `review.auto=false`
  - `gemini-dispatch` no longer auto-reviews on `pull_request.opened` when `review.auto=false` (manual commands still work)
- Add alias support: `@gemini ...` is normalized to `@gemini-cli ...` (only when the mention is at the start of the comment).

## Why
We want:
- manual mentions to always work
- the ability to turn auto PR reviews on/off at the repo level without disabling the manual review pipeline.

## Notes
- This change is backward compatible: if `review.auto` is missing, it defaults to `true`.