### PR TITLE
feat: sticky gemini review comment

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -188,7 +188,9 @@ jobs:
           fallback-token: '${{ secrets.GITHUB_TOKEN || github.token }}'
 
       - name: Run Gemini pull request review
+        id: gemini_review
         uses: google-github-actions/run-gemini-cli@v0
+        continue-on-error: true
         env:
           GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
           ISSUE_TITLE: '${{ github.event.pull_request.title || github.event.issue.title }}'
@@ -241,6 +243,87 @@ jobs:
             3. Any architectural or operational concerns related to the affected areas
 
             Keep the response concise and structured with clear headings.
+
+      - name: Upsert PR comment (Gemini Review)
+        if: always()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # ratchet:actions/github-script@v7
+        env:
+          ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          MODEL_USED: '${{ vars.GEMINI_MODEL }}'
+          OUTCOME: '${{ steps.gemini_review.outcome }}'
+          RESPONSE: '${{ steps.gemini_review.outputs.gemini_response }}'
+          ERRORS: '${{ steps.gemini_review.outputs.gemini_errors }}'
+        with:
+          github-token: '${{ github.token }}'
+          script: |
+            const marker = '<!-- automation:gemini-review -->';
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const runUrl = process.env.RUN_URL;
+            const modelUsed = process.env.MODEL_USED || '';
+            const outcome = (process.env.OUTCOME || '').toLowerCase();
+
+            const maxLen = 60000;
+            const trim = (s) => {
+              const t = (s || '').trim();
+              if (t.length <= maxLen) return t;
+              return t.slice(0, maxLen) + `\n\n...(truncated, ${t.length - maxLen} chars omitted)`;
+            };
+
+            const summarizeError = (raw) => {
+              const t = (raw || '').trim();
+              if (!t) return '';
+              // Keep it human-readable: first ~30 lines is usually enough.
+              const lines = t.split('\n').slice(0, 30).join('\n');
+              return trim(lines);
+            };
+
+            const ok = outcome === 'success';
+            const response = trim(process.env.RESPONSE);
+            const errors = summarizeError(process.env.ERRORS);
+
+            const header = `## Gemini Review (latest)\n${marker}`;
+            const meta = [
+              `- Status: ${ok ? 'success' : 'failure'}`,
+              modelUsed ? `- Model: ${modelUsed}` : null,
+              `- Run: ${runUrl}`,
+            ].filter(Boolean).join('\n');
+
+            const content = ok
+              ? (response ? `\n\n${response}` : `\n\n(No response captured. Check run logs: ${runUrl})`)
+              : `\n\n### Error\n\n\`\`\`\n${errors || '(no error text captured)'}\n\`\`\`\n\n(See run logs: ${runUrl})`;
+
+            const body = `${header}\n\n${meta}${content}`;
+
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find((c) => (c.body || '').includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body,
+              });
+            }
+
+      - name: Fail job if review failed
+        if: steps.gemini_review.outcome != 'success'
+        run: exit 1
 
   triage:
     needs: dispatch

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -338,12 +338,84 @@ jobs:
           exit 1
 
       - name: 'Notify on failure'
-        if: always() && steps.gemini_pr_review_1.outcome != 'success' && steps.gemini_pr_review_2.outcome != 'success' && steps.gemini_pr_review_fallback.outcome != 'success'
+        if: always()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # ratchet:actions/github-script@v7
         env:
-          GH_TOKEN: '${{ github.token }}'
           ISSUE_NUMBER: '${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}'
-          REPOSITORY: '${{ github.repository }}'
-        run: |-
-          gh issue comment "${ISSUE_NUMBER}" \
-            --body "Review encountered an error. Please [check the logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details." \
-            --repo "${REPOSITORY}"
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          MODEL_PRIMARY: '${{ vars.GEMINI_MODEL }}'
+          MODEL_FALLBACK: "${{ vars.GEMINI_FALLBACK_MODEL || 'gemini-3-flash-preview' }}"
+          OUTCOME_1: '${{ steps.gemini_pr_review_1.outcome }}'
+          RESP_1: '${{ steps.gemini_pr_review_1.outputs.gemini_response }}'
+          ERR_1: '${{ steps.gemini_pr_review_1.outputs.gemini_errors }}'
+          OUTCOME_2: '${{ steps.gemini_pr_review_2.outcome }}'
+          RESP_2: '${{ steps.gemini_pr_review_2.outputs.gemini_response }}'
+          ERR_2: '${{ steps.gemini_pr_review_2.outputs.gemini_errors }}'
+          OUTCOME_FB: '${{ steps.gemini_pr_review_fallback.outcome }}'
+          RESP_FB: '${{ steps.gemini_pr_review_fallback.outputs.gemini_response }}'
+          ERR_FB: '${{ steps.gemini_pr_review_fallback.outputs.gemini_errors }}'
+        with:
+          github-token: '${{ github.token }}'
+          script: |
+            const marker = '<!-- automation:gemini-review -->';
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const runUrl = process.env.RUN_URL;
+
+            const maxLen = 60000;
+            const trim = (s) => {
+              const t = (s || '').trim();
+              if (t.length <= maxLen) return t;
+              return t.slice(0, maxLen) + `\n\n...(truncated, ${t.length - maxLen} chars omitted)`;
+            };
+
+            const pick = () => {
+              if ((process.env.OUTCOME_1 || '').toLowerCase() === 'success') {
+                return { ok: true, model: process.env.MODEL_PRIMARY || '', response: process.env.RESP_1 || '', error: '' };
+              }
+              if ((process.env.OUTCOME_2 || '').toLowerCase() === 'success') {
+                return { ok: true, model: process.env.MODEL_PRIMARY || '', response: process.env.RESP_2 || '', error: '' };
+              }
+              if ((process.env.OUTCOME_FB || '').toLowerCase() === 'success') {
+                return { ok: true, model: process.env.MODEL_FALLBACK || '', response: process.env.RESP_FB || '', error: '' };
+              }
+
+              // Prefer the fallback error if present; otherwise take the first non-empty.
+              const err = process.env.ERR_FB || process.env.ERR_2 || process.env.ERR_1 || '';
+              return { ok: false, model: process.env.MODEL_PRIMARY || '', response: '', error: err };
+            };
+
+            const summarizeError = (raw) => {
+              const t = (raw || '').trim();
+              if (!t) return '';
+              const lines = t.split('\n').slice(0, 30).join('\n');
+              return trim(lines);
+            };
+
+            const result = pick();
+            const header = `## Gemini Review (latest)\n${marker}`;
+            const meta = [
+              `- Status: ${result.ok ? 'success' : 'failure'}`,
+              result.model ? `- Model: ${result.model}` : null,
+              `- Run: ${runUrl}`,
+            ].filter(Boolean).join('\n');
+
+            const content = result.ok
+              ? `\n\n${trim(result.response) || `(No response captured. Check run logs: ${runUrl})`}`
+              : `\n\n### Error\n\n\`\`\`\n${summarizeError(result.error) || '(no error text captured)'}\n\`\`\`\n\n(See run logs: ${runUrl})`;
+
+            const body = `${header}\n\n${meta}${content}`;
+
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find((c) => (c.body || '').includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+            }


### PR DESCRIPTION
## 변경 내용
- Gemini 리뷰 결과를 PR 코멘트로 남기되, 매번 새 코멘트를 쌓지 않고 1개의 sticky 코멘트를 업데이트하도록 변경했습니다.
- 실패(예: 429 quota 등) 시에도 failure reason 일부(첫 30줄)를 코멘트로 남겨서 '응답 없음'처럼 보이지 않게 했습니다.

## 구현 디테일
- marker: `<!-- automation:gemini-review -->`
- upsert 로직: marker가 포함된 기존 코멘트가 있으면 edit, 없으면 create
- `gemini-dispatch.yml`의 review job에도 동일 upsert 적용(기존에는 ack만 있고 결과 코멘트가 없었음)

## 동작
- 성공: 리뷰 본문을 sticky 코멘트에 갱신
- 실패: 에러 요약 + run 링크를 sticky 코멘트에 갱신