### PR TITLE
fix(bump-automation-ref): App 토큰으로 .github/workflows push (GITHUB_TOKEN 한계 해결)

### DIFF
--- a/examples/baseline-workflows/.github/workflows/bump-automation-ref.yml
+++ b/examples/baseline-workflows/.github/workflows/bump-automation-ref.yml
@@ -20,10 +20,38 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
+      # GITHUB_TOKEN 은 GitHub 정책상 .github/workflows/* 수정 push 가 거부되므로
+      # ("refusing to allow a GitHub App to create or update workflow ... without
+      # workflows permission") workflows:write 권한을 가진 GitHub App 토큰으로
+      # checkout/push 한다. App 미설정 시 GITHUB_TOKEN 으로 폴백(이 경우 push 실패).
+      - name: Mint GitHub App token
+        id: app-token
+        if: ${{ vars.APP_ID != '' }}
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # ratchet:actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Resolve token
+        id: tok
+        env:
+          MINTED: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          if [ -n "${MINTED:-}" ]; then
+            printf 'token=%s\n' "$MINTED" >> "$GITHUB_OUTPUT"
+            echo "::notice::Using GitHub App token for workflow push"
+          else
+            printf 'token=%s\n' "${{ github.token }}" >> "$GITHUB_OUTPUT"
+            echo "::warning::APP_ID 미설정 — GITHUB_TOKEN 으로는 .github/workflows push 가 거부됨 (App 에 workflows:write 권한 필요)"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.tok.outputs.token }}
+          persist-credentials: true
 
       - name: Determine automation_ref change
         id: ref
@@ -95,7 +123,7 @@ jobs:
       - name: Create PR
         if: steps.ref.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.tok.outputs.token }}
           NEW_REF: ${{ steps.ref.outputs.new_ref }}
         run: |
           set -euo pipefail

--- a/examples/baseline-workflows/workflows/bump-automation-ref.yml
+++ b/examples/baseline-workflows/workflows/bump-automation-ref.yml
@@ -20,10 +20,38 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
+      # GITHUB_TOKEN 은 GitHub 정책상 .github/workflows/* 수정 push 가 거부되므로
+      # ("refusing to allow a GitHub App to create or update workflow ... without
+      # workflows permission") workflows:write 권한을 가진 GitHub App 토큰으로
+      # checkout/push 한다. App 미설정 시 GITHUB_TOKEN 으로 폴백(이 경우 push 실패).
+      - name: Mint GitHub App token
+        id: app-token
+        if: ${{ vars.APP_ID != '' }}
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # ratchet:actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Resolve token
+        id: tok
+        env:
+          MINTED: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          if [ -n "${MINTED:-}" ]; then
+            printf 'token=%s\n' "$MINTED" >> "$GITHUB_OUTPUT"
+            echo "::notice::Using GitHub App token for workflow push"
+          else
+            printf 'token=%s\n' "${{ github.token }}" >> "$GITHUB_OUTPUT"
+            echo "::warning::APP_ID 미설정 — GITHUB_TOKEN 으로는 .github/workflows push 가 거부됨 (App 에 workflows:write 권한 필요)"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.tok.outputs.token }}
+          persist-credentials: true
 
       - name: Determine automation_ref change
         id: ref
@@ -95,7 +123,7 @@ jobs:
       - name: Create PR
         if: steps.ref.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.tok.outputs.token }}
           NEW_REF: ${{ steps.ref.outputs.new_ref }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## 배경
`bump-automation-ref` 워크플로우가 caller `.yml`을 rewrite한 뒤 push할 때 `GITHUB_TOKEN`으로는 `.github/workflows/*` 수정이 GitHub 정책상 거부됨:
> `refusing to allow a GitHub App to create or update workflow ... without workflows permission`

→ `automation_ref` 자동 bump가 **항상 실패**했습니다 (wlan-package run `28344431818` failure로 확인).

## 변경
기존 GitHub App 인프라(`vars.APP_ID` + `secrets.APP_PRIVATE_KEY` — `gemini-*` 워크플로우가 이미 사용)를 **재사용**:
- `actions/create-github-app-token@v2`로 App 토큰 발급 (`Mint GitHub App token` step, `if: vars.APP_ID != ''`)
- `Resolve token` step에서 App 토큰 / `GITHUB_TOKEN` 폴백 결정
- `actions/checkout`에 `token` + `persist-credentials: true`, Create PR의 `GH_TOKEN`을 App 토큰으로

배포 소스(`workflows/`)와 자기적용(`.github/workflows/`) **두 사본 모두** 수정. YAML 검증 통과.

## ⚠️ 선결 조건 (이게 없으면 여전히 실패)
GitHub App에 **`Workflows: Read and write`** 권한 부여 필요 (App 설정 → Repository permissions). 없으면 App 토큰도 push가 거부되어 폴백→실패(`::warning::` 출력).

## 후속
- 머지 후 `scripts/setup-github-workflows.sh` 재배포로 fleet 리포에 반영
- fleet의 다른 리포는 아직 자동 bump 결함 상태일 수 있음 — caller `@vX`는 수동 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)