### PR TITLE
feat(fleet): add safe workflow rollout orchestrator

### DIFF
--- a/.github/workflows/test-fleet-tools.yml
+++ b/.github/workflows/test-fleet-tools.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: pip
       - name: Install test dependencies
         run: python -m pip install pytest PyYAML
       - name: Run tests

--- a/.github/workflows/test-fleet-tools.yml
+++ b/.github/workflows/test-fleet-tools.yml
@@ -1,0 +1,31 @@
+name: Test Fleet Tools
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/*.py'
+      - 'tests/*.py'
+      - '.github/workflows/test-fleet-tools.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/*.py'
+      - 'tests/*.py'
+      - '.github/workflows/test-fleet-tools.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: Install test dependencies
+        run: python -m pip install pytest PyYAML
+      - name: Run tests
+        run: pytest -q

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -30,6 +30,8 @@ repository secret 전제조건을 한 실행에서 조율한다. GitHub는 Git P
 
 workspace는 reset/clean 가능한 전용 disposable clone 디렉터리여야 한다. 최초 한 번
 명시적으로 초기화한다.
+HTTPS clone/push는 ambient `GITHUB_TOKEN`/`GH_TOKEN`을 사용하지 않으므로 사전에
+`gh auth login`과 `gh auth setup-git`이 완료돼 있어야 한다.
 
 ```bash
 # 읽기 전용 계획. 원격 secret/variable은 이름만 조회한다.
@@ -63,6 +65,9 @@ python3 scripts/rollout_workflow_fleet.py \
 
 각 실행은 `rollout-manifest.json`에 base/head/PR/blocked 결과를 남긴다. 한 저장소가
 blocked여도 다른 저장소의 준비는 계속하지만 명령은 non-zero로 끝난다.
+동일 release branch를 다시 게시할 때는 push 직전 원격 SHA를 조회해 exact
+`--force-with-lease=<ref>:<sha>`로 보호하므로 다른 실행이나 사람이 갱신한 branch를
+덮어쓰지 않는다.
 
 계약은 현재 checkout이 아니라 지정한 local+remote release tag artifact에서 직접
 추출한다. 따라서 `--ref v1.36`을 사용하면 branch도

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -19,6 +19,9 @@ repository secret 전제조건을 한 실행에서 조율한다. GitHub는 Git P
 - `CLAUDE_CODE_OAUTH_TOKEN` 누락 시에만 `~/.claude/.credentials.json`을 source로 쓸 수 있다.
 - 그 외 누락 secret은 같은 이름의 환경변수가 있을 때만 쓸 수 있다.
 - `--sync-missing-secrets`가 없으면 이름 검사만 하며 어떠한 secret도 쓰지 않는다.
+- 개인 Claude OAuth token fan-out은 추가로 `--allow-personal-oauth-fanout`을 명시해야
+  한다. 이 옵션은 저장소마다 자격증명을 복제해 blast radius를 넓히므로, 이미 배포된
+  `personal-ops/claude-token-sync`의 대상/rotation 정책을 승인한 운영에서만 사용한다.
 - Claude token의 지속적인 rotation은 `personal-ops/claude-token-sync`가 담당한다.
 
 ## 실행
@@ -46,12 +49,18 @@ python3 scripts/rollout_workflow_fleet.py \
   --workspace /path/to/disposable-fleet \
   --mode publish \
   --sync-missing-secrets \
+  --allow-personal-oauth-fanout \
   --confirm \
   --actionlint /path/to/actionlint
 ```
 
 각 실행은 `rollout-manifest.json`에 base/head/PR/blocked 결과를 남긴다. 한 저장소가
 blocked여도 다른 저장소의 준비는 계속하지만 명령은 non-zero로 끝난다.
+
+계약은 현재 checkout이 아니라 지정한 local+remote release tag artifact에서 직접
+추출한다. 따라서 `--ref v1.36`을 사용하면 branch도
+`codex/automation-v1.36-fleet`로 분리되고, 원격 tag와 local tag가 같은 commit인지
+검증되지 않으면 어떤 소비 저장소도 수정하지 않는다.
 
 ## Merge와 rollback
 

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -1,0 +1,60 @@
+# Workflow Fleet Rollout
+
+`scripts/rollout_workflow_fleet.py`는 중앙 reusable workflow caller와 필요한
+repository secret 전제조건을 한 실행에서 조율한다. GitHub는 Git PR과 secret write를
+하나의 transaction으로 제공하지 않으므로, 도구는 둘을 원자적이라고 주장하지 않는다.
+대신 secret 전제조건을 먼저 통과한 저장소만 독립 branch/PR로 게시한다.
+
+## 보존하는 것
+
+- 기존 workflow 파일과 caller job만 처리하고 새 workflow를 강제로 추가하지 않는다.
+- 저장소별 trigger, `if` guard, `permissions`, 기존 `with` 입력을 보존한다.
+- 중앙 release ref, `secrets` mapping, 지원되는 `app_id`, `automation_ref`만 변경한다.
+- caller가 없는 저장소는 skip한다.
+- required secret이 없고 안전한 source도 없으면 해당 저장소만 blocked 처리한다.
+
+## Secret source
+
+- 이미 존재하는 repository secret은 값을 읽거나 다시 쓰지 않는다.
+- `CLAUDE_CODE_OAUTH_TOKEN` 누락 시에만 `~/.claude/.credentials.json`을 source로 쓸 수 있다.
+- 그 외 누락 secret은 같은 이름의 환경변수가 있을 때만 쓸 수 있다.
+- `--sync-missing-secrets`가 없으면 이름 검사만 하며 어떠한 secret도 쓰지 않는다.
+- Claude token의 지속적인 rotation은 `personal-ops/claude-token-sync`가 담당한다.
+
+## 실행
+
+workspace는 reset/clean 가능한 전용 disposable clone 디렉터리여야 한다. 최초 한 번
+명시적으로 초기화한다.
+
+```bash
+# 읽기 전용 계획. 원격 secret/variable은 이름만 조회한다.
+python3 scripts/rollout_workflow_fleet.py \
+  --workspace /path/to/disposable-fleet \
+  --initialize-workspace \
+  --mode plan \
+  --actionlint /path/to/actionlint
+
+# 로컬 branch 준비까지만 수행
+python3 scripts/rollout_workflow_fleet.py \
+  --workspace /path/to/disposable-fleet \
+  --mode prepare \
+  --repo example-repo \
+  --actionlint /path/to/actionlint
+
+# 필요한 secret이 있으면 먼저 동기화한 뒤 저장소별 PR 생성
+python3 scripts/rollout_workflow_fleet.py \
+  --workspace /path/to/disposable-fleet \
+  --mode publish \
+  --sync-missing-secrets \
+  --confirm \
+  --actionlint /path/to/actionlint
+```
+
+각 실행은 `rollout-manifest.json`에 base/head/PR/blocked 결과를 남긴다. 한 저장소가
+blocked여도 다른 저장소의 준비는 계속하지만 명령은 non-zero로 끝난다.
+
+## Merge와 rollback
+
+PR 생성은 한 명령으로 가능하지만 merge는 CI 결과를 확인해 배치별로 수행한다.
+문제 발생 시 해당 저장소 PR을 닫거나 branch를 삭제한다. merge 후에는 ref만 되돌리지
+말고 직전 ref와 직전 `secrets` mapping을 함께 복원한다. release tag는 이동하지 않는다.

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -17,7 +17,9 @@ repository secret 전제조건을 한 실행에서 조율한다. GitHub는 Git P
 
 - 이미 존재하는 repository secret은 값을 읽거나 다시 쓰지 않는다.
 - `CLAUDE_CODE_OAUTH_TOKEN` 누락 시에만 `~/.claude/.credentials.json`을 source로 쓸 수 있다.
-- 그 외 누락 secret은 같은 이름의 환경변수가 있을 때만 쓸 수 있다.
+- 그 외 누락 secret은 같은 이름의 환경변수가 있고 `--allow-env-secret NAME`으로
+  그 이름을 이번 실행에 명시 승인했을 때만 쓸 수 있다. 승인된 이름은 값 없이
+  preflight 출력에 표시된다.
 - `--sync-missing-secrets`가 없으면 이름 검사만 하며 어떠한 secret도 쓰지 않는다.
 - 개인 Claude OAuth token fan-out은 추가로 `--allow-personal-oauth-fanout`을 명시해야
   한다. 이 옵션은 저장소마다 자격증명을 복제해 blast radius를 넓히므로, 이미 배포된
@@ -50,6 +52,7 @@ python3 scripts/rollout_workflow_fleet.py \
   --mode publish \
   --sync-missing-secrets \
   --allow-personal-oauth-fanout \
+  --allow-env-secret GEMINI_API_KEY \
   --confirm \
   --actionlint /path/to/actionlint
 ```

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -54,6 +54,10 @@ python3 scripts/rollout_workflow_fleet.py \
   --actionlint /path/to/actionlint
 ```
 
+`plan`과 `prepare`에서는 `--sync-missing-secrets`를 지정할 수 없으며 parser가 즉시
+거부한다. 실제 repository secret write는 `publish + --sync-missing-secrets +
+--confirm` 조합에서만 가능하다.
+
 각 실행은 `rollout-manifest.json`에 base/head/PR/blocked 결과를 남긴다. 한 저장소가
 blocked여도 다른 저장소의 준비는 계속하지만 명령은 non-zero로 끝난다.
 

--- a/scripts/prepare_workflow_rollout.py
+++ b/scripts/prepare_workflow_rollout.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Prepare existing automation reusable-workflow callers for a safe fleet rollout.
+
+This module deliberately does not add workflows or replace whole caller files. It keeps
+repository-owned triggers, guards, permissions and inputs, changing only the central
+release ref, secret mapping, optional app_id forwarding and automation_ref config.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import sys
+
+import yaml
+
+
+USE_RE = re.compile(
+    r"^(?P<indent> +)uses:\s*['\"]?"
+    r"jhw7500/automation/\.github/workflows/(?P<workflow>[^@\s'\"]+)@"
+    r"(?P<ref>[^\s'\"]+)['\"]?\s*$"
+)
+CONFIG_REF_RE = re.compile(r"(?m)^(automation_ref:\s*)\S+\s*$")
+GEMINI_AUTH_SECRETS = {"APP_PRIVATE_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"}
+
+
+class RolloutError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Contract:
+    declared: set[str]
+    required: set[str]
+    has_app_id: bool
+
+
+@dataclass(frozen=True)
+class RolloutResult:
+    callers: int
+    changed_files: tuple[Path, ...]
+    required_secrets: frozenset[str]
+
+
+def load_yaml(path: Path) -> dict:
+    data = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    return data if isinstance(data, dict) else {}
+
+
+def workflow_contract(automation: Path, filename: str) -> Contract:
+    path = automation / ".github/workflows" / filename
+    if not path.is_file():
+        raise RolloutError(f"central workflow not found: {filename}")
+    workflow = load_yaml(path)
+    on = workflow.get("on", {})
+    if not isinstance(on, dict) or "workflow_call" not in on:
+        raise RolloutError(f"central workflow is not reusable: {filename}")
+    call = on.get("workflow_call") or {}
+    if not isinstance(call, dict):
+        raise RolloutError(f"invalid workflow_call contract: {filename}")
+    secrets = call.get("secrets", {})
+    inputs = call.get("inputs", {})
+    if not isinstance(secrets, dict):
+        secrets = {}
+    if not isinstance(inputs, dict):
+        inputs = {}
+    required = {
+        name
+        for name, values in secrets.items()
+        if isinstance(values, dict) and values.get("required", "false") == "true"
+    }
+    return Contract(set(secrets), required, "app_id" in inputs)
+
+
+def leading_spaces(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def block_end(lines: list[str], start: int, parent_indent: int) -> int:
+    for index in range(start + 1, len(lines)):
+        stripped = lines[index].strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if leading_spaces(lines[index]) <= parent_indent:
+            return index
+    return len(lines)
+
+
+def secret_names_for(
+    filename: str,
+    contract: Contract,
+    available_secrets: set[str],
+    available_variables: set[str],
+) -> tuple[list[str], bool]:
+    missing = contract.required - available_secrets
+    if missing:
+        raise RolloutError(
+            f"{filename}: missing required secrets: {', '.join(sorted(missing))}"
+        )
+
+    selected = contract.declared & available_secrets
+    has_gemini_auth_contract = GEMINI_AUTH_SECRETS <= contract.declared
+    app_enabled = "APP_ID" in available_variables
+    if "APP_PRIVATE_KEY" in contract.declared:
+        if app_enabled and "APP_PRIVATE_KEY" not in available_secrets:
+            raise RolloutError(f"{filename}: APP_ID exists but APP_PRIVATE_KEY is missing")
+        if not app_enabled:
+            selected.discard("APP_PRIVATE_KEY")
+
+    if has_gemini_auth_contract:
+        usable_api_key = bool({"GEMINI_API_KEY", "GOOGLE_API_KEY"} & available_secrets)
+        usable_app = app_enabled and "APP_PRIVATE_KEY" in available_secrets
+        if not (usable_api_key or usable_app):
+            raise RolloutError(f"{filename}: no usable Gemini authentication path")
+
+    return sorted(selected), contract.has_app_id and app_enabled
+
+
+def replace_job_segment(
+    segment: list[str],
+    indent: str,
+    new_ref: str,
+    names: list[str],
+    pass_app_id: bool,
+) -> list[str]:
+    use_match = USE_RE.match(segment[0].rstrip("\n"))
+    if use_match is None:
+        raise RolloutError("internal error: reusable workflow use line not found")
+    newline = "\n" if segment[0].endswith("\n") else ""
+    segment[0] = re.sub(
+        r"(@)[^\s'\"]+(['\"]?\s*)$",
+        lambda match: match.group(1) + new_ref + match.group(2),
+        segment[0].rstrip("\n"),
+    ) + newline
+
+    width = len(indent)
+    secret_index = None
+    secret_end = None
+    with_index = None
+    for index, line in enumerate(segment):
+        stripped = line.strip()
+        if leading_spaces(line) == width and re.match(r"secrets\s*:", stripped):
+            secret_index = index
+            secret_end = block_end(segment, index, width)
+        if leading_spaces(line) == width and stripped == "with:":
+            with_index = index
+
+    if secret_index is not None and secret_end is not None:
+        del segment[secret_index:secret_end]
+        if with_index is not None and secret_index < with_index:
+            with_index -= secret_end - secret_index
+
+    if pass_app_id:
+        app_line = f"{indent}  app_id: ${{{{ vars.APP_ID }}}}\n"
+        if with_index is None:
+            insertion = len(segment)
+            segment[insertion:insertion] = [f"{indent}with:\n", app_line]
+        else:
+            with_end = block_end(segment, with_index, width)
+            existing = any(
+                leading_spaces(line) > width and line.strip().startswith("app_id:")
+                for line in segment[with_index + 1 : with_end]
+            )
+            if not existing:
+                segment.insert(with_end, app_line)
+
+    if names:
+        mapping = [f"{indent}secrets:\n"] + [
+            f"{indent}  {name}: ${{{{ secrets.{name} }}}}\n" for name in names
+        ]
+        segment.extend(mapping)
+    return segment
+
+
+def transform_workflow(
+    path: Path,
+    automation: Path,
+    new_ref: str,
+    available_secrets: set[str],
+    available_variables: set[str],
+) -> tuple[str, int, set[str]]:
+    original = path.read_text(encoding="utf-8")
+    lines = original.splitlines(keepends=True)
+    uses: list[tuple[int, re.Match[str]]] = []
+    for index, line in enumerate(lines):
+        match = USE_RE.match(line.rstrip("\n"))
+        if match is not None:
+            uses.append((index, match))
+
+    required: set[str] = set()
+    for index, match in reversed(uses):
+        indent = match.group("indent")
+        end = block_end(lines, index, len(indent) - 2)
+        contract = workflow_contract(automation, match.group("workflow"))
+        names, pass_app_id = secret_names_for(
+            match.group("workflow"), contract, available_secrets, available_variables
+        )
+        required.update(names)
+        segment = replace_job_segment(lines[index:end], indent, new_ref, names, pass_app_id)
+        lines[index:end] = segment
+
+    return "".join(lines), len(uses), required
+
+
+def prepare_repository(
+    repo: Path,
+    automation: Path,
+    new_ref: str,
+    available_secrets: set[str],
+    available_variables: set[str],
+) -> RolloutResult:
+    repo = repo.resolve()
+    automation = automation.resolve()
+    workflow_dir = repo / ".github/workflows"
+    planned: dict[Path, str] = {}
+    caller_count = 0
+    required: set[str] = set()
+
+    if workflow_dir.is_dir():
+        for path in sorted(workflow_dir.glob("*.y*ml")):
+            transformed, callers, names = transform_workflow(
+                path, automation, new_ref, available_secrets, available_variables
+            )
+            caller_count += callers
+            required.update(names)
+            if transformed != path.read_text(encoding="utf-8"):
+                planned[path] = transformed
+
+    if caller_count == 0:
+        return RolloutResult(0, (), frozenset())
+
+    config = repo / ".github/workflow-config.yml"
+    if config.is_file():
+        old_config = config.read_text(encoding="utf-8")
+        if CONFIG_REF_RE.search(old_config):
+            new_config = CONFIG_REF_RE.sub(rf"\g<1>{new_ref}", old_config, count=1)
+        else:
+            new_config = f"automation_ref: {new_ref}\n" + old_config
+    else:
+        new_config = f"automation_ref: {new_ref}\n"
+    if not config.is_file() or new_config != config.read_text(encoding="utf-8"):
+        planned[config] = new_config
+
+    # Validate all generated YAML before writing any file.
+    for path, text in planned.items():
+        try:
+            yaml.load(text, Loader=yaml.BaseLoader)
+        except yaml.YAMLError as exc:
+            raise RolloutError(f"generated invalid YAML for {path}: {exc}") from exc
+
+    for path, text in planned.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    changed = tuple(sorted(path.relative_to(repo) for path in planned))
+    return RolloutResult(caller_count, changed, frozenset(required))
+
+
+def csv_set(value: str) -> set[str]:
+    return {item for item in value.split(",") if item}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--automation", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--ref", default="v1.35")
+    parser.add_argument("--available-secrets", default="")
+    parser.add_argument("--available-variables", default="")
+    args = parser.parse_args(argv)
+    try:
+        result = prepare_repository(
+            args.repo,
+            args.automation,
+            args.ref,
+            csv_set(args.available_secrets),
+            csv_set(args.available_variables),
+        )
+    except RolloutError as exc:
+        print(f"FAIL {args.repo}: {exc}", file=sys.stderr)
+        return 1
+    print(
+        f"PASS {args.repo}: {result.callers} caller(s), "
+        f"{len(result.changed_files)} changed file(s), "
+        f"secrets={','.join(sorted(result.required_secrets)) or 'none'}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/prepare_workflow_rollout.py
+++ b/scripts/prepare_workflow_rollout.py
@@ -97,6 +97,40 @@ def block_end(lines: list[str], start: int, parent_indent: int) -> int:
     return len(lines)
 
 
+def validate_use_context(lines: list[str], index: int, indent: str, path: Path) -> None:
+    """Fail closed unless the line editor can safely own the caller job tail."""
+    width = len(indent)
+    parent_index = None
+    parent_width = -1
+    for candidate in range(index - 1, -1, -1):
+        stripped = lines[candidate].strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        candidate_width = leading_spaces(lines[candidate])
+        if candidate_width < width:
+            parent_index = candidate
+            parent_width = candidate_width
+            break
+    parent_is_mapping_key = (
+        parent_index is not None
+        and re.fullmatch(r"[^:#][^:]*:\s*(?:#.*)?", lines[parent_index].strip())
+        is not None
+    )
+    if parent_index is None or width - parent_width != 2 or not parent_is_mapping_key:
+        raise RolloutError(
+            f"{path.name}: reusable workflow uses must be indented exactly "
+            "two spaces below its job key"
+        )
+
+    for line in lines[parent_index + 1 : index]:
+        if leading_spaces(line) != width:
+            continue
+        if re.match(r"(?:secrets|with)\s*:", line.strip()):
+            raise RolloutError(
+                f"{path.name}: secrets/with must follow uses for safe rewriting"
+            )
+
+
 def secret_names_for(
     filename: str,
     contract: Contract,
@@ -222,6 +256,7 @@ def transform_workflow(
     required: set[str] = set()
     for index, match in reversed(uses):
         indent = match.group("indent")
+        validate_use_context(lines, index, indent, path)
         end = block_end(lines, index, len(indent) - 2)
         contract = workflow_contract(automation, match.group("workflow"))
         names, pass_app_id = secret_names_for(

--- a/scripts/prepare_workflow_rollout.py
+++ b/scripts/prepare_workflow_rollout.py
@@ -30,6 +30,12 @@ class RolloutError(RuntimeError):
     pass
 
 
+class SecretPrerequisiteError(RolloutError):
+    def __init__(self, message: str, missing_secrets: set[str]) -> None:
+        super().__init__(message)
+        self.missing_secrets = frozenset(missing_secrets)
+
+
 @dataclass(frozen=True)
 class Contract:
     declared: set[str]
@@ -96,8 +102,9 @@ def secret_names_for(
 ) -> tuple[list[str], bool]:
     missing = contract.required - available_secrets
     if missing:
-        raise RolloutError(
-            f"{filename}: missing required secrets: {', '.join(sorted(missing))}"
+        raise SecretPrerequisiteError(
+            f"{filename}: missing required secrets: {', '.join(sorted(missing))}",
+            missing,
         )
 
     selected = contract.declared & available_secrets
@@ -105,7 +112,10 @@ def secret_names_for(
     app_enabled = "APP_ID" in available_variables
     if "APP_PRIVATE_KEY" in contract.declared:
         if app_enabled and "APP_PRIVATE_KEY" not in available_secrets:
-            raise RolloutError(f"{filename}: APP_ID exists but APP_PRIVATE_KEY is missing")
+            raise SecretPrerequisiteError(
+                f"{filename}: APP_ID exists but APP_PRIVATE_KEY is missing",
+                {"APP_PRIVATE_KEY"},
+            )
         if not app_enabled:
             selected.discard("APP_PRIVATE_KEY")
 
@@ -113,7 +123,10 @@ def secret_names_for(
         usable_api_key = bool({"GEMINI_API_KEY", "GOOGLE_API_KEY"} & available_secrets)
         usable_app = app_enabled and "APP_PRIVATE_KEY" in available_secrets
         if not (usable_api_key or usable_app):
-            raise RolloutError(f"{filename}: no usable Gemini authentication path")
+            raise SecretPrerequisiteError(
+                f"{filename}: no usable Gemini authentication path",
+                {"GEMINI_API_KEY"},
+            )
 
     return sorted(selected), contract.has_app_id and app_enabled
 

--- a/scripts/prepare_workflow_rollout.py
+++ b/scripts/prepare_workflow_rollout.py
@@ -110,25 +110,20 @@ def secret_names_for(
     selected = contract.declared & available_secrets
     has_gemini_auth_contract = GEMINI_AUTH_SECRETS <= contract.declared
     app_enabled = "APP_ID" in available_variables
-    if "APP_PRIVATE_KEY" in contract.declared:
-        if app_enabled and "APP_PRIVATE_KEY" not in available_secrets:
-            raise SecretPrerequisiteError(
-                f"{filename}: APP_ID exists but APP_PRIVATE_KEY is missing",
-                {"APP_PRIVATE_KEY"},
-            )
-        if not app_enabled:
-            selected.discard("APP_PRIVATE_KEY")
+    usable_app = app_enabled and "APP_PRIVATE_KEY" in available_secrets
+    if "APP_PRIVATE_KEY" in contract.declared and not usable_app:
+        selected.discard("APP_PRIVATE_KEY")
 
     if has_gemini_auth_contract:
         usable_api_key = bool({"GEMINI_API_KEY", "GOOGLE_API_KEY"} & available_secrets)
-        usable_app = app_enabled and "APP_PRIVATE_KEY" in available_secrets
         if not (usable_api_key or usable_app):
+            missing = {"APP_PRIVATE_KEY"} if app_enabled else {"GEMINI_API_KEY"}
             raise SecretPrerequisiteError(
                 f"{filename}: no usable Gemini authentication path",
-                {"GEMINI_API_KEY"},
+                missing,
             )
 
-    return sorted(selected), contract.has_app_id and app_enabled
+    return sorted(selected), contract.has_app_id and usable_app
 
 
 def replace_job_segment(

--- a/scripts/prepare_workflow_rollout.py
+++ b/scripts/prepare_workflow_rollout.py
@@ -18,11 +18,14 @@ import yaml
 
 
 USE_RE = re.compile(
-    r"^(?P<indent> +)uses:\s*['\"]?"
+    r"^(?P<indent> +)uses:\s*(?P<quote>['\"]?)"
     r"jhw7500/automation/\.github/workflows/(?P<workflow>[^@\s'\"]+)@"
-    r"(?P<ref>[^\s'\"]+)['\"]?\s*$"
+    r"(?P<ref>[^\s'\"]+)(?P=quote)(?P<suffix>\s*(?:#.*)?)$"
 )
-CONFIG_REF_RE = re.compile(r"(?m)^(automation_ref:\s*)\S+\s*$")
+CONFIG_REF_RE = re.compile(
+    r"(?m)^(?P<prefix>automation_ref:[ \t]*)\S+"
+    r"(?P<suffix>[ \t]*(?:#.*)?)$"
+)
 GEMINI_AUTH_SECRETS = {"APP_PRIVATE_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"}
 
 
@@ -87,7 +90,7 @@ def leading_spaces(line: str) -> int:
 def block_end(lines: list[str], start: int, parent_indent: int) -> int:
     for index in range(start + 1, len(lines)):
         stripped = lines[index].strip()
-        if not stripped or stripped.startswith("#"):
+        if not stripped:
             continue
         if leading_spaces(lines[index]) <= parent_indent:
             return index
@@ -137,11 +140,12 @@ def replace_job_segment(
     if use_match is None:
         raise RolloutError("internal error: reusable workflow use line not found")
     newline = "\n" if segment[0].endswith("\n") else ""
-    segment[0] = re.sub(
-        r"(@)[^\s'\"]+(['\"]?\s*)$",
-        lambda match: match.group(1) + new_ref + match.group(2),
-        segment[0].rstrip("\n"),
-    ) + newline
+    quote = use_match.group("quote")
+    suffix = use_match.group("suffix")
+    segment[0] = (
+        f"{indent}uses: {quote}jhw7500/automation/.github/workflows/"
+        f"{use_match.group('workflow')}@{new_ref}{quote}{suffix}{newline}"
+    )
 
     width = len(indent)
     secret_index = None
@@ -197,6 +201,24 @@ def transform_workflow(
         if match is not None:
             uses.append((index, match))
 
+    workflow = load_yaml(path)
+    jobs = workflow.get("jobs", {})
+    yaml_callers = 0
+    if isinstance(jobs, dict):
+        for job in jobs.values():
+            if not isinstance(job, dict):
+                continue
+            use = job.get("uses")
+            if isinstance(use, str) and re.fullmatch(
+                r"jhw7500/automation/\.github/workflows/[^@\s]+@[^\s]+", use
+            ):
+                yaml_callers += 1
+    if yaml_callers != len(uses):
+        raise RolloutError(
+            f"{path.name}: found {yaml_callers} YAML caller(s) but "
+            f"can safely rewrite only {len(uses)}"
+        )
+
     required: set[str] = set()
     for index, match in reversed(uses):
         indent = match.group("indent")
@@ -242,8 +264,17 @@ def prepare_repository(
     config = repo / ".github/workflow-config.yml"
     if config.is_file():
         old_config = config.read_text(encoding="utf-8")
-        if CONFIG_REF_RE.search(old_config):
-            new_config = CONFIG_REF_RE.sub(rf"\g<1>{new_ref}", old_config, count=1)
+        matches = list(CONFIG_REF_RE.finditer(old_config))
+        if len(matches) > 1:
+            raise RolloutError(f"duplicate automation_ref keys: {config}")
+        if matches:
+            new_config = CONFIG_REF_RE.sub(
+                lambda match: (
+                    match.group("prefix") + new_ref + match.group("suffix")
+                ),
+                old_config,
+                count=1,
+            )
         else:
             new_config = f"automation_ref: {new_ref}\n" + old_config
     else:

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -26,10 +26,16 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from scripts.audit_workflow_fleet import audit_repository
-from scripts.prepare_workflow_rollout import RolloutError, prepare_repository
-
-
-BRANCH = "codex/automation-v1.35-fleet"
+from scripts.prepare_workflow_rollout import (
+    RolloutError,
+    SecretPrerequisiteError,
+    prepare_repository,
+)
+from scripts.verify_workflow_release import (
+    resolve_commit,
+    verify_remote_tag,
+    verify_tag_content,
+)
 
 
 @dataclass
@@ -80,7 +86,9 @@ def remote_names(owner: str, repo: str, kind: str) -> set[str]:
     return {item["name"] for item in data}  # type: ignore[union-attr]
 
 
-def secret_source(name: str) -> str | None:
+def secret_source(name: str, allow_personal_oauth_fanout: bool = False) -> str | None:
+    if name == "CLAUDE_CODE_OAUTH_TOKEN" and not allow_personal_oauth_fanout:
+        return None
     value = os.environ.get(name)
     if value:
         return value
@@ -97,7 +105,16 @@ def secret_source(name: str) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
-def clone_or_reset(workspace: Path, owner: str, repo: str, branch: str) -> tuple[Path, str]:
+def rollout_branch(ref: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", ref).strip("-")
+    if not safe:
+        raise RolloutError(f"invalid rollout ref: {ref!r}")
+    return f"codex/automation-{safe}-fleet"
+
+
+def clone_or_reset(
+    workspace: Path, owner: str, repo: str, default: str, rollout: str
+) -> tuple[Path, str]:
     path = workspace / repo
     if not (path / ".git").is_dir():
         run(
@@ -111,10 +128,10 @@ def clone_or_reset(workspace: Path, owner: str, repo: str, branch: str) -> tuple
                 str(path),
             ]
         )
-    run(["git", "fetch", "--no-tags", "origin", branch], cwd=path)
-    base = run(["git", "rev-parse", f"origin/{branch}"], cwd=path)
-    run(["git", "checkout", "-q", "-B", BRANCH, f"origin/{branch}"], cwd=path)
-    run(["git", "reset", "--hard", "-q", f"origin/{branch}"], cwd=path)
+    run(["git", "fetch", "--no-tags", "origin", default], cwd=path)
+    base = run(["git", "rev-parse", f"origin/{default}"], cwd=path)
+    run(["git", "checkout", "-q", "-B", rollout, f"origin/{default}"], cwd=path)
+    run(["git", "reset", "--hard", "-q", f"origin/{default}"], cwd=path)
     run(["git", "clean", "-fdq"], cwd=path)
     return path, base
 
@@ -128,13 +145,47 @@ def preview_copy(repo: Path) -> tempfile.TemporaryDirectory[str]:
     return temp
 
 
+def materialize_release_contract(
+    automation: Path, ref: str
+) -> tuple[tempfile.TemporaryDirectory[str], Path, str]:
+    expected = resolve_commit(automation, f"refs/tags/{ref}")
+    verify_tag_content(automation, ref)
+    verify_remote_tag(automation, "origin", ref, expected)
+    temp = tempfile.TemporaryDirectory()
+    archive = subprocess.run(
+        ["git", "archive", ref, ".github/workflows"],
+        cwd=automation,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if archive.returncode != 0:
+        temp.cleanup()
+        raise CommandError(f"cannot archive release {ref}")
+    extract = subprocess.run(
+        ["tar", "-x", "-C", temp.name],
+        input=archive.stdout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if extract.returncode != 0:
+        temp.cleanup()
+        raise CommandError(f"cannot extract release {ref}")
+    return temp, Path(temp.name), expected
+
+
 def sync_missing(
-    owner: str, repo: str, missing: set[str], enabled: bool
+    owner: str,
+    repo: str,
+    missing: set[str],
+    enabled: bool,
+    allow_personal_oauth_fanout: bool,
 ) -> tuple[set[str], tuple[str, ...]]:
     available = remote_names(owner, repo, "secret")
     synced: list[str] = []
     for name in sorted(missing - available):
-        value = secret_source(name) if enabled else None
+        value = (
+            secret_source(name, allow_personal_oauth_fanout) if enabled else None
+        )
         if value is None:
             continue
         run(
@@ -153,25 +204,21 @@ def prepare_with_prerequisites(
     owner: str,
     repo: str,
     sync_missing_enabled: bool,
+    allow_personal_oauth_fanout: bool,
 ) -> tuple[object, tuple[str, ...]]:
     secrets = remote_names(owner, repo, "secret")
     variables = remote_names(owner, repo, "variable")
     synced: tuple[str, ...] = ()
     try:
         return prepare_repository(repo_path, automation, ref, secrets, variables), synced
-    except RolloutError as first:
-        text = str(first)
-        candidates: set[str] = set()
-        if "missing required secrets:" in text:
-            candidates.update(text.split("missing required secrets:", 1)[1].split(", "))
-        if "APP_ID exists but APP_PRIVATE_KEY is missing" in text:
-            candidates.add("APP_PRIVATE_KEY")
-        if "no usable Gemini authentication path" in text:
-            candidates.update({"GEMINI_API_KEY"})
-        if not candidates:
-            raise
+    except SecretPrerequisiteError as first:
+        candidates = set(first.missing_secrets)
         secrets, synced = sync_missing(
-            owner, repo, candidates, enabled=sync_missing_enabled
+            owner,
+            repo,
+            candidates,
+            enabled=sync_missing_enabled,
+            allow_personal_oauth_fanout=allow_personal_oauth_fanout,
         )
         return prepare_repository(repo_path, automation, ref, secrets, variables), synced
 
@@ -242,7 +289,7 @@ def actionlint_diagnostics(actionlint: Path, root: Path) -> Counter[str]:
 
 
 def publish_repository(
-    repo: Path, owner: str, name: str, default: str, ref: str
+    repo: Path, owner: str, name: str, default: str, ref: str, branch: str
 ) -> tuple[str, str]:
     run(["git", "add", ".github"], cwd=repo)
     run(
@@ -250,7 +297,7 @@ def publish_repository(
         cwd=repo,
     )
     head = run(["git", "rev-parse", "HEAD"], cwd=repo)
-    run(["git", "push", "--force-with-lease", "-u", "origin", BRANCH], cwd=repo)
+    run(["git", "push", "--force-with-lease", "-u", "origin", branch], cwd=repo)
     existing = gh_json(
         [
             "pr",
@@ -258,7 +305,7 @@ def publish_repository(
             "-R",
             f"{owner}/{name}",
             "--head",
-            BRANCH,
+            branch,
             "--base",
             default,
             "--state",
@@ -288,7 +335,7 @@ def publish_repository(
             "--base",
             default,
             "--head",
-            BRANCH,
+            branch,
             "--title",
             f"ci: restrict shared workflow secrets ({ref})",
             "--body",
@@ -307,6 +354,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--mode", choices=("plan", "prepare", "publish"), default="plan")
     parser.add_argument("--repo", action="append", default=[])
     parser.add_argument("--sync-missing-secrets", action="store_true")
+    parser.add_argument(
+        "--allow-personal-oauth-fanout",
+        action="store_true",
+        help="explicitly allow ~/.claude OAuth token to fill missing repository secrets",
+    )
     parser.add_argument("--actionlint", type=Path)
     parser.add_argument("--confirm", action="store_true")
     parser.add_argument("--manifest", type=Path)
@@ -328,6 +380,8 @@ def main(argv: list[str] | None = None) -> int:
         parser.error(f"repositories not in config: {', '.join(unknown)}")
     if args.mode == "publish" and not args.confirm:
         parser.error("--mode publish requires --confirm")
+    if args.allow_personal_oauth_fanout and not args.sync_missing_secrets:
+        parser.error("--allow-personal-oauth-fanout requires --sync-missing-secrets")
 
     marker = args.workspace / ".automation-fleet-workspace"
     if not marker.is_file():
@@ -339,47 +393,59 @@ def main(argv: list[str] | None = None) -> int:
         args.workspace.mkdir(parents=True, exist_ok=True)
         marker.write_text("managed disposable clones only\n", encoding="utf-8")
     outcomes: list[RepoOutcome] = []
-    for name in repos:
-        try:
-            default = default_branch(owner, name)
-            repo, base = clone_or_reset(args.workspace, owner, name, default)
-            target = repo
-            preview = None
-            if args.mode == "plan":
-                preview = preview_copy(repo)
-                target = Path(preview.name)
-            result, synced = prepare_with_prerequisites(
-                target,
-                automation,
-                args.ref,
-                owner,
-                name,
-                args.sync_missing_secrets and args.mode != "plan",
-            )
-            if result.callers == 0:
-                outcomes.append(RepoOutcome(name, "skipped", "no existing central callers", base))
-            elif not result.changed_files:
-                outcomes.append(RepoOutcome(name, "current", "already matches contract", base))
-            else:
-                validate_repository(
-                    target,
-                    automation,
-                    args.actionlint,
-                    baseline_repo=repo if args.mode == "plan" else None,
+    contract_temp, contract_source, release_commit = materialize_release_contract(
+        automation, args.ref
+    )
+    branch = rollout_branch(args.ref)
+    try:
+        for name in repos:
+            try:
+                default = default_branch(owner, name)
+                repo, base = clone_or_reset(
+                    args.workspace, owner, name, default, branch
                 )
-                if args.mode == "publish":
-                    head, url = publish_repository(repo, owner, name, default, args.ref)
-                    outcomes.append(
-                        RepoOutcome(name, "published", f"{result.callers} callers", base, head, url, synced)
-                    )
+                target = repo
+                preview = None
+                if args.mode == "plan":
+                    preview = preview_copy(repo)
+                    target = Path(preview.name)
+                result, synced = prepare_with_prerequisites(
+                    target,
+                    contract_source,
+                    args.ref,
+                    owner,
+                    name,
+                    args.sync_missing_secrets and args.mode != "plan",
+                    args.allow_personal_oauth_fanout,
+                )
+                if result.callers == 0:
+                    outcomes.append(RepoOutcome(name, "skipped", "no existing central callers", base))
+                elif not result.changed_files:
+                    outcomes.append(RepoOutcome(name, "current", "already matches contract", base))
                 else:
-                    outcomes.append(
-                        RepoOutcome(name, args.mode, f"{result.callers} callers", base, synced_secrets=synced)
+                    validate_repository(
+                        target,
+                        contract_source,
+                        args.actionlint,
+                        baseline_repo=repo if args.mode == "plan" else None,
                     )
-            if preview is not None:
-                preview.cleanup()
-        except (CommandError, RolloutError, OSError, json.JSONDecodeError) as exc:
-            outcomes.append(RepoOutcome(name, "blocked", str(exc)))
+                    if args.mode == "publish":
+                        head, url = publish_repository(
+                            repo, owner, name, default, args.ref, branch
+                        )
+                        outcomes.append(
+                            RepoOutcome(name, "published", f"{result.callers} callers", base, head, url, synced)
+                        )
+                    else:
+                        outcomes.append(
+                            RepoOutcome(name, args.mode, f"{result.callers} callers", base, synced_secrets=synced)
+                        )
+                if preview is not None:
+                    preview.cleanup()
+            except (CommandError, RolloutError, OSError, json.JSONDecodeError) as exc:
+                outcomes.append(RepoOutcome(name, "blocked", str(exc)))
+    finally:
+        contract_temp.cleanup()
 
     manifest = args.manifest or args.workspace / "rollout-manifest.json"
     manifest.write_text(
@@ -390,7 +456,10 @@ def main(argv: list[str] | None = None) -> int:
         suffix = f" {item.pr_url}" if item.pr_url else ""
         print(f"{item.status.upper():9} {item.repo}: {item.detail}{suffix}")
     blocked = sum(item.status == "blocked" for item in outcomes)
-    print(f"SUMMARY total={len(outcomes)} blocked={blocked} manifest={manifest}")
+    print(
+        f"SUMMARY ref={args.ref} commit={release_commit} "
+        f"total={len(outcomes)} blocked={blocked} manifest={manifest}"
+    )
     return 1 if blocked else 0
 
 

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -74,18 +74,39 @@ def gh_json(args: list[str]) -> object:
 
 def default_branch(owner: str, repo: str) -> str:
     data = gh_json(["repo", "view", f"{owner}/{repo}", "--json", "defaultBranchRef"])
-    return data["defaultBranchRef"]["name"]  # type: ignore[index]
+    if not isinstance(data, dict):
+        raise CommandError(f"{owner}/{repo}: unexpected repository metadata")
+    branch = data.get("defaultBranchRef")
+    if not isinstance(branch, dict) or not isinstance(branch.get("name"), str):
+        raise CommandError(f"{owner}/{repo}: default branch is unavailable")
+    return branch["name"]
 
 
 def remote_names(owner: str, repo: str, kind: str) -> set[str]:
     data = gh_json([kind, "list", "-R", f"{owner}/{repo}", "--json", "name"])
-    return {item["name"] for item in data}  # type: ignore[union-attr]
+    if not isinstance(data, list):
+        raise CommandError(f"{owner}/{repo}: unexpected {kind} inventory")
+    names: set[str] = set()
+    for item in data:
+        if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+            raise CommandError(f"{owner}/{repo}: malformed {kind} inventory item")
+        names.add(item["name"])
+    return names
 
 
-def secret_source(name: str, allow_personal_oauth_fanout: bool = False) -> str | None:
-    if name == "CLAUDE_CODE_OAUTH_TOKEN" and not allow_personal_oauth_fanout:
-        return None
-    value = os.environ.get(name)
+def secret_source(
+    name: str,
+    allow_personal_oauth_fanout: bool = False,
+    allowed_env_secrets: set[str] | None = None,
+) -> str | None:
+    if name == "CLAUDE_CODE_OAUTH_TOKEN":
+        if not allow_personal_oauth_fanout:
+            return None
+        value = os.environ.get(name)
+        if value:
+            return value
+    allowed_env_secrets = allowed_env_secrets or set()
+    value = os.environ.get(name) if name in allowed_env_secrets else None
     if value:
         return value
     if name != "CLAUDE_CODE_OAUTH_TOKEN":
@@ -173,12 +194,17 @@ def sync_missing(
     missing: set[str],
     enabled: bool,
     allow_personal_oauth_fanout: bool,
+    allowed_env_secrets: set[str],
 ) -> tuple[set[str], tuple[str, ...]]:
     available = remote_names(owner, repo, "secret")
     synced: list[str] = []
     for name in sorted(missing - available):
         value = (
-            secret_source(name, allow_personal_oauth_fanout) if enabled else None
+            secret_source(
+                name, allow_personal_oauth_fanout, allowed_env_secrets
+            )
+            if enabled
+            else None
         )
         if value is None:
             continue
@@ -199,6 +225,7 @@ def prepare_with_prerequisites(
     repo: str,
     sync_missing_enabled: bool,
     allow_personal_oauth_fanout: bool,
+    allowed_env_secrets: set[str],
 ) -> tuple[object, tuple[str, ...]]:
     secrets = remote_names(owner, repo, "secret")
     variables = remote_names(owner, repo, "variable")
@@ -213,6 +240,7 @@ def prepare_with_prerequisites(
             candidates,
             enabled=sync_missing_enabled,
             allow_personal_oauth_fanout=allow_personal_oauth_fanout,
+            allowed_env_secrets=allowed_env_secrets,
         )
         return prepare_repository(repo_path, automation, ref, secrets, variables), synced
 
@@ -353,6 +381,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="explicitly allow ~/.claude OAuth token to fill missing repository secrets",
     )
+    parser.add_argument(
+        "--allow-env-secret",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="allow this exact environment variable as a missing-secret source",
+    )
     parser.add_argument("--actionlint", type=Path)
     parser.add_argument("--confirm", action="store_true")
     parser.add_argument("--manifest", type=Path)
@@ -378,6 +413,13 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--sync-missing-secrets is allowed only in --mode publish")
     if args.allow_personal_oauth_fanout and not args.sync_missing_secrets:
         parser.error("--allow-personal-oauth-fanout requires --sync-missing-secrets")
+    if args.allow_env_secret and not args.sync_missing_secrets:
+        parser.error("--allow-env-secret requires --sync-missing-secrets")
+    invalid_env_names = [
+        name for name in args.allow_env_secret if re.fullmatch(r"[A-Z][A-Z0-9_]*", name) is None
+    ]
+    if invalid_env_names:
+        parser.error(f"invalid secret environment names: {', '.join(invalid_env_names)}")
 
     marker = args.workspace / ".automation-fleet-workspace"
     if not marker.is_file():
@@ -393,6 +435,12 @@ def main(argv: list[str] | None = None) -> int:
         automation, args.ref
     )
     branch = rollout_branch(args.ref)
+    allowed_env_secrets = set(args.allow_env_secret)
+    if allowed_env_secrets:
+        print(
+            "ALLOWED ENV SECRET SOURCES: "
+            + ", ".join(sorted(allowed_env_secrets))
+        )
     try:
         for name in repos:
             try:
@@ -400,44 +448,47 @@ def main(argv: list[str] | None = None) -> int:
                 repo, base = clone_or_reset(
                     args.workspace, owner, name, default, branch
                 )
-                target = repo
                 preview = None
-                if args.mode == "plan":
-                    preview = preview_copy(repo)
-                    target = Path(preview.name)
-                result, synced = prepare_with_prerequisites(
-                    target,
-                    contract_source,
-                    args.ref,
-                    owner,
-                    name,
-                    args.sync_missing_secrets and args.mode == "publish",
-                    args.allow_personal_oauth_fanout,
-                )
-                if result.callers == 0:
-                    outcomes.append(RepoOutcome(name, "skipped", "no existing central callers", base))
-                elif not result.changed_files:
-                    outcomes.append(RepoOutcome(name, "current", "already matches contract", base))
-                else:
-                    validate_repository(
+                try:
+                    target = repo
+                    if args.mode == "plan":
+                        preview = preview_copy(repo)
+                        target = Path(preview.name)
+                    result, synced = prepare_with_prerequisites(
                         target,
                         contract_source,
-                        args.actionlint,
-                        baseline_repo=repo if args.mode == "plan" else None,
+                        args.ref,
+                        owner,
+                        name,
+                        args.sync_missing_secrets and args.mode == "publish",
+                        args.allow_personal_oauth_fanout,
+                        allowed_env_secrets,
                     )
-                    if args.mode == "publish":
-                        head, url = publish_repository(
-                            repo, owner, name, default, args.ref, branch
-                        )
-                        outcomes.append(
-                            RepoOutcome(name, "published", f"{result.callers} callers", base, head, url, synced)
-                        )
+                    if result.callers == 0:
+                        outcomes.append(RepoOutcome(name, "skipped", "no existing central callers", base))
+                    elif not result.changed_files:
+                        outcomes.append(RepoOutcome(name, "current", "already matches contract", base))
                     else:
-                        outcomes.append(
-                            RepoOutcome(name, args.mode, f"{result.callers} callers", base, synced_secrets=synced)
+                        validate_repository(
+                            target,
+                            contract_source,
+                            args.actionlint,
+                            baseline_repo=repo if args.mode == "plan" else None,
                         )
-                if preview is not None:
-                    preview.cleanup()
+                        if args.mode == "publish":
+                            head, url = publish_repository(
+                                repo, owner, name, default, args.ref, branch
+                            )
+                            outcomes.append(
+                                RepoOutcome(name, "published", f"{result.callers} callers", base, head, url, synced)
+                            )
+                        else:
+                            outcomes.append(
+                                RepoOutcome(name, args.mode, f"{result.callers} callers", base, synced_secrets=synced)
+                            )
+                finally:
+                    if preview is not None:
+                        preview.cleanup()
             except (CommandError, RolloutError, OSError, json.JSONDecodeError) as exc:
                 outcomes.append(RepoOutcome(name, "blocked", str(exc)))
     finally:

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -59,7 +59,11 @@ def run(
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={key: value for key, value in os.environ.items() if key != "GITHUB_TOKEN"},
+        env={
+            key: value
+            for key, value in os.environ.items()
+            if key not in {"GITHUB_TOKEN", "GH_TOKEN"}
+        },
     )
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip()
@@ -229,20 +233,24 @@ def prepare_with_prerequisites(
 ) -> tuple[object, tuple[str, ...]]:
     secrets = remote_names(owner, repo, "secret")
     variables = remote_names(owner, repo, "variable")
-    synced: tuple[str, ...] = ()
-    try:
-        return prepare_repository(repo_path, automation, ref, secrets, variables), synced
-    except SecretPrerequisiteError as first:
-        candidates = set(first.missing_secrets)
-        secrets, synced = sync_missing(
-            owner,
-            repo,
-            candidates,
-            enabled=sync_missing_enabled,
-            allow_personal_oauth_fanout=allow_personal_oauth_fanout,
-            allowed_env_secrets=allowed_env_secrets,
-        )
-        return prepare_repository(repo_path, automation, ref, secrets, variables), synced
+    synced_all: list[str] = []
+    while True:
+        try:
+            result = prepare_repository(repo_path, automation, ref, secrets, variables)
+            return result, tuple(synced_all)
+        except SecretPrerequisiteError as error:
+            previous = set(secrets)
+            secrets, synced = sync_missing(
+                owner,
+                repo,
+                set(error.missing_secrets),
+                enabled=sync_missing_enabled,
+                allow_personal_oauth_fanout=allow_personal_oauth_fanout,
+                allowed_env_secrets=allowed_env_secrets,
+            )
+            synced_all.extend(name for name in synced if name not in synced_all)
+            if secrets == previous:
+                raise error
 
 
 def validate_repository(
@@ -402,7 +410,8 @@ def main(argv: list[str] | None = None) -> int:
     config_path = args.config or automation / "scripts/workflow-config.json"
     config = json.loads(config_path.read_text(encoding="utf-8"))
     owner = config["gh_owner"]
-    configured = sorted(config["repos"])
+    repo_config = config["repos"]
+    configured = sorted(repo_config)
     repos = args.repo or configured
     unknown = sorted(set(repos) - set(configured))
     if unknown:
@@ -444,6 +453,11 @@ def main(argv: list[str] | None = None) -> int:
     try:
         for name in repos:
             try:
+                if repo_config[name].get("workflows", True) is False:
+                    outcomes.append(
+                        RepoOutcome(name, "skipped", "workflows disabled by config")
+                    )
+                    continue
                 default = default_branch(owner, name)
                 repo, base = clone_or_reset(
                     args.workspace, owner, name, default, branch
@@ -460,7 +474,9 @@ def main(argv: list[str] | None = None) -> int:
                         args.ref,
                         owner,
                         name,
-                        args.sync_missing_secrets and args.mode == "publish",
+                        args.sync_missing_secrets
+                        and args.mode == "publish"
+                        and repo_config[name].get("secrets", True) is not False,
                         args.allow_personal_oauth_fanout,
                         allowed_env_secrets,
                     )

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -31,11 +31,7 @@ from scripts.prepare_workflow_rollout import (
     SecretPrerequisiteError,
     prepare_repository,
 )
-from scripts.verify_workflow_release import (
-    resolve_commit,
-    verify_remote_tag,
-    verify_tag_content,
-)
+from scripts.verify_workflow_release import verify_release
 
 
 @dataclass
@@ -148,9 +144,7 @@ def preview_copy(repo: Path) -> tempfile.TemporaryDirectory[str]:
 def materialize_release_contract(
     automation: Path, ref: str
 ) -> tuple[tempfile.TemporaryDirectory[str], Path, str]:
-    expected = resolve_commit(automation, f"refs/tags/{ref}")
-    verify_tag_content(automation, ref)
-    verify_remote_tag(automation, "origin", ref, expected)
+    expected = verify_release(automation, ref, ref, remote="origin")
     temp = tempfile.TemporaryDirectory()
     archive = subprocess.run(
         ["git", "archive", ref, ".github/workflows"],
@@ -380,6 +374,8 @@ def main(argv: list[str] | None = None) -> int:
         parser.error(f"repositories not in config: {', '.join(unknown)}")
     if args.mode == "publish" and not args.confirm:
         parser.error("--mode publish requires --confirm")
+    if args.sync_missing_secrets and args.mode != "publish":
+        parser.error("--sync-missing-secrets is allowed only in --mode publish")
     if args.allow_personal_oauth_fanout and not args.sync_missing_secrets:
         parser.error("--allow-personal-oauth-fanout requires --sync-missing-secrets")
 
@@ -415,7 +411,7 @@ def main(argv: list[str] | None = None) -> int:
                     args.ref,
                     owner,
                     name,
-                    args.sync_missing_secrets and args.mode != "plan",
+                    args.sync_missing_secrets and args.mode == "publish",
                     args.allow_personal_oauth_fanout,
                 )
                 if result.callers == 0:

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -513,6 +513,14 @@ def main(argv: list[str] | None = None) -> int:
                         preview.cleanup()
             except (CommandError, RolloutError, OSError, json.JSONDecodeError) as exc:
                 outcomes.append(RepoOutcome(name, "blocked", str(exc)))
+            except Exception as exc:
+                outcomes.append(
+                    RepoOutcome(
+                        name,
+                        "blocked",
+                        f"unexpected {type(exc).__name__}: {exc}",
+                    )
+                )
     finally:
         contract_temp.cleanup()
 

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -327,7 +327,13 @@ def publish_repository(
         cwd=repo,
     )
     head = run(["git", "rev-parse", "HEAD"], cwd=repo)
-    run(["git", "push", "--force-with-lease", "-u", "origin", branch], cwd=repo)
+    remote_ref = f"refs/heads/{branch}"
+    remote_line = run(
+        ["git", "ls-remote", "--heads", "origin", remote_ref], cwd=repo
+    )
+    remote_sha = remote_line.split(maxsplit=1)[0] if remote_line else ""
+    lease = f"--force-with-lease={remote_ref}:{remote_sha}"
+    run(["git", "push", lease, "-u", "origin", branch], cwd=repo)
     existing = gh_json(
         [
             "pr",

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Orchestrate a fail-closed, per-repository workflow and secret rollout.
+
+The command keeps workflow delivery (Git PRs) and secret writes as separate phases in
+one run because GitHub cannot make them atomic. Secret prerequisites are checked first;
+only then are existing callers transformed, validated, committed, pushed and opened as
+independent PRs. No repository-owned trigger or permission block is replaced.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.audit_workflow_fleet import audit_repository
+from scripts.prepare_workflow_rollout import RolloutError, prepare_repository
+
+
+BRANCH = "codex/automation-v1.35-fleet"
+
+
+@dataclass
+class RepoOutcome:
+    repo: str
+    status: str
+    detail: str
+    base_sha: str = ""
+    head_sha: str = ""
+    pr_url: str = ""
+    synced_secrets: tuple[str, ...] = ()
+
+
+class CommandError(RuntimeError):
+    pass
+
+
+def run(
+    args: list[str], *, cwd: Path | None = None, input_text: str | None = None
+) -> str:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={key: value for key, value in os.environ.items() if key != "GITHUB_TOKEN"},
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise CommandError(f"{' '.join(args)}: {detail}")
+    return result.stdout.strip()
+
+
+def gh_json(args: list[str]) -> object:
+    output = run(["gh", *args])
+    return json.loads(output or "null")
+
+
+def default_branch(owner: str, repo: str) -> str:
+    data = gh_json(["repo", "view", f"{owner}/{repo}", "--json", "defaultBranchRef"])
+    return data["defaultBranchRef"]["name"]  # type: ignore[index]
+
+
+def remote_names(owner: str, repo: str, kind: str) -> set[str]:
+    data = gh_json([kind, "list", "-R", f"{owner}/{repo}", "--json", "name"])
+    return {item["name"] for item in data}  # type: ignore[union-attr]
+
+
+def secret_source(name: str) -> str | None:
+    value = os.environ.get(name)
+    if value:
+        return value
+    if name != "CLAUDE_CODE_OAUTH_TOKEN":
+        return None
+    credentials = Path.home() / ".claude/.credentials.json"
+    if not credentials.is_file():
+        return None
+    try:
+        data = json.loads(credentials.read_text(encoding="utf-8"))
+        value = data["claudeAiOauth"]["accessToken"]
+    except (KeyError, TypeError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, str) and value else None
+
+
+def clone_or_reset(workspace: Path, owner: str, repo: str, branch: str) -> tuple[Path, str]:
+    path = workspace / repo
+    if not (path / ".git").is_dir():
+        run(
+            [
+                "git",
+                "clone",
+                "--quiet",
+                "--filter=blob:none",
+                "--no-tags",
+                f"https://github.com/{owner}/{repo}.git",
+                str(path),
+            ]
+        )
+    run(["git", "fetch", "--no-tags", "origin", branch], cwd=path)
+    base = run(["git", "rev-parse", f"origin/{branch}"], cwd=path)
+    run(["git", "checkout", "-q", "-B", BRANCH, f"origin/{branch}"], cwd=path)
+    run(["git", "reset", "--hard", "-q", f"origin/{branch}"], cwd=path)
+    run(["git", "clean", "-fdq"], cwd=path)
+    return path, base
+
+
+def preview_copy(repo: Path) -> tempfile.TemporaryDirectory[str]:
+    temp = tempfile.TemporaryDirectory()
+    target = Path(temp.name)
+    github = repo / ".github"
+    if github.is_dir():
+        shutil.copytree(github, target / ".github")
+    return temp
+
+
+def sync_missing(
+    owner: str, repo: str, missing: set[str], enabled: bool
+) -> tuple[set[str], tuple[str, ...]]:
+    available = remote_names(owner, repo, "secret")
+    synced: list[str] = []
+    for name in sorted(missing - available):
+        value = secret_source(name) if enabled else None
+        if value is None:
+            continue
+        run(
+            ["gh", "secret", "set", name, "-R", f"{owner}/{repo}", "--body", "-"],
+            input_text=value,
+        )
+        available.add(name)
+        synced.append(name)
+    return available, tuple(synced)
+
+
+def prepare_with_prerequisites(
+    repo_path: Path,
+    automation: Path,
+    ref: str,
+    owner: str,
+    repo: str,
+    sync_missing_enabled: bool,
+) -> tuple[object, tuple[str, ...]]:
+    secrets = remote_names(owner, repo, "secret")
+    variables = remote_names(owner, repo, "variable")
+    synced: tuple[str, ...] = ()
+    try:
+        return prepare_repository(repo_path, automation, ref, secrets, variables), synced
+    except RolloutError as first:
+        text = str(first)
+        candidates: set[str] = set()
+        if "missing required secrets:" in text:
+            candidates.update(text.split("missing required secrets:", 1)[1].split(", "))
+        if "APP_ID exists but APP_PRIVATE_KEY is missing" in text:
+            candidates.add("APP_PRIVATE_KEY")
+        if "no usable Gemini authentication path" in text:
+            candidates.update({"GEMINI_API_KEY"})
+        if not candidates:
+            raise
+        secrets, synced = sync_missing(
+            owner, repo, candidates, enabled=sync_missing_enabled
+        )
+        return prepare_repository(repo_path, automation, ref, secrets, variables), synced
+
+
+def validate_repository(
+    repo: Path,
+    automation: Path,
+    actionlint: Path | None,
+    baseline_repo: Path | None = None,
+) -> None:
+    issues = audit_repository(repo, automation)
+    if issues:
+        raise CommandError("; ".join(issues))
+    if baseline_repo is None:
+        run(["git", "diff", "--check"], cwd=repo)
+    if actionlint is not None:
+        workflows = sorted((repo / ".github/workflows").glob("*.y*ml"))
+        if workflows:
+            current = actionlint_diagnostics(actionlint, repo)
+            if baseline_repo is not None:
+                baseline = actionlint_diagnostics(actionlint, baseline_repo)
+            else:
+                with tempfile.TemporaryDirectory() as temp:
+                    archive = subprocess.run(
+                        ["git", "archive", "HEAD", ".github/workflows"],
+                        cwd=repo,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                    )
+                    if archive.returncode != 0:
+                        raise CommandError("unable to archive baseline workflows for actionlint")
+                    extract = subprocess.run(
+                        ["tar", "-x", "-C", temp],
+                        input=archive.stdout,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                    )
+                    if extract.returncode != 0:
+                        raise CommandError("unable to extract baseline workflows for actionlint")
+                    baseline = actionlint_diagnostics(actionlint, Path(temp))
+            new_diagnostics = current - baseline
+            if new_diagnostics:
+                detail = "; ".join(
+                    f"{message} ({count})" for message, count in new_diagnostics.items()
+                )
+                raise CommandError(f"new actionlint diagnostics: {detail}")
+
+
+def actionlint_diagnostics(actionlint: Path, root: Path) -> Counter[str]:
+    workflows = sorted((root / ".github/workflows").glob("*.y*ml"))
+    if not workflows:
+        return Counter()
+    result = subprocess.run(
+        [str(actionlint), "-shellcheck=", *map(str, workflows)],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    diagnostics: Counter[str] = Counter()
+    for line in result.stdout.splitlines():
+        if ".yml:" not in line and ".yaml:" not in line:
+            continue
+        normalized = line.replace(str(root) + "/", "")
+        normalized = re.sub(r":\d+:\d+:", ":", normalized, count=1)
+        diagnostics[normalized] += 1
+    return diagnostics
+
+
+def publish_repository(
+    repo: Path, owner: str, name: str, default: str, ref: str
+) -> tuple[str, str]:
+    run(["git", "add", ".github"], cwd=repo)
+    run(
+        ["git", "commit", "-m", f"ci: restrict shared workflow secrets ({ref})"],
+        cwd=repo,
+    )
+    head = run(["git", "rev-parse", "HEAD"], cwd=repo)
+    run(["git", "push", "--force-with-lease", "-u", "origin", BRANCH], cwd=repo)
+    existing = gh_json(
+        [
+            "pr",
+            "list",
+            "-R",
+            f"{owner}/{name}",
+            "--head",
+            BRANCH,
+            "--base",
+            default,
+            "--state",
+            "open",
+            "--json",
+            "url",
+        ]
+    )
+    if existing:
+        return head, existing[0]["url"]  # type: ignore[index]
+    body = (
+        f"Update existing reusable-workflow callers to verified automation@{ref} and "
+        "replace `secrets: inherit` with contract-derived explicit mappings. "
+        "Repository-owned triggers, guards and permissions are preserved.\n\n"
+        "Pre-push gates: required secret-name inventory, YAML parse, caller contract audit, "
+        "`git diff --check`, and actionlint when configured.\n\n"
+        "Rollback: restore the previous automation ref and `secrets: inherit` together; "
+        "do not move the release tag."
+    )
+    url = run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "-R",
+            f"{owner}/{name}",
+            "--base",
+            default,
+            "--head",
+            BRANCH,
+            "--title",
+            f"ci: restrict shared workflow secrets ({ref})",
+            "--body",
+            body,
+        ]
+    )
+    return head, url
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--automation", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--config", type=Path)
+    parser.add_argument("--workspace", type=Path, required=True)
+    parser.add_argument("--ref", default="v1.35")
+    parser.add_argument("--mode", choices=("plan", "prepare", "publish"), default="plan")
+    parser.add_argument("--repo", action="append", default=[])
+    parser.add_argument("--sync-missing-secrets", action="store_true")
+    parser.add_argument("--actionlint", type=Path)
+    parser.add_argument("--confirm", action="store_true")
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument(
+        "--initialize-workspace",
+        action="store_true",
+        help="create the safety marker required before managed clones may be reset/cleaned",
+    )
+    args = parser.parse_args(argv)
+
+    automation = args.automation.resolve()
+    config_path = args.config or automation / "scripts/workflow-config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    owner = config["gh_owner"]
+    configured = sorted(config["repos"])
+    repos = args.repo or configured
+    unknown = sorted(set(repos) - set(configured))
+    if unknown:
+        parser.error(f"repositories not in config: {', '.join(unknown)}")
+    if args.mode == "publish" and not args.confirm:
+        parser.error("--mode publish requires --confirm")
+
+    marker = args.workspace / ".automation-fleet-workspace"
+    if not marker.is_file():
+        if not args.initialize_workspace:
+            parser.error(
+                f"workspace is not initialized: {args.workspace}; "
+                "use --initialize-workspace only for a dedicated disposable directory"
+            )
+        args.workspace.mkdir(parents=True, exist_ok=True)
+        marker.write_text("managed disposable clones only\n", encoding="utf-8")
+    outcomes: list[RepoOutcome] = []
+    for name in repos:
+        try:
+            default = default_branch(owner, name)
+            repo, base = clone_or_reset(args.workspace, owner, name, default)
+            target = repo
+            preview = None
+            if args.mode == "plan":
+                preview = preview_copy(repo)
+                target = Path(preview.name)
+            result, synced = prepare_with_prerequisites(
+                target,
+                automation,
+                args.ref,
+                owner,
+                name,
+                args.sync_missing_secrets and args.mode != "plan",
+            )
+            if result.callers == 0:
+                outcomes.append(RepoOutcome(name, "skipped", "no existing central callers", base))
+            elif not result.changed_files:
+                outcomes.append(RepoOutcome(name, "current", "already matches contract", base))
+            else:
+                validate_repository(
+                    target,
+                    automation,
+                    args.actionlint,
+                    baseline_repo=repo if args.mode == "plan" else None,
+                )
+                if args.mode == "publish":
+                    head, url = publish_repository(repo, owner, name, default, args.ref)
+                    outcomes.append(
+                        RepoOutcome(name, "published", f"{result.callers} callers", base, head, url, synced)
+                    )
+                else:
+                    outcomes.append(
+                        RepoOutcome(name, args.mode, f"{result.callers} callers", base, synced_secrets=synced)
+                    )
+            if preview is not None:
+                preview.cleanup()
+        except (CommandError, RolloutError, OSError, json.JSONDecodeError) as exc:
+            outcomes.append(RepoOutcome(name, "blocked", str(exc)))
+
+    manifest = args.manifest or args.workspace / "rollout-manifest.json"
+    manifest.write_text(
+        json.dumps([asdict(item) for item in outcomes], ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    for item in outcomes:
+        suffix = f" {item.pr_url}" if item.pr_url else ""
+        print(f"{item.status.upper():9} {item.repo}: {item.detail}{suffix}")
+    blocked = sum(item.status == "blocked" for item in outcomes)
+    print(f"SUMMARY total={len(outcomes)} blocked={blocked} manifest={manifest}")
+    return 1 if blocked else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_prepare_workflow_rollout.py
+++ b/tests/test_prepare_workflow_rollout.py
@@ -163,6 +163,27 @@ class PrepareWorkflowRolloutTest(unittest.TestCase):
             prepare_repository(self.repo, self.automation, "v1.35", set(), set())
         self.assertEqual(before, p.read_text())
 
+    def test_structural_caller_that_cannot_be_rewritten_fails_before_writing(self) -> None:
+        p = self.write("folded-caller.yml", """\
+            jobs:
+              call:
+                uses: >-
+                  jhw7500/automation/.github/workflows/claude.yml@v1.33
+                secrets: inherit
+        """)
+        before = p.read_text()
+        with self.assertRaisesRegex(
+            RolloutError, "found 1 YAML caller.*safely rewrite only 0"
+        ):
+            prepare_repository(
+                self.repo,
+                self.automation,
+                "v1.35",
+                {"CLAUDE_CODE_OAUTH_TOKEN"},
+                set(),
+            )
+        self.assertEqual(before, p.read_text())
+
     def test_secretless_workflow_removes_inherit(self) -> None:
         p = self.write("notice.yml", """\
             jobs:

--- a/tests/test_prepare_workflow_rollout.py
+++ b/tests/test_prepare_workflow_rollout.py
@@ -86,6 +86,22 @@ class PrepareWorkflowRolloutTest(unittest.TestCase):
         self.assertNotIn("secrets: inherit", text)
         self.assertEqual(1, result.callers)
 
+    def test_preserves_inline_comment_on_uses_line(self) -> None:
+        p = self.write("caller.yml", """\
+            jobs:
+              call:
+                uses: 'jhw7500/automation/.github/workflows/claude.yml@v1.33' # pinned
+                secrets: inherit
+        """)
+        prepare_repository(
+            self.repo,
+            self.automation,
+            "v1.35",
+            {"CLAUDE_CODE_OAUTH_TOKEN"},
+            set(),
+        )
+        self.assertIn("claude.yml@v1.35' # pinned", p.read_text())
+
     def test_app_id_and_private_key_are_mapped_only_when_app_id_variable_exists(self) -> None:
         p = self.write("gemini.yml", """\
             jobs:
@@ -176,6 +192,28 @@ class PrepareWorkflowRolloutTest(unittest.TestCase):
         config = (self.repo / ".github/workflow-config.yml").read_text()
         self.assertIn("automation_ref: v1.35", config)
         self.assertIn("custom:\n    enabled: true", config)
+
+    def test_updates_commented_config_ref_without_duplicate_key(self) -> None:
+        config_path = self.repo / ".github/workflow-config.yml"
+        config_path.write_text(
+            "automation_ref: v1.33  # pinned by fleet\nworkflows:\n  custom:\n    enabled: true\n"
+        )
+        self.write("caller.yml", """\
+            jobs:
+              call:
+                uses: jhw7500/automation/.github/workflows/claude.yml@v1.33
+                secrets: inherit
+        """)
+        prepare_repository(
+            self.repo,
+            self.automation,
+            "v1.35",
+            {"CLAUDE_CODE_OAUTH_TOKEN"},
+            set(),
+        )
+        config = config_path.read_text()
+        self.assertEqual(1, config.count("automation_ref:"))
+        self.assertIn("automation_ref: v1.35  # pinned by fleet", config)
 
 
 if __name__ == "__main__":

--- a/tests/test_prepare_workflow_rollout.py
+++ b/tests/test_prepare_workflow_rollout.py
@@ -184,6 +184,42 @@ class PrepareWorkflowRolloutTest(unittest.TestCase):
             )
         self.assertEqual(before, p.read_text())
 
+    def test_secrets_before_uses_fails_before_writing(self) -> None:
+        p = self.write("ordered-caller.yml", """\
+            jobs:
+              call:
+                secrets: inherit
+                uses: jhw7500/automation/.github/workflows/claude.yml@v1.33
+        """)
+        before = p.read_text()
+        with self.assertRaisesRegex(RolloutError, "secrets/with must follow uses"):
+            prepare_repository(
+                self.repo,
+                self.automation,
+                "v1.35",
+                {"CLAUDE_CODE_OAUTH_TOKEN"},
+                set(),
+            )
+        self.assertEqual(before, p.read_text())
+
+    def test_noncanonical_job_indentation_fails_before_writing(self) -> None:
+        p = self.write("indented-caller.yml", """\
+            jobs:
+                call:
+                    uses: jhw7500/automation/.github/workflows/claude.yml@v1.33
+                    secrets: inherit
+        """)
+        before = p.read_text()
+        with self.assertRaisesRegex(RolloutError, "indented exactly two spaces"):
+            prepare_repository(
+                self.repo,
+                self.automation,
+                "v1.35",
+                {"CLAUDE_CODE_OAUTH_TOKEN"},
+                set(),
+            )
+        self.assertEqual(before, p.read_text())
+
     def test_secretless_workflow_removes_inherit(self) -> None:
         p = self.write("notice.yml", """\
             jobs:

--- a/tests/test_prepare_workflow_rollout.py
+++ b/tests/test_prepare_workflow_rollout.py
@@ -106,6 +106,25 @@ class PrepareWorkflowRolloutTest(unittest.TestCase):
         self.assertIn("GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}", text)
         self.assertNotIn("GOOGLE_API_KEY:", text)
 
+    def test_app_id_without_private_key_uses_available_api_key_path(self) -> None:
+        p = self.write("gemini.yml", """\
+            jobs:
+              call:
+                uses: jhw7500/automation/.github/workflows/gemini.yml@v1.32
+                secrets: inherit
+        """)
+        prepare_repository(
+            self.repo,
+            self.automation,
+            "v1.35",
+            {"GEMINI_API_KEY"},
+            {"APP_ID"},
+        )
+        text = p.read_text()
+        self.assertNotIn("app_id:", text)
+        self.assertNotIn("APP_PRIVATE_KEY:", text)
+        self.assertIn("GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}", text)
+
     def test_optional_auth_requires_at_least_one_usable_gemini_path(self) -> None:
         self.write("gemini.yml", """\
             jobs:

--- a/tests/test_prepare_workflow_rollout.py
+++ b/tests/test_prepare_workflow_rollout.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+import tempfile
+import textwrap
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scripts.prepare_workflow_rollout import RolloutError, prepare_repository
+
+
+class PrepareWorkflowRolloutTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.automation = self.root / "automation"
+        wf = self.automation / ".github/workflows"
+        wf.mkdir(parents=True)
+        (wf / "claude.yml").write_text(textwrap.dedent("""\
+            on:
+              workflow_call:
+                secrets:
+                  CLAUDE_CODE_OAUTH_TOKEN:
+                    required: true
+            jobs: {}
+        """))
+        (wf / "gemini.yml").write_text(textwrap.dedent("""\
+            on:
+              workflow_call:
+                inputs:
+                  app_id:
+                    type: string
+                    required: false
+                secrets:
+                  APP_PRIVATE_KEY:
+                    required: false
+                  GEMINI_API_KEY:
+                    required: false
+                  GOOGLE_API_KEY:
+                    required: false
+            jobs: {}
+        """))
+        (wf / "notice.yml").write_text(textwrap.dedent("""\
+            on:
+              workflow_call:
+            jobs: {}
+        """))
+        self.repo = self.root / "consumer"
+        (self.repo / ".github/workflows").mkdir(parents=True)
+        (self.repo / ".github/workflow-config.yml").write_text(
+            "automation_ref: v1.33\nworkflows:\n  custom:\n    enabled: true\n"
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def write(self, name: str, body: str) -> Path:
+        p = self.repo / ".github/workflows" / name
+        p.write_text(textwrap.dedent(body))
+        return p
+
+    def test_preserves_trigger_permissions_and_maps_only_available_secrets(self) -> None:
+        p = self.write("caller.yml", """\
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              call:
+                if: github.actor != 'bot'
+                permissions:
+                  contents: read
+                uses: jhw7500/automation/.github/workflows/claude.yml@v1.33
+                secrets: inherit
+        """)
+        result = prepare_repository(
+            self.repo, self.automation, "v1.35", {"CLAUDE_CODE_OAUTH_TOKEN"}, set()
+        )
+        text = p.read_text()
+        self.assertIn("types: [opened]", text)
+        self.assertIn("if: github.actor != 'bot'", text)
+        self.assertIn("contents: read", text)
+        self.assertIn("claude.yml@v1.35", text)
+        self.assertIn("CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}", text)
+        self.assertNotIn("secrets: inherit", text)
+        self.assertEqual(1, result.callers)
+
+    def test_app_id_and_private_key_are_mapped_only_when_app_id_variable_exists(self) -> None:
+        p = self.write("gemini.yml", """\
+            jobs:
+              call:
+                uses: jhw7500/automation/.github/workflows/gemini.yml@v1.32
+                secrets: inherit
+        """)
+        prepare_repository(
+            self.repo,
+            self.automation,
+            "v1.35",
+            {"GEMINI_API_KEY", "APP_PRIVATE_KEY"},
+            {"APP_ID"},
+        )
+        text = p.read_text()
+        self.assertIn("with:\n      app_id: ${{ vars.APP_ID }}", text)
+        self.assertIn("APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}", text)
+        self.assertIn("GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}", text)
+        self.assertNotIn("GOOGLE_API_KEY:", text)
+
+    def test_optional_auth_requires_at_least_one_usable_gemini_path(self) -> None:
+        self.write("gemini.yml", """\
+            jobs:
+              call:
+                uses: jhw7500/automation/.github/workflows/gemini.yml@v1.33
+                secrets: inherit
+        """)
+        with self.assertRaisesRegex(RolloutError, "no usable Gemini authentication"):
+            prepare_repository(self.repo, self.automation, "v1.35", set(), set())
+
+    def test_missing_required_secret_fails_before_writing(self) -> None:
+        p = self.write("caller.yml", """\
+            jobs:
+              call:
+                uses: jhw7500/automation/.github/workflows/claude.yml@v1.33
+                secrets: inherit
+        """)
+        before = p.read_text()
+        with self.assertRaisesRegex(RolloutError, "missing required secrets"):
+            prepare_repository(self.repo, self.automation, "v1.35", set(), set())
+        self.assertEqual(before, p.read_text())
+
+    def test_secretless_workflow_removes_inherit(self) -> None:
+        p = self.write("notice.yml", """\
+            jobs:
+              call:
+                uses: jhw7500/automation/.github/workflows/notice.yml@v1.31
+                secrets: inherit
+        """)
+        prepare_repository(self.repo, self.automation, "v1.35", set(), set())
+        self.assertNotIn("secrets:", p.read_text())
+
+    def test_no_callers_is_a_noop_and_does_not_change_config(self) -> None:
+        before = (self.repo / ".github/workflow-config.yml").read_text()
+        result = prepare_repository(self.repo, self.automation, "v1.35", set(), set())
+        self.assertEqual(0, result.callers)
+        self.assertEqual(before, (self.repo / ".github/workflow-config.yml").read_text())
+
+    def test_updates_config_without_overwriting_repository_settings(self) -> None:
+        self.write("caller.yml", """\
+            jobs:
+              call:
+                uses: jhw7500/automation/.github/workflows/claude.yml@v1.33
+                secrets: inherit
+        """)
+        prepare_repository(
+            self.repo, self.automation, "v1.35", {"CLAUDE_CODE_OAUTH_TOKEN"}, set()
+        )
+        config = (self.repo / ".github/workflow-config.yml").read_text()
+        self.assertIn("automation_ref: v1.35", config)
+        self.assertIn("custom:\n    enabled: true", config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -16,11 +16,13 @@ from scripts.rollout_workflow_fleet import (
     default_branch,
     main,
     materialize_release_contract,
+    prepare_with_prerequisites,
     publish_repository,
     rollout_branch,
     secret_source,
     sync_missing,
 )
+from scripts.prepare_workflow_rollout import SecretPrerequisiteError
 
 
 SECURE_WORKFLOW = """\
@@ -103,6 +105,37 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
         self.assertEqual(("TOKEN",), synced)
         self.assertEqual("sensitive-value", calls[0][1])
         self.assertNotIn("sensitive-value", calls[0][0])
+
+    def test_multiple_missing_secrets_are_synced_until_prepare_succeeds(self) -> None:
+        first = SecretPrerequisiteError("missing first", {"FIRST_TOKEN"})
+        second = SecretPrerequisiteError("missing second", {"SECOND_TOKEN"})
+        prepared = object()
+        with patch(
+            "scripts.rollout_workflow_fleet.remote_names",
+            side_effect=[set(), set()],
+        ), patch(
+            "scripts.rollout_workflow_fleet.prepare_repository",
+            side_effect=[first, second, prepared],
+        ), patch(
+            "scripts.rollout_workflow_fleet.sync_missing",
+            side_effect=[
+                ({"FIRST_TOKEN"}, ("FIRST_TOKEN",)),
+                ({"FIRST_TOKEN", "SECOND_TOKEN"}, ("SECOND_TOKEN",)),
+            ],
+        ) as sync:
+            result, synced = prepare_with_prerequisites(
+                Path("/tmp/repo"),
+                Path("/tmp/automation"),
+                "v1.35",
+                "owner",
+                "repo",
+                True,
+                False,
+                {"FIRST_TOKEN", "SECOND_TOKEN"},
+            )
+        self.assertIs(prepared, result)
+        self.assertEqual(("FIRST_TOKEN", "SECOND_TOKEN"), synced)
+        self.assertEqual(2, sync.call_count)
 
     def test_release_contract_is_read_from_verified_tag_not_newer_head(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scripts.rollout_workflow_fleet import (
+    materialize_release_contract,
+    publish_repository,
+    rollout_branch,
+    secret_source,
+    sync_missing,
+)
+
+
+SECURE_WORKFLOW = """\
+on:
+  workflow_call:
+jobs:
+  opencode-review:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Run OpenCode PR review
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          use_github_token: true
+"""
+
+
+class RolloutWorkflowFleetTest(unittest.TestCase):
+    def test_branch_is_derived_from_release_ref(self) -> None:
+        self.assertEqual("codex/automation-v1.35-fleet", rollout_branch("v1.35"))
+        self.assertEqual("codex/automation-v1.36-fleet", rollout_branch("v1.36"))
+        self.assertNotEqual(rollout_branch("v1.35"), rollout_branch("v1.36"))
+
+    def test_personal_oauth_source_requires_explicit_fanout_consent(self) -> None:
+        with patch.dict(os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "test-token"}):
+            self.assertIsNone(secret_source("CLAUDE_CODE_OAUTH_TOKEN", False))
+            self.assertEqual(
+                "test-token", secret_source("CLAUDE_CODE_OAUTH_TOKEN", True)
+            )
+
+    def test_sync_missing_passes_secret_via_stdin_and_never_argv(self) -> None:
+        calls: list[tuple[list[str], str | None]] = []
+
+        def fake_run(args: list[str], **kwargs: object) -> str:
+            calls.append((args, kwargs.get("input_text")))  # type: ignore[arg-type]
+            return ""
+
+        with patch("scripts.rollout_workflow_fleet.remote_names", return_value=set()), patch(
+            "scripts.rollout_workflow_fleet.secret_source", return_value="sensitive-value"
+        ), patch("scripts.rollout_workflow_fleet.run", side_effect=fake_run):
+            available, synced = sync_missing(
+                "owner", "repo", {"TOKEN"}, True, False
+            )
+        self.assertEqual({"TOKEN"}, available)
+        self.assertEqual(("TOKEN",), synced)
+        self.assertEqual("sensitive-value", calls[0][1])
+        self.assertNotIn("sensitive-value", calls[0][0])
+
+    def test_release_contract_is_read_from_verified_tag_not_newer_head(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            repo = Path(temp) / "repo"
+            remote = Path(temp) / "remote.git"
+            workflow = repo / ".github/workflows/opencode-auto-review.yml"
+            workflow.parent.mkdir(parents=True)
+            workflow.write_text(SECURE_WORKFLOW)
+            self.git(repo, "init", "-q")
+            self.git(repo, "config", "user.name", "Test")
+            self.git(repo, "config", "user.email", "test@example.com")
+            self.git(repo, "add", ".")
+            self.git(repo, "commit", "-qm", "v1.35 contract")
+            tagged = self.git(repo, "rev-parse", "HEAD").strip()
+            self.git(repo, "tag", "-a", "v1.35", "-m", "v1.35")
+            subprocess.run(["git", "init", "--bare", "-q", str(remote)], check=True)
+            self.git(repo, "remote", "add", "origin", str(remote))
+            self.git(repo, "push", "-q", "origin", "v1.35")
+
+            workflow.write_text(SECURE_WORKFLOW + "# newer untagged contract\n")
+            self.git(repo, "add", ".")
+            self.git(repo, "commit", "-qm", "newer head")
+
+            extracted_temp, extracted, commit = materialize_release_contract(repo, "v1.35")
+            try:
+                text = (
+                    extracted / ".github/workflows/opencode-auto-review.yml"
+                ).read_text()
+                self.assertEqual(tagged, commit)
+                self.assertNotIn("newer untagged", text)
+            finally:
+                extracted_temp.cleanup()
+
+    def test_publish_uses_release_specific_branch_for_push_and_pr(self) -> None:
+        calls: list[list[str]] = []
+        outputs = iter(["", "", "head-sha", "", "https://example.test/pr/1"])
+
+        def fake_run(args: list[str], **_: object) -> str:
+            calls.append(args)
+            return next(outputs)
+
+        with patch("scripts.rollout_workflow_fleet.run", side_effect=fake_run), patch(
+            "scripts.rollout_workflow_fleet.gh_json", return_value=[]
+        ):
+            head, url = publish_repository(
+                Path("/tmp/repo"),
+                "owner",
+                "repo",
+                "main",
+                "v1.36",
+                "codex/automation-v1.36-fleet",
+            )
+        self.assertEqual("head-sha", head)
+        self.assertEqual("https://example.test/pr/1", url)
+        flattened = [item for command in calls for item in command]
+        self.assertIn("codex/automation-v1.36-fleet", flattened)
+        self.assertNotIn("codex/automation-v1.35-fleet", flattened)
+
+    @staticmethod
+    def git(repo: Path, *args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from pathlib import Path
+import json
 import os
 import subprocess
 import sys
@@ -7,6 +8,7 @@ import tempfile
 import textwrap
 import unittest
 from unittest.mock import patch
+from unittest.mock import Mock
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -23,6 +25,7 @@ from scripts.rollout_workflow_fleet import (
     sync_missing,
 )
 from scripts.prepare_workflow_rollout import SecretPrerequisiteError
+from scripts.prepare_workflow_rollout import RolloutResult
 
 
 SECURE_WORKFLOW = """\
@@ -186,7 +189,16 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
 
     def test_publish_uses_release_specific_branch_for_push_and_pr(self) -> None:
         calls: list[list[str]] = []
-        outputs = iter(["", "", "head-sha", "", "https://example.test/pr/1"])
+        outputs = iter(
+            [
+                "",
+                "",
+                "head-sha",
+                "remote-sha\trefs/heads/codex/automation-v1.36-fleet",
+                "",
+                "https://example.test/pr/1",
+            ]
+        )
 
         def fake_run(args: list[str], **_: object) -> str:
             calls.append(args)
@@ -208,6 +220,71 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
         flattened = [item for command in calls for item in command]
         self.assertIn("codex/automation-v1.36-fleet", flattened)
         self.assertNotIn("codex/automation-v1.35-fleet", flattened)
+        self.assertIn(
+            "--force-with-lease=refs/heads/codex/automation-v1.36-fleet:remote-sha",
+            flattened,
+        )
+
+    def test_main_publishes_one_repo_contains_next_failure_and_writes_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            (workspace / ".automation-fleet-workspace").write_text("managed\n")
+            config = root / "config.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "gh_owner": "owner",
+                        "repos": {
+                            "a-ready": {"workflows": True, "secrets": True},
+                            "b-broken": {"workflows": True, "secrets": True},
+                        },
+                    }
+                )
+            )
+            release_temp = Mock()
+            prepared = RolloutResult(
+                callers=1,
+                changed_files=(Path(".github/workflows/caller.yml"),),
+                required_secrets=frozenset({"TOKEN"}),
+            )
+            with patch(
+                "scripts.rollout_workflow_fleet.materialize_release_contract",
+                return_value=(release_temp, Path("/contract"), "release-sha"),
+            ), patch(
+                "scripts.rollout_workflow_fleet.default_branch",
+                side_effect=["main", CommandError("default branch unavailable")],
+            ), patch(
+                "scripts.rollout_workflow_fleet.clone_or_reset",
+                return_value=(Path("/clone/a-ready"), "base-sha"),
+            ), patch(
+                "scripts.rollout_workflow_fleet.prepare_with_prerequisites",
+                return_value=(prepared, ()),
+            ), patch(
+                "scripts.rollout_workflow_fleet.validate_repository"
+            ), patch(
+                "scripts.rollout_workflow_fleet.publish_repository",
+                return_value=("head-sha", "https://example.test/pr/1"),
+            ):
+                rc = main(
+                    [
+                        "--automation",
+                        str(ROOT),
+                        "--config",
+                        str(config),
+                        "--workspace",
+                        str(workspace),
+                        "--mode",
+                        "publish",
+                        "--confirm",
+                    ]
+                )
+            self.assertEqual(1, rc)
+            manifest = json.loads((workspace / "rollout-manifest.json").read_text())
+            self.assertEqual(["published", "blocked"], [item["status"] for item in manifest])
+            self.assertEqual("https://example.test/pr/1", manifest[0]["pr_url"])
+            release_temp.cleanup.assert_called_once()
 
     @staticmethod
     def git(repo: Path, *args: str) -> str:

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -12,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from scripts.rollout_workflow_fleet import (
+    main,
     materialize_release_contract,
     publish_repository,
     rollout_branch,
@@ -43,6 +44,22 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
         self.assertEqual("codex/automation-v1.35-fleet", rollout_branch("v1.35"))
         self.assertEqual("codex/automation-v1.36-fleet", rollout_branch("v1.36"))
         self.assertNotEqual(rollout_branch("v1.35"), rollout_branch("v1.36"))
+
+    def test_prepare_mode_rejects_any_secret_sync_request_before_side_effects(self) -> None:
+        with tempfile.TemporaryDirectory() as temp, patch(
+            "scripts.rollout_workflow_fleet.materialize_release_contract"
+        ) as materialize:
+            with self.assertRaises(SystemExit):
+                main(
+                    [
+                        "--workspace",
+                        temp,
+                        "--mode",
+                        "prepare",
+                        "--sync-missing-secrets",
+                    ]
+                )
+            materialize.assert_not_called()
 
     def test_personal_oauth_source_requires_explicit_fanout_consent(self) -> None:
         with patch.dict(os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "test-token"}):
@@ -100,6 +117,21 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
                 self.assertNotIn("newer untagged", text)
             finally:
                 extracted_temp.cleanup()
+
+    def test_release_contract_rejects_non_version_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            repo = Path(temp) / "repo"
+            workflow = repo / ".github/workflows/opencode-auto-review.yml"
+            workflow.parent.mkdir(parents=True)
+            workflow.write_text(SECURE_WORKFLOW)
+            self.git(repo, "init", "-q")
+            self.git(repo, "config", "user.name", "Test")
+            self.git(repo, "config", "user.email", "test@example.com")
+            self.git(repo, "add", ".")
+            self.git(repo, "commit", "-qm", "contract")
+            self.git(repo, "tag", "release-candidate")
+            with self.assertRaisesRegex(RuntimeError, "invalid release ref"):
+                materialize_release_contract(repo, "release-candidate")
 
     def test_publish_uses_release_specific_branch_for_push_and_pr(self) -> None:
         calls: list[list[str]] = []

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -12,6 +12,8 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from scripts.rollout_workflow_fleet import (
+    CommandError,
+    default_branch,
     main,
     materialize_release_contract,
     publish_repository,
@@ -68,6 +70,22 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
                 "test-token", secret_source("CLAUDE_CODE_OAUTH_TOKEN", True)
             )
 
+    def test_ambient_environment_secret_requires_name_allowlist(self) -> None:
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "personal-key"}):
+            self.assertIsNone(secret_source("GEMINI_API_KEY", False, set()))
+            self.assertEqual(
+                "personal-key",
+                secret_source("GEMINI_API_KEY", False, {"GEMINI_API_KEY"}),
+            )
+
+    def test_missing_default_branch_becomes_a_command_error(self) -> None:
+        with patch(
+            "scripts.rollout_workflow_fleet.gh_json",
+            return_value={"defaultBranchRef": None},
+        ):
+            with self.assertRaisesRegex(CommandError, "default branch is unavailable"):
+                default_branch("owner", "empty-repo")
+
     def test_sync_missing_passes_secret_via_stdin_and_never_argv(self) -> None:
         calls: list[tuple[list[str], str | None]] = []
 
@@ -79,7 +97,7 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
             "scripts.rollout_workflow_fleet.secret_source", return_value="sensitive-value"
         ), patch("scripts.rollout_workflow_fleet.run", side_effect=fake_run):
             available, synced = sync_missing(
-                "owner", "repo", {"TOKEN"}, True, False
+                "owner", "repo", {"TOKEN"}, True, False, {"TOKEN"}
             )
         self.assertEqual({"TOKEN"}, available)
         self.assertEqual(("TOKEN",), synced)

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -254,7 +254,7 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
                 return_value=(release_temp, Path("/contract"), "release-sha"),
             ), patch(
                 "scripts.rollout_workflow_fleet.default_branch",
-                side_effect=["main", CommandError("default branch unavailable")],
+                side_effect=["main", ValueError("unexpected metadata shape")],
             ), patch(
                 "scripts.rollout_workflow_fleet.clone_or_reset",
                 return_value=(Path("/clone/a-ready"), "base-sha"),
@@ -284,6 +284,7 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
             manifest = json.loads((workspace / "rollout-manifest.json").read_text())
             self.assertEqual(["published", "blocked"], [item["status"] for item in manifest])
             self.assertEqual("https://example.test/pr/1", manifest[0]["pr_url"])
+            self.assertIn("unexpected ValueError", manifest[1]["detail"])
             release_temp.cleanup.assert_called_once()
 
     @staticmethod


### PR DESCRIPTION
## Summary
- add a contract-driven transformer that updates only existing reusable-workflow callers
- preserve repository-specific triggers, guards, permissions and inputs
- inventory required secret/variable names before writes and fail closed when no safe source exists
- coordinate plan/prepare/publish modes with dedicated-workspace guard, independent PRs and JSON manifest
- compare actionlint diagnostics against each repository baseline so pre-existing findings do not block rollout

## One-command design
`rollout_workflow_fleet.py --mode publish --sync-missing-secrets --confirm` performs secret prerequisite checks/sync first, then prepares, validates, commits, pushes and opens independent PRs. GitHub cannot make secret writes and PR merges atomic; the tool documents and preserves that boundary. Claude token rotation remains owned by `personal-ops/claude-token-sync`.

## Validation
- `pytest -q`: 25 passed
- full 19-repository plan using remote default branches and secret/variable name inventory
- 15 repositories ready/current, 2 caller-free skips, 2 fail-closed due missing `ZHIPU_API_KEY`
- generated YAML, contract audit, diff check and actionlint-regression gates pass for all ready repositories
