### PR TITLE
fix(workflow): harden comment-driven automation workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,10 +32,18 @@ jobs:
     needs: check-enabled
     if: |
       needs.check-enabled.outputs.enabled == 'true' && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        (github.event_name == 'issue_comment' &&
+          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' &&
+          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' &&
+          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) &&
+          contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' &&
+          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) &&
+          (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/gemini-chat.yml
+++ b/.github/workflows/gemini-chat.yml
@@ -4,15 +4,42 @@ on:
   workflow_call:
 
 jobs:
+  check-enabled:
+    name: Check if enabled
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      - name: Check workflow config
+        id: check
+        uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
+        with:
+          workflow-name: gemini-chat
+
   gemini-chat:
+    needs: check-enabled
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@gemini') && !contains(github.event.comment.body, '@gemini-cli')) ||
-      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '@gemini ')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@gemini') && !contains(github.event.comment.body, '@gemini-cli')) ||
-      (github.event_name == 'pull_request_review_comment' && startsWith(github.event.comment.body, '@gemini ')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@gemini') || contains(github.event.issue.title, '@gemini')) && !contains(github.event.issue.body, '@gemini-cli') && !contains(github.event.issue.title, '@gemini-cli')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@gemini') && !contains(github.event.review.body, '@gemini-cli')) ||
-      (github.event_name == 'pull_request_review' && startsWith(github.event.review.body, '@gemini '))
+      needs.check-enabled.outputs.enabled == 'true' &&
+      (
+        (github.event_name == 'issue_comment' && contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      ) &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@gemini') && !contains(github.event.comment.body, '@gemini-cli')) ||
+        (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '@gemini ')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@gemini') && !contains(github.event.comment.body, '@gemini-cli')) ||
+        (github.event_name == 'pull_request_review_comment' && startsWith(github.event.comment.body, '@gemini ')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@gemini') || contains(github.event.issue.title, '@gemini')) && !contains(github.event.issue.body, '@gemini-cli') && !contains(github.event.issue.title, '@gemini-cli')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@gemini') && !contains(github.event.review.body, '@gemini-cli')) ||
+        (github.event_name == 'pull_request_review' && startsWith(github.event.review.body, '@gemini '))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -156,3 +183,15 @@ jobs:
             ## 🤖 Gemini Response (대화형)
 
             Then address the user's specific request above.
+
+  skipped:
+    name: Workflow Skipped
+    needs: check-enabled
+    if: needs.check-enabled.outputs.enabled != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notice
+        run: |
+          echo "::notice::gemini-chat workflow is disabled in .github/workflow-config.yml"
+          echo "## Workflow Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "gemini-chat is disabled in workflow-config.yml" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -4,12 +4,34 @@ on:
   workflow_call:
 
 jobs:
+  check-enabled:
+    name: Check if enabled
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      - name: Check workflow config
+        id: check
+        uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
+        with:
+          workflow-name: opencode
+
   opencode:
+    needs: check-enabled
     if: |
-      contains(github.event.comment.body, ' /oc') ||
-      startsWith(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, ' /opencode') ||
-      startsWith(github.event.comment.body, '/opencode')
+      needs.check-enabled.outputs.enabled == 'true' &&
+      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+      (
+        contains(github.event.comment.body, ' /oc') ||
+        startsWith(github.event.comment.body, '/oc') ||
+        contains(github.event.comment.body, ' /opencode') ||
+        startsWith(github.event.comment.body, '/opencode')
+      )
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -28,3 +50,15 @@ jobs:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
         with:
           model: zai-coding-plan/glm-4.7
+
+  skipped:
+    name: Workflow Skipped
+    needs: check-enabled
+    if: needs.check-enabled.outputs.enabled != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notice
+        run: |
+          echo "::notice::opencode workflow is disabled in .github/workflow-config.yml"
+          echo "## Workflow Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "opencode is disabled in workflow-config.yml" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Run opencode
-        uses: anomalyco/opencode/github@latest
+        uses: anomalyco/opencode/github@bbc7bdb3fd5078d0add23273e0fdae436b9b47e4 # v1.1.43
         env:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
         with:


### PR DESCRIPTION
## What changed
- Pinned `anomalyco/opencode/github` to a release commit SHA (v1.1.43) to remove `@latest` supply-chain risk.
- Added `check-workflow-enabled` gating for comment-driven workflows that previously had no config gate (`opencode`, `gemini-chat`).
- Added `author_association` allowlist gate (`OWNER|MEMBER|COLLABORATOR`) for `opencode`, `gemini-chat`, and `claude` to reduce accidental/unauthorized triggers.

## Why
- These workflows run on untrusted text inputs (comments) and may have access to sensitive secrets/tokens in consumer repos. Even for internal repos, we want to reduce blast radius from mistakes and supply-chain changes.

## Behavior notes
- Intended for internal repos (members-only usage). If a consumer repo needs external users to trigger these, the allowlist will need to be adjusted.

## Follow-up
- After merge, create tag `v1.22` on the merge commit, then bump consumer repos (e.g. gstApp) to `@v1.22`.