### PR TITLE
chore(fleet): automation_ref 단일 소스 v1.31 bump

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,6 +1,6 @@
 {
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.30",
+  "automation_ref": "v1.31",
   "template_dir": "examples/baseline-workflows",
 
   "workflows": [


### PR DESCRIPTION
## 요약

fleet 전파 도구(`scripts/setup-github-workflows.sh`)의 단일 소스 버전을 **v1.30 → v1.31**로 올립니다.

v1.31(PR #12)에는 `gemini-auto-review`의 PR 제목/본문 **셸 인젝션(RCE)** 차단 + 리뷰 프롬프트 강화 + 문서 정합이 포함됩니다. 이 bump 이후 `setup-github-workflows.sh`를 실행하면 소비 저장소들의 `automation_ref`가 v1.31로 정규화됩니다.

## 변경
- `scripts/workflow-config.json`: `automation_ref` `v1.30` → `v1.31` (1줄)

## 참고
- 소비 repo 전파는 이 PR 머지 후 `setup-github-workflows.sh --workflows-only`로 별도 수행.
- `wlan-opc`는 중첩 경로(`projects/wlan-package/wlan-opc`)라 fleet 스크립트가 SKIP → 이미 수동 재핀(완료).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
