### PR TITLE
fix(claude-review): 헤드리스 Write 막혀 리뷰 미게시 — --permission-mode acceptEdits

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -164,8 +164,12 @@ jobs:
           # Read + 단일 파일 Write(claude-review.md)만 허용: 리뷰 본문을 그 파일로 써서 --body-file로
           # 게시(인라인 --body의 셸 쿼팅 시행착오·$(...) 우회 제거). Write를 한 파일로 스코프해 PR diff가
           # untrusted여도 injection이 러너 임의 경로에 쓰지 못하게 한다. Bash는 gh pr 하위명령으로만 제한.
+          # --permission-mode acceptEdits: 헤드리스 러너엔 승인자가 없어, allowed-tools에 Write가 있어도
+          # 기본 모드에선 변경 도구(Write/Edit)가 permission prompt에 막혀 claude-review.md 작성→게시가
+          # 실패했다(v1.32 회귀: PR에 리뷰 미게시). acceptEdits로 허용된 Write(claude-review.md)를 prompt
+          # 없이 실행한다. Bash는 allowed-tools(gh pr 하위명령)로 계속 게이트되어 영향 없음.
           claude_args: >-
-            ${{ needs.check-enabled.outputs.model && format('--model {0} ', needs.check-enabled.outputs.model) || '' }}--allowed-tools "Read,Write(claude-review.md),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*)"
+            ${{ needs.check-enabled.outputs.model && format('--model {0} ', needs.check-enabled.outputs.model) || '' }}--permission-mode acceptEdits --allowed-tools "Read,Write(claude-review.md),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*)"
           show_full_output: true  # Enable for debugging (can be set to false in production)
 
 


### PR DESCRIPTION
## 문제 (v1.32 회귀)

v1.32에서 Claude 리뷰 게시 방식을 **"리뷰 본문을 `claude-review.md`에 Write → `gh pr review --body-file`로 게시"**로 바꾸며 `claude_args`의 `--allowed-tools`에 `Write(claude-review.md)`를 추가했다. 그러나 **`--permission-mode`가 미설정(default)**이라, 헤드리스 러너에는 승인자가 없어 변경 도구(Write)가 permission prompt에 막힌다 → 파일 미작성 → `gh pr review` 미실행 → **PR에 Claude 리뷰가 게시되지 않음**.

`claude-code-action` 단계는 에러 없이 끝나 job이 `success`로 보이므로 그동안 조용히 누락됐다.

## 증거

| PR (wlan-package) | automation 버전 | 게시 방식 | Claude 리뷰 |
|---|---|---|---|
| #65, #67 | v1.31 이하 | `gh pr review` 직접(Write 미사용) | ✅ 정상 게시 |
| #68, #69 | v1.32 | Write→`--body-file` | ❌ 누락 (Write permission prompt) |

run 로그: `"I need permission to write the review file. Please approve the file write to claude-review.md..."` — 리뷰는 완성됐으나 파일 작성에서 막힘.

## 수정

`claude_args`에 **`--permission-mode acceptEdits`** 추가 → 허용된 `Write(claude-review.md)`가 prompt 없이 실행된다. Bash는 `--allowed-tools`(gh pr 하위명령)로 계속 게이트되어 보안 스코프 영향 없음.

## 머지 후

이 reusable workflow를 참조하는 모든 리포의 Claude 자동 리뷰가 복구된다. 머지 후 **새 태그(v1.33 등) 발행** + 소비 리포의 `@v1.32` 참조 업데이트가 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)