### PR TITLE
fix: use github.token for Claude code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -83,6 +83,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use the workflow token for GitHub API calls.
+          # This avoids OIDC/app-token validation failures on PRs that modify workflow files.
+          github_token: ${{ github.token }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}


### PR DESCRIPTION
Claude Code Review was failing on PRs that modify workflow files due to GitHub's OIDC/workflow validation guardrails.

This change passes `github_token: ${{ github.token }}` to `anthropics/claude-code-action@v1` so it can comment using the workflow token without attempting the app-token exchange.