### PR TITLE
feat: opencode auto PR review + full toggle coverage

### DIFF
--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -216,7 +216,7 @@ jobs:
   skipped:
     name: Workflow Skipped
     needs: check-enabled
-    if: needs.check-enabled.outputs.enabled != 'true'
+    if: needs.check-enabled.outputs.enabled != 'true' || needs.check-enabled.outputs.auto_enabled != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Notice

--- a/.github/workflows/gemini-chat.yml
+++ b/.github/workflows/gemini-chat.yml
@@ -2,6 +2,12 @@ name: 'Gemini Chat'
 
 on:
   workflow_call:
+    inputs:
+      force_run:
+        description: 'Run even if disabled in workflow-config.yml'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   check-enabled:
@@ -20,6 +26,7 @@ jobs:
         uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
         with:
           workflow-name: gemini-chat
+          force-run: ${{ inputs.force_run && 'true' || 'false' }}
 
   gemini-chat:
     needs: check-enabled

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -3,6 +3,11 @@ name: '▶️ Gemini Invoke'
 on:
   workflow_call:
     inputs:
+      force_run:
+        description: 'Run even if disabled in workflow-config.yml'
+        type: boolean
+        required: false
+        default: false
       item_number:
         type: 'string'
         description: 'Issue or pull request number (optional; defaults to event item number)'
@@ -37,7 +42,27 @@ defaults:
     shell: 'bash'
 
 jobs:
+  check-enabled:
+    name: Check if enabled
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      - name: Check workflow config
+        id: check
+        uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
+        with:
+          workflow-name: gemini-invoke
+          force-run: ${{ inputs.force_run && 'true' || 'false' }}
+
   invoke:
+    needs: check-enabled
+    if: needs.check-enabled.outputs.enabled == 'true'
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'
@@ -152,3 +177,15 @@ jobs:
           gh issue comment "${ISSUE_NUMBER}" \
             --body "I encountered an error while processing your request. Please [check the logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details." \
             --repo "${REPOSITORY}"
+
+  skipped:
+    name: Workflow Skipped
+    needs: check-enabled
+    if: needs.check-enabled.outputs.enabled != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notice
+        run: |
+          echo "::notice::gemini-invoke workflow is disabled in .github/workflow-config.yml"
+          echo "## Workflow Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "gemini-invoke is disabled in workflow-config.yml" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -3,6 +3,11 @@ name: '🔎 Gemini Review'
 on:
   workflow_call:
     inputs:
+      force_run:
+        description: 'Run even if disabled in workflow-config.yml'
+        type: boolean
+        required: false
+        default: false
       pr_number:
         type: 'string'
         description: 'Pull request number (optional; defaults to event PR number)'
@@ -43,7 +48,27 @@ defaults:
     shell: 'bash'
 
 jobs:
+  check-enabled:
+    name: Check if enabled
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      - name: Check workflow config
+        id: check
+        uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
+        with:
+          workflow-name: gemini-review
+          force-run: ${{ inputs.force_run && 'true' || 'false' }}
+
   review:
+    needs: check-enabled
+    if: needs.check-enabled.outputs.enabled == 'true'
     runs-on: 'ubuntu-latest'
     timeout-minutes: 15
     permissions:
@@ -488,3 +513,15 @@ jobs:
             } else {
               await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
             }
+
+  skipped:
+    name: Workflow Skipped
+    needs: check-enabled
+    if: needs.check-enabled.outputs.enabled != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notice
+        run: |
+          echo "::notice::gemini-review workflow is disabled in .github/workflow-config.yml"
+          echo "## Workflow Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "gemini-review is disabled in workflow-config.yml" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -3,6 +3,11 @@ name: '🔀 Gemini Triage'
 on:
   workflow_call:
     inputs:
+      force_run:
+        description: 'Run even if disabled in workflow-config.yml'
+        type: boolean
+        required: false
+        default: false
       issue_number:
         type: 'string'
         description: 'Issue number (optional; defaults to event issue number)'
@@ -29,7 +34,27 @@ defaults:
     shell: 'bash'
 
 jobs:
+  check-enabled:
+    name: Check if enabled
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      - name: Check workflow config
+        id: check
+        uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
+        with:
+          workflow-name: gemini-triage
+          force-run: ${{ inputs.force_run && 'true' || 'false' }}
+
   triage:
+    needs: check-enabled
+    if: needs.check-enabled.outputs.enabled == 'true'
     runs-on: 'ubuntu-latest'
     timeout-minutes: 7
     outputs:
@@ -113,8 +138,9 @@ jobs:
     runs-on: 'ubuntu-latest'
     needs:
       - 'triage'
+      - 'check-enabled'
     if: |-
-      ${{ needs.triage.outputs.selected_labels != '' }}
+      ${{ needs.check-enabled.outputs.enabled == 'true' && needs.triage.outputs.selected_labels != '' }}
     permissions:
       contents: 'read'
       issues: 'write'
@@ -169,3 +195,15 @@ jobs:
             } else {
               core.info(`Failed to determine labels to set. There may not be enough information in the issue or pull request.`)
             }
+
+  skipped:
+    name: Workflow Skipped
+    needs: check-enabled
+    if: needs.check-enabled.outputs.enabled != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notice
+        run: |
+          echo "::notice::gemini-triage workflow is disabled in .github/workflow-config.yml"
+          echo "## Workflow Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "gemini-triage is disabled in workflow-config.yml" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -57,6 +57,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -1,0 +1,91 @@
+name: 'OpenCode Auto PR Review'
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'Pull request number (optional; defaults to event PR number)'
+        type: string
+        required: false
+      force_run:
+        description: 'Run even if disabled in workflow-config.yml'
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  check-enabled:
+    name: Check if enabled
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+      auto_enabled: ${{ steps.auto_mode.outputs.auto_enabled }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      - name: Check workflow config
+        id: check
+        uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
+        with:
+          workflow-name: opencode-auto-review
+          force-run: ${{ inputs.force_run && 'true' || 'false' }}
+
+      - name: Check auto review mode
+        id: auto_mode
+        env:
+          FORCE_RUN: ${{ inputs.force_run && 'true' || 'false' }}
+        run: |-
+          CONFIG_FILE=".github/workflow-config.yml"
+          if [[ "$FORCE_RUN" == 'true' ]]; then
+            echo "auto_enabled=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          auto_enabled="true"
+          if [[ -f "$CONFIG_FILE" ]]; then
+            auto_enabled="$(ruby -ryaml -e 'cfg = (YAML.load_file(ARGV[0]) rescue {}) || {}; v = cfg.dig("review", "auto"); v = true if v.nil?; puts(v ? "true" : "false")' "$CONFIG_FILE" 2>/dev/null || echo true)"
+          fi
+          echo "auto_enabled=${auto_enabled}" >> "$GITHUB_OUTPUT"
+
+  opencode-review:
+    needs: check-enabled
+    if: needs.check-enabled.outputs.enabled == 'true' && needs.check-enabled.outputs.auto_enabled == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run OpenCode PR review
+        uses: anomalyco/opencode/github@bbc7bdb3fd5078d0add23273e0fdae436b9b47e4 # v1.1.43
+        env:
+          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+        with:
+          model: zai-coding-plan/glm-4.7
+          prompt: |
+            Review this pull request. Focus on:
+            - correctness and regressions
+            - security issues
+            - performance pitfalls
+            - concrete, actionable suggestions
+            Keep it concise and high-signal.
+
+  skipped:
+    name: Workflow Skipped
+    needs: check-enabled
+    if: needs.check-enabled.outputs.enabled != 'true' || needs.check-enabled.outputs.auto_enabled != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notice
+        run: |
+          echo "::notice::OpenCode Auto PR Review is disabled by workflow-config.yml (or review.auto=false)"
+          echo "## Workflow Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "opencode-auto-review is disabled (or review.auto=false)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -2,6 +2,12 @@ name: 'opencode'
 
 on:
   workflow_call:
+    inputs:
+      force_run:
+        description: 'Run even if disabled in workflow-config.yml'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   check-enabled:
@@ -20,6 +26,7 @@ jobs:
         uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
         with:
           workflow-name: opencode
+          force-run: ${{ inputs.force_run && 'true' || 'false' }}
 
   opencode:
     needs: check-enabled


### PR DESCRIPTION
## What changed
- Added reusable workflow `opencode-auto-review.yml` for automatic PR review using OpenCode.
- Made Gemini sub-workflows toggleable via `.github/workflow-config.yml` (`gemini-invoke`, `gemini-review`, `gemini-triage`).
- Improved skipped visibility when `review.auto=false` for `gemini-auto-review`.
- Added `force_run` override input to `opencode` and `gemini-chat` for consistency.

## Why
- Requirement: all workflows should be controllable via workflow-config toggles, while keeping CI/CD (build/test/deploy) repo-specific.
- Add OpenCode as an optional auto review provider alongside Claude/Gemini.

## Notes
- `opencode-auto-review` is gated by both `workflows.opencode-auto-review.enabled` and `review.auto` (default true if missing).
- Action is SHA-pinned (same pin as current opencode workflow).

## Follow-up
- After merge, tag `v1.23` and bump consumer repos (e.g. gstApp) to `@v1.23`.
