### PR TITLE
ci: baseline 템플릿에서 pull_request_review 트리거 제거 (봇 리뷰 루프 차단)

### DIFF
--- a/examples/baseline-workflows/.github/workflows/claude.yml
+++ b/examples/baseline-workflows/.github/workflows/claude.yml
@@ -7,8 +7,6 @@ on:
     types: [created]
   issues:
     types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   claude:

--- a/examples/baseline-workflows/.github/workflows/gemini-chat.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-chat.yml
@@ -7,8 +7,6 @@ on:
     types: [created]
   issues:
     types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   gemini-chat:

--- a/examples/baseline-workflows/.github/workflows/gemini-dispatch.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-dispatch.yml
@@ -4,9 +4,6 @@ on:
   pull_request_review_comment:
     types:
       - created
-  pull_request_review:
-    types:
-      - submitted
   pull_request:
     types:
       - opened

--- a/examples/baseline-workflows/workflows/claude.yml
+++ b/examples/baseline-workflows/workflows/claude.yml
@@ -7,8 +7,6 @@ on:
     types: [created]
   issues:
     types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   claude:

--- a/examples/baseline-workflows/workflows/gemini-dispatch.yml
+++ b/examples/baseline-workflows/workflows/gemini-dispatch.yml
@@ -4,9 +4,6 @@ on:
   pull_request_review_comment:
     types:
       - 'created'
-  pull_request_review:
-    types:
-      - 'submitted'
   pull_request:
     types:
       - 'opened'


### PR DESCRIPTION
## 문제
baseline wrapper 템플릿(`examples/baseline-workflows/`)의 `claude.yml`·`gemini-dispatch.yml`·`gemini-chat.yml`이 `on: pull_request_review: [submitted]`에 트리거되어, 봇(claude/gemini)이 PR 리뷰를 제출하면 그 이벤트가 워크플로우를 다시 깨워 또 리뷰를 남기는 **피드백 루프**를 유발합니다.

이 템플릿을 `setup-github-workflows.sh`(line 204, `workflows/` 복사)로 받은 다운스트림 repo에서 실제 발현 확인:
- pcap-analyzer #13 claude봇 10개, wlan-package #43 claude봇 **18개**, wlan-opc #54 8개, pim-check #51 6개

## 수정
canonical 템플릿(`workflows/`)과 레거시 사본(`.github/workflows/`) 모두에서 `pull_request_review` 트리거만 제거(5파일, 12줄).
- `pull_request_review_comment`(@멘션)·`pull_request`(opened)·push 리뷰는 유지
- reusable 본체(`.github/workflows/claude.yml` = workflow_call)는 트리거 없어 무관

## 주의
이미 baseline을 복사한 기존 repo는 자동 갱신되지 않아 **개별 수정 PR이 별도로 필요**합니다(pim-check·wlan-package·wlan-opc 진행 예정, pcap-analyzer는 완료). bump-automation-ref는 `@vX.Y` ref만 교체하므로 개별 수정은 영구 유지됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)