### PR TITLE
docs: baseline consumer workflow pack

### DIFF
--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -1,0 +1,98 @@
+# Shared Workflow Consumer Contract
+
+This document defines the consumer-facing contract for repositories that use the reusable
+workflows in `jhw7500/automation`.
+
+The intent:
+
+- Consumer repos keep only thin workflow wrappers (event triggers + `uses:`).
+- All non-trivial logic lives in `jhw7500/automation`.
+
+## Baseline copy
+
+Start by copying the baseline wrappers:
+
+- `examples/baseline-workflows/.github/`
+
+Copy that folder into your consumer repo's `.github/`.
+
+## Repo config file: `.github/workflow-config.yml`
+
+Workflows read `.github/workflow-config.yml` for repo-level behavior.
+
+### `review.auto`
+
+```yaml
+review:
+  auto: false
+```
+
+Semantics:
+
+- `review.auto: true`: enable automatic PR reviews (e.g. on PR opened/synchronize).
+- `review.auto: false`: disable automatic PR reviews.
+- Manual triggers must continue to work regardless of `review.auto`.
+  - Example manual trigger: comment `@gemini-cli /review ...`.
+
+## Secrets (consumer repository)
+
+Required secrets depend on which workflows you enable.
+
+- `GEMINI_API_KEY`
+  - Required for Gemini workflows (review/triage/invoke/dispatch).
+- `CLAUDE_CODE_OAUTH_TOKEN`
+  - Required for Claude workflows.
+
+## Variables (consumer repository)
+
+These are configured as GitHub Actions Variables.
+
+### Gemini runtime
+
+- `GEMINI_CLI_VERSION`
+  - Example: `preview`
+- `GEMINI_MODEL`
+  - Recommended default: `gemini-3-flash-preview`
+- `GEMINI_FALLBACK_MODEL`
+  - Recommended default: `gemini-3-flash-preview`
+- `GEMINI_DEBUG`
+  - Set to `true` to enable verbose logging.
+- `UPLOAD_ARTIFACTS`
+  - Set to `true` to upload run artifacts (logs/reports) for debugging.
+  - Recommended default: `false`.
+
+### Gemini guardrails
+
+- `GEMINI_MAX_READ_BYTES`
+  - Hard cap for file reads through the safe wrapper layer.
+  - Default: `200000` (bytes) if unset.
+
+- `GEMINI_SPARSE_CHECKOUT`
+- `GEMINI_SPARSE_CHECKOUT_PATTERNS`
+
+Sparse checkout is optional. If you enable it, you must provide patterns.
+
+Example:
+
+```text
+GEMINI_SPARSE_CHECKOUT=true
+GEMINI_SPARSE_CHECKOUT_PATTERNS=\
+.github/\
+src/\
+scripts/\
+README.md
+```
+
+Notes:
+
+- Keep patterns tight to reduce checkout size and reduce the chance of context bloat.
+- Do not include large generated artifacts or release outputs.
+
+## Wrapper workflow expectations
+
+Consumer repos should:
+
+- Pin reusable workflow versions (e.g. `@v1.15`) in wrapper `uses:` lines.
+- Keep wrappers portable (no `main`/`master` assumptions).
+- Avoid storing documentation under `.github/workflows/` in consumer repos.
+  - Put docs in `docs/` or keep them in `jhw7500/automation`.

--- a/examples/baseline-workflows/.github/workflow-config.yml
+++ b/examples/baseline-workflows/.github/workflow-config.yml
@@ -1,0 +1,10 @@
+# GitHub Actions Workflow Configuration
+#
+# This file controls enable/disable toggles for automatic workflows.
+# Workflows should default to enabled if this file is missing.
+
+# Global review behavior.
+# - manual triggers (e.g. @gemini-cli /review, @claude) should keep working regardless.
+# - set review.auto=false to disable automatic PR reviews.
+review:
+  auto: false

--- a/examples/baseline-workflows/.github/workflows/claude-code-review.yml
+++ b/examples/baseline-workflows/.github/workflows/claude-code-review.yml
@@ -1,0 +1,18 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    uses: jhw7500/automation/.github/workflows/claude-code-review.yml@v1.15
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets: inherit

--- a/examples/baseline-workflows/.github/workflows/claude.yml
+++ b/examples/baseline-workflows/.github/workflows/claude.yml
@@ -1,0 +1,22 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    uses: jhw7500/automation/.github/workflows/claude.yml@v1.15
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    secrets: inherit

--- a/examples/baseline-workflows/.github/workflows/gemini-auto-review.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-auto-review.yml
@@ -1,0 +1,18 @@
+name: Gemini Auto PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  gemini-review:
+    if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    uses: jhw7500/automation/.github/workflows/gemini-auto-review.yml@v1.15
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets: inherit

--- a/examples/baseline-workflows/.github/workflows/gemini-dispatch.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-dispatch.yml
@@ -1,0 +1,33 @@
+name: Gemini Dispatch
+
+on:
+  pull_request_review_comment:
+    types:
+      - created
+  pull_request_review:
+    types:
+      - submitted
+  pull_request:
+    types:
+      - opened
+  issues:
+    types:
+      - opened
+      - reopened
+  issue_comment:
+    types:
+      - created
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  dispatch:
+    uses: jhw7500/automation/.github/workflows/gemini-dispatch.yml@v1.15
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    secrets: inherit

--- a/examples/baseline-workflows/.github/workflows/gemini-invoke.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-invoke.yml
@@ -1,0 +1,46 @@
+name: Gemini Invoke
+
+on:
+  workflow_call:
+    inputs:
+      item_number:
+        type: string
+        description: Issue or pull request number
+        required: true
+      item_title:
+        type: string
+        description: Issue or pull request title
+        required: true
+      item_body:
+        type: string
+        description: Issue or pull request body
+        required: true
+      event_name:
+        type: string
+        description: Caller event name
+        required: true
+      is_pull_request:
+        type: boolean
+        description: Whether the caller event is for a pull request
+        required: true
+      additional_context:
+        type: string
+        description: Any additional context from the request
+        required: false
+
+jobs:
+  invoke:
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    uses: jhw7500/automation/.github/workflows/gemini-invoke.yml@v1.15
+    with:
+      item_number: ${{ inputs.item_number }}
+      item_title: ${{ inputs.item_title }}
+      item_body: ${{ inputs.item_body }}
+      event_name: ${{ inputs.event_name }}
+      is_pull_request: ${{ inputs.is_pull_request }}
+      additional_context: ${{ inputs.additional_context }}
+    secrets: inherit

--- a/examples/baseline-workflows/.github/workflows/gemini-review.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-review.yml
@@ -1,0 +1,36 @@
+name: Gemini Review
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        type: string
+        description: Pull request number
+        required: true
+      issue_title:
+        type: string
+        description: Pull request title
+        required: true
+      issue_body:
+        type: string
+        description: Pull request body
+        required: true
+      additional_context:
+        type: string
+        description: Any additional context from the request
+        required: false
+
+jobs:
+  review:
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    uses: jhw7500/automation/.github/workflows/gemini-review.yml@v1.15
+    with:
+      pr_number: ${{ inputs.pr_number }}
+      issue_title: ${{ inputs.issue_title }}
+      issue_body: ${{ inputs.issue_body }}
+      additional_context: ${{ inputs.additional_context }}
+    secrets: inherit

--- a/examples/baseline-workflows/.github/workflows/gemini-scheduled-triage.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-scheduled-triage.yml
@@ -1,0 +1,14 @@
+name: Gemini Scheduled Issue Triage
+
+on:
+  workflow_dispatch:
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    uses: jhw7500/automation/.github/workflows/gemini-scheduled-triage.yml@v1.15
+    secrets: inherit

--- a/examples/baseline-workflows/.github/workflows/gemini-triage.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-triage.yml
@@ -1,0 +1,36 @@
+name: Gemini Triage
+
+on:
+  workflow_call:
+    inputs:
+      issue_number:
+        type: string
+        description: Issue number
+        required: true
+      issue_title:
+        type: string
+        description: Issue title
+        required: true
+      issue_body:
+        type: string
+        description: Issue body
+        required: true
+      additional_context:
+        type: string
+        description: Any additional context from the request
+        required: false
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      id-token: write
+      issues: read
+      pull-requests: read
+    uses: jhw7500/automation/.github/workflows/gemini-triage.yml@v1.15
+    with:
+      issue_number: ${{ inputs.issue_number }}
+      issue_title: ${{ inputs.issue_title }}
+      issue_body: ${{ inputs.issue_body }}
+      additional_context: ${{ inputs.additional_context }}
+    secrets: inherit

--- a/examples/baseline-workflows/README.md
+++ b/examples/baseline-workflows/README.md
@@ -1,0 +1,33 @@
+# Baseline Consumer Workflows
+
+This folder contains a minimal, copy-paste-friendly set of workflow wrappers for repositories
+that want to consume shared reusable workflows from `jhw7500/automation`.
+
+Goal: keep consumer repos thin (event triggers + `uses:`) and keep logic centralized in
+`jhw7500/automation`.
+
+## How to use
+
+1) Copy the `.github/` directory from this folder into your target repository.
+
+2) Update the pinned version in each workflow file:
+
+- Search for `jhw7500/automation/.github/workflows/...@v1.15` and bump to the desired tag.
+
+3) Configure `review.auto` in `.github/workflow-config.yml`:
+
+- `review.auto: false` (recommended default) disables automatic PR reviews.
+- Manual commands remain available.
+
+## Required secrets / variables
+
+See `docs/workflows/contracts.md` for the full list.
+
+Quick minimum:
+
+- Secret: `GEMINI_API_KEY`
+- Variable: `GEMINI_MODEL`
+
+If you enable Claude workflows:
+
+- Secret: `CLAUDE_CODE_OAUTH_TOKEN`


### PR DESCRIPTION
## 변경 내용
- 소비자 레포가 복사해서 바로 사용할 수 있는 최소 wrapper 워크플로우 팩을 추가했습니다.
  - `examples/baseline-workflows/.github/`
- 소비자 레포의 secrets/vars/config 계약을 문서화했습니다.
  - `docs/workflows/contracts.md`

## 의도
- 각 저장소에는 이벤트 엔트리포인트(wrapper)만 남기고, 로직은 `jhw7500/automation`에 집중시키기 위함입니다.
- wrapper 파일을 다른 저장소로 그대로 복사 가능한 형태로 유지합니다.

## 사용 방법
- `examples/baseline-workflows/.github/`를 대상 레포의 `.github/`로 복사
- wrapper들의 `uses: ...@v1.15` 버전만 원하는 태그로 조정
- `docs/workflows/contracts.md`에 정의된 secrets/vars 설정