### PR TITLE
fix(opencode): 자동 리뷰가 GITHUB_TOKEN을 쓰게 해 코드 푸시 권한 차단

### DIFF
--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -56,7 +56,10 @@ jobs:
     if: needs.check-enabled.outputs.enabled == 'true' && needs.check-enabled.outputs.auto_enabled == 'true'
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      # id-token 없음(의도) — 이게 있으면 액션이 OIDC 토큰을 발급받아
+      # api.opencode.ai 에서 App 토큰으로 교환할 수 있고, 그 토큰은 아래 contents: read
+      # 의 통제를 받지 않는다. use_github_token: true 와 함께 이중으로 막는다:
+      # 플래그가 기대대로 동작하지 않더라도 OIDC 발급 자체가 불가능(fail-closed).
       contents: read
       pull-requests: write
       issues: write

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -67,11 +67,20 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      # use_github_token: OIDC 교환(api.opencode.ai → opencode-agent App 토큰)을 건너뛰고
+      # 이 잡의 GITHUB_TOKEN 을 쓴다. App 토큰은 App 설치 권한만 따르므로 위 permissions
+      # 블록(contents: read)이 무력했다 — 실제로 자동 리뷰가 PR 브랜치에 코드 커밋을 푸시한
+      # 사례가 있다(wlan-package #163, 게다가 실패하는 테스트였다). GITHUB_TOKEN 으로
+      # 바꾸면 permissions 블록이 그대로 강제되어 리뷰는 쓰되(pull-requests/issues: write)
+      # 코드는 못 쓴다(contents: read).
+      # 액션은 GITHUB_TOKEN 을 자동 주입하지 않으므로 env 로 명시해야 한다.
       - name: Run OpenCode PR review
         uses: anomalyco/opencode/github@bbc7bdb3fd5078d0add23273e0fdae436b9b47e4 # v1.1.43
         env:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          use_github_token: true
           model: zai-coding-plan/glm-4.7
           prompt: |
             Review this pull request. Focus on:


### PR DESCRIPTION
## 문제

자동 리뷰 잡은 `permissions: contents: read`로 선언돼 있는데도 **PR 브랜치에 코드 커밋을 푸시할 수 있었다.**

wlan-package [#163](https://github.com/jhw7500/wlan-package/pull/163)에서 실제 발생:

```
6c090ac  opencode-agent[bot]  "Fixed tests, found lock/polling issues"   (unsigned)
```

하필 **실패하는 테스트**를 푸시해 브랜치가 red가 됐고, 작성자가 자기 push를 거부당해 우연히 발견했다. 못 봤으면 red인 채로 머지 대기했을 것이다.

## 원인 — `permissions:` 블록이 이 경로엔 무력

액션(`anomalyco/opencode/github`)은 기본적으로 `id-token: write`로 **OIDC 토큰을 발급받아 `api.opencode.ai`에서 `opencode-agent` GitHub App 설치 토큰으로 교환**한다(`action.yml`의 `oidc_base_url` 기본값). 그 App 토큰의 권한은 **App 설치 시 부여된 것**이라 워크플로우 `permissions:` 블록의 통제를 전혀 받지 않는다.

`permissions:`는 `GITHUB_TOKEN`만 제약한다. 그래서 YAML엔 `contents: read`인데 실제로는 contents 쓰기가 됐다 — **읽는 사람에게 거짓 안심을 주는 상태**.

## 수정

```yaml
env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # 액션이 자동 주입하지 않음
with:
  use_github_token: true                       # OIDC 교환 건너뜀
```

`use_github_token: true`면 OIDC 교환을 건너뛰고 이 잡의 `GITHUB_TOKEN`을 쓴다 → **`permissions:` 블록이 그대로 강제**된다.

| 동작 | 결과 |
|---|---|
| 리뷰 게시 | ✅ 가능 (`pull-requests: write`, `issues: write`) |
| 코드 푸시 | ❌ 차단 (`contents: read`) |

`env.GITHUB_TOKEN`을 함께 넣은 이유: 액션 `action.yml`은 `USE_GITHUB_TOKEN`만 CLI로 넘기고 `GITHUB_TOKEN`은 주입하지 않는다. 빠뜨리면 토큰이 없어 **리뷰 게시가 조용히 실패**한다.

부수 효과로 기존의 `User opencode-agent[bot] does not have write permissions`(App이 PR 리뷰 게시 권한은 없고 contents 쓰기는 있던 비대칭)도 해소된다.

## 범위

대화형 `opencode.yml`(`/opencode` 코멘트 트리거)은 **제외**했다. 사람이 명시 호출하는 경로라 코드 수정이 의도된 사용일 수 있고, 캘러 permissions가 `pull-requests: read`/`issues: read`라 같은 변경을 하면 코멘트조차 못 단다. 필요하면 별도 판단.

## 머지 후

이 리포는 태그 참조(`@v1.33`)로 소비되므로 **새 태그(v1.34) 발행 + 소비 리포 참조 bump**가 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANazFgkczJPedAvn6mCdVy