### PR TITLE
fix(opencode): support private repository PR fetches

### DIFF
--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -22,9 +22,13 @@ jobs:
   check-enabled:
     name: Check if enabled
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
       auto_enabled: ${{ steps.auto_mode.outputs.auto_enabled }}
+      safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,13 +60,29 @@ jobs:
           fi
           echo "auto_enabled=${auto_enabled}" >> "$GITHUB_OUTPUT"
 
+      - name: Verify same-repository PR
+        id: pr_scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          echo "safe_pr=false" >> "$GITHUB_OUTPUT"
+          if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            exit 0
+          fi
+          metadata="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            --jq '[.head.repo.full_name, .head.repo.fork] | @tsv' 2>/dev/null)" || exit 0
+          IFS=$'\t' read -r head_repo head_fork <<< "$metadata"
+          if [[ "$head_repo" == "$GITHUB_REPOSITORY" && "$head_fork" == "false" ]]; then
+            echo "safe_pr=true" >> "$GITHUB_OUTPUT"
+          fi
+
   opencode-review:
     needs: check-enabled
     if: >-
       needs.check-enabled.outputs.enabled == 'true' &&
       needs.check-enabled.outputs.auto_enabled == 'true' &&
-      github.event.pull_request.head.repo.fork == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      needs.check-enabled.outputs.safe_pr == 'true'
     runs-on: ubuntu-latest
     permissions:
       # id-token 없음(의도) — 이게 있으면 액션이 OIDC 토큰을 발급받아
@@ -109,7 +129,10 @@ jobs:
   skipped:
     name: Workflow Skipped
     needs: check-enabled
-    if: needs.check-enabled.outputs.enabled != 'true' || needs.check-enabled.outputs.auto_enabled != 'true'
+    if: >-
+      needs.check-enabled.outputs.enabled != 'true' ||
+      needs.check-enabled.outputs.auto_enabled != 'true' ||
+      needs.check-enabled.outputs.safe_pr != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Notice

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -58,7 +58,11 @@ jobs:
 
   opencode-review:
     needs: check-enabled
-    if: needs.check-enabled.outputs.enabled == 'true' && needs.check-enabled.outputs.auto_enabled == 'true'
+    if: >-
+      needs.check-enabled.outputs.enabled == 'true' &&
+      needs.check-enabled.outputs.auto_enabled == 'true' &&
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       # id-token 없음(의도) — 이게 있으면 액션이 OIDC 토큰을 발급받아

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -74,7 +74,9 @@ jobs:
         with:
           fetch-depth: 1
           # OpenCode fetches the PR head branch after checkout. Private repositories
-          # require this read-only job token to remain available for that fetch.
+          # require authenticated fetch. This same token is intentionally passed to the
+          # action below; contents: read prevents code pushes, while PR/issues write is
+          # limited to review output. Consumer callers admit same-repository PRs only.
           persist-credentials: true
 
       # use_github_token: OIDC 교환(api.opencode.ai → opencode-agent App 토큰)을 건너뛰고

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -73,7 +73,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          persist-credentials: false
+          # OpenCode fetches the PR head branch after checkout. Private repositories
+          # require this read-only job token to remain available for that fetch.
+          persist-credentials: true
 
       # use_github_token: OIDC 교환(api.opencode.ai → opencode-agent App 토큰)을 건너뛰고
       # 이 잡의 GITHUB_TOKEN 을 쓴다. App 토큰은 App 설치 권한만 따르므로 위 permissions

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -137,6 +137,6 @@ jobs:
     steps:
       - name: Notice
         run: |
-          echo "::notice::OpenCode Auto PR Review is disabled by workflow-config.yml (or review.auto=false)"
+          echo "::notice::OpenCode Auto PR Review is disabled or the PR is not from this repository"
           echo "## Workflow Skipped" >> $GITHUB_STEP_SUMMARY
-          echo "opencode-auto-review is disabled (or review.auto=false)" >> $GITHUB_STEP_SUMMARY
+          echo "opencode-auto-review is disabled, auto review is off, or the PR is external" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -54,7 +54,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          # The action fetches PR branches itself; private repositories require the
+          # contents: read job token to remain available for that authenticated fetch.
+          persist-credentials: true
 
       - name: Run opencode
         uses: anomalyco/opencode/github@bbc7bdb3fd5078d0add23273e0fdae436b9b47e4 # v1.1.43

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -41,7 +41,7 @@ jobs:
         id: pr_scope
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           echo "safe_pr=false" >> "$GITHUB_OUTPUT"
           if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -18,8 +18,12 @@ jobs:
   check-enabled:
     name: Check if enabled
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
+      safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,10 +37,28 @@ jobs:
           workflow-name: opencode
           force-run: ${{ inputs.force_run && 'true' || 'false' }}
 
+      - name: Verify same-repository PR
+        id: pr_scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          echo "safe_pr=false" >> "$GITHUB_OUTPUT"
+          if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            exit 0
+          fi
+          metadata="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            --jq '[.head.repo.full_name, .head.repo.fork] | @tsv' 2>/dev/null)" || exit 0
+          IFS=$'\t' read -r head_repo head_fork <<< "$metadata"
+          if [[ "$head_repo" == "$GITHUB_REPOSITORY" && "$head_fork" == "false" ]]; then
+            echo "safe_pr=true" >> "$GITHUB_OUTPUT"
+          fi
+
   opencode:
     needs: check-enabled
     if: |
       needs.check-enabled.outputs.enabled == 'true' &&
+      needs.check-enabled.outputs.safe_pr == 'true' &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
       (
         contains(github.event.comment.body, ' /oc') ||
@@ -46,10 +68,9 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -62,13 +83,17 @@ jobs:
         uses: anomalyco/opencode/github@bbc7bdb3fd5078d0add23273e0fdae436b9b47e4 # v1.1.43
         env:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
+          use_github_token: true
           model: zai-coding-plan/glm-4.7
 
   skipped:
     name: Workflow Skipped
     needs: check-enabled
-    if: needs.check-enabled.outputs.enabled != 'true'
+    if: >-
+      needs.check-enabled.outputs.enabled != 'true' ||
+      needs.check-enabled.outputs.safe_pr != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Notice

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -98,6 +98,6 @@ jobs:
     steps:
       - name: Notice
         run: |
-          echo "::notice::opencode workflow is disabled in .github/workflow-config.yml"
+          echo "::notice::opencode is disabled or the PR is not from this repository"
           echo "## Workflow Skipped" >> $GITHUB_STEP_SUMMARY
-          echo "opencode is disabled in workflow-config.yml" >> $GITHUB_STEP_SUMMARY
+          echo "opencode is disabled or the PR is external" >> $GITHUB_STEP_SUMMARY

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -49,6 +49,19 @@ Required secrets depend on which workflows you enable.
   - Required for Gemini workflows (review/triage/invoke/dispatch).
 - `CLAUDE_CODE_OAUTH_TOKEN`
   - Required for Claude workflows.
+- `ZHIPU_API_KEY`
+  - Required for OpenCode workflows.
+
+### OpenCode PR boundary
+
+OpenCode automatic review and the manual `/oc` command run only for pull requests whose
+head branch belongs to the same repository. Fork/external PRs fail closed and produce a
+skipped workflow summary. This restriction lets private repositories retain the read-only
+checkout credential required by OpenCode's internal branch fetch without exposing it while
+processing external contributor content.
+
+Both OpenCode workflows force the job-scoped `github.token`; `id-token: write` is forbidden,
+so the action cannot exchange OIDC for an App token outside the declared job permissions.
 
 ## Variables (consumer repository)
 

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -62,6 +62,9 @@ processing external contributor content.
 
 Both OpenCode workflows force the job-scoped `github.token`; `id-token: write` is forbidden,
 so the action cannot exchange OIDC for an App token outside the declared job permissions.
+Consumer OpenCode jobs must grant exactly `contents: read`, `pull-requests: write`, and
+`issues: write`. The fleet rollout tool normalizes these two caller permission blocks; this
+is the intentional exception to its general rule of preserving repository-owned permissions.
 
 ## Variables (consumer repository)
 

--- a/examples/baseline-workflows/.github/workflow-config.yml
+++ b/examples/baseline-workflows/.github/workflow-config.yml
@@ -7,7 +7,7 @@
 #
 # NOTE: GitHub Actions does not allow dynamic refs in `uses: ...@ref`, so this value
 # is used by a repo automation workflow that opens a PR updating all `uses:` refs.
-automation_ref: v1.35
+automation_ref: v1.36
 
 # Global review behavior.
 # - manual triggers (e.g. @gemini-cli /review, @claude) should keep working regardless.

--- a/examples/baseline-workflows/.github/workflows/auto-rereview-request.yml
+++ b/examples/baseline-workflows/.github/workflows/auto-rereview-request.yml
@@ -20,4 +20,4 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    uses: jhw7500/automation/.github/workflows/auto-rereview-request.yml@v1.35
+    uses: jhw7500/automation/.github/workflows/auto-rereview-request.yml@v1.36

--- a/examples/baseline-workflows/.github/workflows/claude-code-review.yml
+++ b/examples/baseline-workflows/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
       issues: read
       id-token: write
-    uses: jhw7500/automation/.github/workflows/claude-code-review.yml@v1.35
+    uses: jhw7500/automation/.github/workflows/claude-code-review.yml@v1.36
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:

--- a/examples/baseline-workflows/.github/workflows/claude.yml
+++ b/examples/baseline-workflows/.github/workflows/claude.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   claude:
-    uses: jhw7500/automation/.github/workflows/claude.yml@v1.35
+    uses: jhw7500/automation/.github/workflows/claude.yml@v1.36
     permissions:
       contents: read
       pull-requests: read

--- a/examples/baseline-workflows/.github/workflows/gemini-auto-review.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-auto-review.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-    uses: jhw7500/automation/.github/workflows/gemini-auto-review.yml@v1.35
+    uses: jhw7500/automation/.github/workflows/gemini-auto-review.yml@v1.36
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:

--- a/examples/baseline-workflows/.github/workflows/gemini-chat.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-chat.yml
@@ -16,7 +16,7 @@ jobs:
       issues: write
       id-token: write
       actions: read
-    uses: jhw7500/automation/.github/workflows/gemini-chat.yml@v1.35
+    uses: jhw7500/automation/.github/workflows/gemini-chat.yml@v1.36
     with:
       app_id: ${{ vars.APP_ID }}
     secrets:

--- a/examples/baseline-workflows/.github/workflows/gemini-dispatch.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-dispatch.yml
@@ -21,7 +21,7 @@ defaults:
 
 jobs:
   dispatch:
-    uses: jhw7500/automation/.github/workflows/gemini-dispatch.yml@v1.35
+    uses: jhw7500/automation/.github/workflows/gemini-dispatch.yml@v1.36
     permissions:
       contents: read
       id-token: write

--- a/examples/baseline-workflows/.github/workflows/gemini-invoke.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-invoke.yml
@@ -35,7 +35,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    uses: jhw7500/automation/.github/workflows/gemini-invoke.yml@v1.35
+    uses: jhw7500/automation/.github/workflows/gemini-invoke.yml@v1.36
     with:
       item_number: ${{ inputs.item_number }}
       item_title: ${{ inputs.item_title }}

--- a/examples/baseline-workflows/.github/workflows/gemini-review.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-review.yml
@@ -27,7 +27,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    uses: jhw7500/automation/.github/workflows/gemini-review.yml@v1.35
+    uses: jhw7500/automation/.github/workflows/gemini-review.yml@v1.36
     with:
       pr_number: ${{ inputs.pr_number }}
       issue_title: ${{ inputs.issue_title }}

--- a/examples/baseline-workflows/.github/workflows/gemini-scheduled-triage.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-scheduled-triage.yml
@@ -10,7 +10,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    uses: jhw7500/automation/.github/workflows/gemini-scheduled-triage.yml@v1.35
+    uses: jhw7500/automation/.github/workflows/gemini-scheduled-triage.yml@v1.36
     with:
       app_id: ${{ vars.APP_ID }}
     secrets:

--- a/examples/baseline-workflows/.github/workflows/gemini-triage.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-triage.yml
@@ -27,7 +27,7 @@ jobs:
       id-token: write
       issues: read
       pull-requests: read
-    uses: jhw7500/automation/.github/workflows/gemini-triage.yml@v1.35
+    uses: jhw7500/automation/.github/workflows/gemini-triage.yml@v1.36
     with:
       issue_number: ${{ inputs.issue_number }}
       issue_title: ${{ inputs.issue_title }}

--- a/examples/baseline-workflows/.github/workflows/opencode.yml
+++ b/examples/baseline-workflows/.github/workflows/opencode.yml
@@ -9,10 +9,9 @@ on:
 jobs:
   opencode:
     permissions:
-      id-token: write
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
     uses: jhw7500/automation/.github/workflows/opencode.yml@v1.35
     secrets:
       ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}

--- a/examples/baseline-workflows/.github/workflows/opencode.yml
+++ b/examples/baseline-workflows/.github/workflows/opencode.yml
@@ -12,6 +12,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    uses: jhw7500/automation/.github/workflows/opencode.yml@v1.35
+    uses: jhw7500/automation/.github/workflows/opencode.yml@v1.36
     secrets:
       ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}

--- a/scripts/prepare_workflow_rollout.py
+++ b/scripts/prepare_workflow_rollout.py
@@ -27,6 +27,12 @@ CONFIG_REF_RE = re.compile(
     r"(?P<suffix>[ \t]*(?:#.*)?)$"
 )
 GEMINI_AUTH_SECRETS = {"APP_PRIVATE_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"}
+OPENCODE_WORKFLOWS = {"opencode.yml", "opencode-auto-review.yml"}
+OPENCODE_CALLER_PERMISSIONS = (
+    ("contents", "read"),
+    ("pull-requests", "write"),
+    ("issues", "write"),
+)
 
 
 class RolloutError(RuntimeError):
@@ -97,7 +103,7 @@ def block_end(lines: list[str], start: int, parent_indent: int) -> int:
     return len(lines)
 
 
-def validate_use_context(lines: list[str], index: int, indent: str, path: Path) -> None:
+def validate_use_context(lines: list[str], index: int, indent: str, path: Path) -> int:
     """Fail closed unless the line editor can safely own the caller job tail."""
     width = len(indent)
     parent_index = None
@@ -129,6 +135,37 @@ def validate_use_context(lines: list[str], index: int, indent: str, path: Path) 
             raise RolloutError(
                 f"{path.name}: secrets/with must follow uses for safe rewriting"
             )
+    return parent_index
+
+
+def enforce_opencode_permissions(
+    lines: list[str], parent_index: int, use_index: int, indent: str, filename: str
+) -> int:
+    width = len(indent)
+    job_end = block_end(lines, parent_index, leading_spaces(lines[parent_index]))
+    permission_indices = [
+        index
+        for index in range(parent_index + 1, job_end)
+        if leading_spaces(lines[index]) == width
+        and re.match(r"permissions\s*:", lines[index].strip())
+    ]
+    if len(permission_indices) > 1:
+        raise RolloutError(f"{filename}: duplicate permissions blocks")
+    canonical = [f"{indent}permissions:\n"] + [
+        f"{indent}  {name}: {value}\n" for name, value in OPENCODE_CALLER_PERMISSIONS
+    ]
+    if permission_indices:
+        start = permission_indices[0]
+        end = block_end(lines, start, width)
+        lines[start:end] = canonical
+    else:
+        lines[use_index:use_index] = canonical
+
+    for index in range(parent_index + 1, block_end(lines, parent_index, leading_spaces(lines[parent_index]))):
+        match = USE_RE.match(lines[index].rstrip("\n"))
+        if match is not None and match.group("workflow") == filename:
+            return index
+    raise RolloutError(f"{filename}: reusable workflow use line lost during permission rewrite")
 
 
 def secret_names_for(
@@ -256,11 +293,19 @@ def transform_workflow(
     required: set[str] = set()
     for index, match in reversed(uses):
         indent = match.group("indent")
-        validate_use_context(lines, index, indent, path)
+        parent_index = validate_use_context(lines, index, indent, path)
+        filename = match.group("workflow")
+        if filename in OPENCODE_WORKFLOWS:
+            index = enforce_opencode_permissions(
+                lines, parent_index, index, indent, filename
+            )
+            match = USE_RE.match(lines[index].rstrip("\n"))
+            if match is None:
+                raise RolloutError(f"{path.name}: OpenCode use line became invalid")
         end = block_end(lines, index, len(indent) - 2)
-        contract = workflow_contract(automation, match.group("workflow"))
+        contract = workflow_contract(automation, filename)
         names, pass_app_id = secret_names_for(
-            match.group("workflow"), contract, available_secrets, available_variables
+            filename, contract, available_secrets, available_variables
         )
         required.update(names)
         segment = replace_job_segment(lines[index:end], indent, new_ref, names, pass_app_id)

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -101,6 +101,21 @@ def verify_tag_content(repo: Path, ref: str) -> None:
     if step.get("env", {}).get("GITHUB_TOKEN") != "${{ github.token }}":
         raise ReleaseVerificationError("OpenCode auto review does not use github.token")
 
+    command = documents.get("opencode.yml")
+    try:
+        command_job = command["jobs"]["opencode"]
+        command_checkout = next(
+            item
+            for item in command_job["steps"]
+            if item.get("name") == "Checkout repository"
+        )
+    except (KeyError, TypeError, StopIteration) as exc:
+        raise ReleaseVerificationError("opencode.yml structure is missing") from exc
+    if command_checkout.get("with", {}).get("persist-credentials") != "true":
+        raise ReleaseVerificationError(
+            "opencode.yml cannot authenticate private repository fetch"
+        )
+
 
 def verify_release(
     repo: Path, ref: str, expected_commit: str, remote: str | None = None

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -92,6 +92,17 @@ def verify_tag_content(repo: Path, ref: str) -> None:
         raise ReleaseVerificationError(
             f"OpenCode auto review permissions differ from {expected_permissions}"
         )
+    condition = job.get("if", "")
+    same_repo_guards = (
+        "github.event.pull_request.head.repo.fork == false",
+        "github.event.pull_request.head.repo.full_name == github.repository",
+    )
+    if not isinstance(condition, str) or not all(
+        guard in condition for guard in same_repo_guards
+    ):
+        raise ReleaseVerificationError(
+            "OpenCode auto review lacks a central same-repository PR guard"
+        )
     if checkout.get("with", {}).get("persist-credentials") != "true":
         raise ReleaseVerificationError(
             "OpenCode auto review cannot authenticate private repository fetch"

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -149,6 +149,8 @@ def verify_tag_content(repo: Path, ref: str) -> None:
         command_check.get("outputs", {}).get("safe_pr")
         == "${{ steps.pr_scope.outputs.safe_pr }}"
         and "gh api" in command_scope.get("run", "")
+        and command_scope.get("env", {}).get("PR_NUMBER")
+        == "${{ github.event.pull_request.number || github.event.issue.number }}"
         and isinstance(command_condition, str)
         and "needs.check-enabled.outputs.safe_pr == 'true'" in command_condition
         and command_job.get("permissions") == command_permissions

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -75,6 +75,9 @@ def verify_tag_content(repo: Path, ref: str) -> None:
     try:
         job = auto["jobs"]["opencode-review"]
         permissions = job["permissions"]
+        checkout = next(
+            item for item in job["steps"] if item.get("name") == "Checkout repository"
+        )
         step = next(
             item for item in job["steps"] if item.get("name") == "Run OpenCode PR review"
         )
@@ -88,6 +91,10 @@ def verify_tag_content(repo: Path, ref: str) -> None:
     if permissions != expected_permissions:
         raise ReleaseVerificationError(
             f"OpenCode auto review permissions differ from {expected_permissions}"
+        )
+    if checkout.get("with", {}).get("persist-credentials") != "true":
+        raise ReleaseVerificationError(
+            "OpenCode auto review cannot authenticate private repository fetch"
         )
     if step.get("with", {}).get("use_github_token") != "true":
         raise ReleaseVerificationError("OpenCode auto review does not force use_github_token")

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -73,6 +73,7 @@ def verify_tag_content(repo: Path, ref: str) -> None:
     if auto is None:
         raise ReleaseVerificationError("opencode-auto-review.yml is missing")
     try:
+        check_job = auto["jobs"]["check-enabled"]
         job = auto["jobs"]["opencode-review"]
         permissions = job["permissions"]
         checkout = next(
@@ -92,13 +93,17 @@ def verify_tag_content(repo: Path, ref: str) -> None:
         raise ReleaseVerificationError(
             f"OpenCode auto review permissions differ from {expected_permissions}"
         )
-    condition = job.get("if", "")
-    same_repo_guards = (
-        "github.event.pull_request.head.repo.fork == false",
-        "github.event.pull_request.head.repo.full_name == github.repository",
+    safe_output = check_job.get("outputs", {}).get("safe_pr")
+    scope_step = next(
+        (item for item in check_job.get("steps", []) if item.get("id") == "pr_scope"),
+        {},
     )
-    if not isinstance(condition, str) or not all(
-        guard in condition for guard in same_repo_guards
+    condition = job.get("if", "")
+    if (
+        safe_output != "${{ steps.pr_scope.outputs.safe_pr }}"
+        or "gh api" not in scope_step.get("run", "")
+        or not isinstance(condition, str)
+        or "needs.check-enabled.outputs.safe_pr == 'true'" not in condition
     ):
         raise ReleaseVerificationError(
             "OpenCode auto review lacks a central same-repository PR guard"
@@ -114,17 +119,45 @@ def verify_tag_content(repo: Path, ref: str) -> None:
 
     command = documents.get("opencode.yml")
     try:
+        command_check = command["jobs"]["check-enabled"]
         command_job = command["jobs"]["opencode"]
         command_checkout = next(
             item
             for item in command_job["steps"]
             if item.get("name") == "Checkout repository"
         )
+        command_step = next(
+            item for item in command_job["steps"] if item.get("name") == "Run opencode"
+        )
     except (KeyError, TypeError, StopIteration) as exc:
         raise ReleaseVerificationError("opencode.yml structure is missing") from exc
     if command_checkout.get("with", {}).get("persist-credentials") != "true":
         raise ReleaseVerificationError(
             "opencode.yml cannot authenticate private repository fetch"
+        )
+    command_scope = next(
+        (item for item in command_check.get("steps", []) if item.get("id") == "pr_scope"),
+        {},
+    )
+    command_condition = command_job.get("if", "")
+    command_permissions = {
+        "contents": "read",
+        "pull-requests": "write",
+        "issues": "write",
+    }
+    command_is_secure = (
+        command_check.get("outputs", {}).get("safe_pr")
+        == "${{ steps.pr_scope.outputs.safe_pr }}"
+        and "gh api" in command_scope.get("run", "")
+        and isinstance(command_condition, str)
+        and "needs.check-enabled.outputs.safe_pr == 'true'" in command_condition
+        and command_job.get("permissions") == command_permissions
+        and command_step.get("with", {}).get("use_github_token") == "true"
+        and command_step.get("env", {}).get("GITHUB_TOKEN") == "${{ github.token }}"
+    )
+    if not command_is_secure:
+        raise ReleaseVerificationError(
+            "opencode.yml security contract permits unsafe PR or App-token access"
         )
 
 

--- a/tests/test_prepare_workflow_rollout.py
+++ b/tests/test_prepare_workflow_rollout.py
@@ -5,6 +5,8 @@ import tempfile
 import textwrap
 import unittest
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
@@ -47,6 +49,15 @@ class PrepareWorkflowRolloutTest(unittest.TestCase):
               workflow_call:
             jobs: {}
         """))
+        for name in ("opencode.yml", "opencode-auto-review.yml"):
+            (wf / name).write_text(textwrap.dedent("""\
+                on:
+                  workflow_call:
+                    secrets:
+                      ZHIPU_API_KEY:
+                        required: true
+                jobs: {}
+            """))
         self.repo = self.root / "consumer"
         (self.repo / ".github/workflows").mkdir(parents=True)
         (self.repo / ".github/workflow-config.yml").write_text(
@@ -219,6 +230,35 @@ class PrepareWorkflowRolloutTest(unittest.TestCase):
                 set(),
             )
         self.assertEqual(before, p.read_text())
+
+    def test_opencode_caller_permissions_drop_oidc_and_allow_review_output(self) -> None:
+        p = self.write("opencode.yml", """\
+            on:
+              issue_comment:
+            jobs:
+              call:
+                if: github.actor != 'bot'
+                permissions:
+                  id-token: write
+                  contents: read
+                  pull-requests: read
+                  issues: read
+                uses: jhw7500/automation/.github/workflows/opencode.yml@v1.35
+                secrets: inherit
+        """)
+        prepare_repository(
+            self.repo,
+            self.automation,
+            "v1.36",
+            {"ZHIPU_API_KEY"},
+            set(),
+        )
+        workflow = yaml.load(p.read_text(), Loader=yaml.BaseLoader)
+        permissions = workflow["jobs"]["call"]["permissions"]
+        self.assertEqual(
+            {"contents": "read", "pull-requests": "write", "issues": "write"},
+            permissions,
+        )
 
     def test_secretless_workflow_removes_inherit(self) -> None:
         p = self.write("notice.yml", """\

--- a/tests/test_prepare_workflow_rollout.py
+++ b/tests/test_prepare_workflow_rollout.py
@@ -260,6 +260,26 @@ class PrepareWorkflowRolloutTest(unittest.TestCase):
             permissions,
         )
 
+    def test_opencode_caller_permissions_are_inserted_when_absent(self) -> None:
+        p = self.write("opencode-auto-review.yml", """\
+            jobs:
+              call:
+                uses: jhw7500/automation/.github/workflows/opencode-auto-review.yml@v1.35
+                secrets: inherit
+        """)
+        prepare_repository(
+            self.repo,
+            self.automation,
+            "v1.36",
+            {"ZHIPU_API_KEY"},
+            set(),
+        )
+        workflow = yaml.load(p.read_text(), Loader=yaml.BaseLoader)
+        self.assertEqual(
+            {"contents": "read", "pull-requests": "write", "issues": "write"},
+            workflow["jobs"]["call"]["permissions"],
+        )
+
     def test_secretless_workflow_removes_inherit(self) -> None:
         p = self.write("notice.yml", """\
             jobs:

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -32,10 +32,15 @@ SECURE_WORKFLOW = """\
 on:
   workflow_call:
 jobs:
+  check-enabled:
+    outputs:
+      safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}
+    steps:
+      - id: pr_scope
+        run: gh api example
   opencode-review:
     if: >-
-      github.event.pull_request.head.repo.fork == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      needs.check-enabled.outputs.safe_pr == 'true'
     permissions:
       contents: read
       pull-requests: write
@@ -56,12 +61,28 @@ SECURE_COMMAND_WORKFLOW = """\
 on:
   workflow_call:
 jobs:
+  check-enabled:
+    outputs:
+      safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}
+    steps:
+      - id: pr_scope
+        run: gh api example
   opencode:
+    if: needs.check-enabled.outputs.safe_pr == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           persist-credentials: true
+      - name: Run opencode
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          use_github_token: true
 """
 
 

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -33,6 +33,9 @@ on:
   workflow_call:
 jobs:
   opencode-review:
+    if: >-
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -37,6 +37,8 @@ jobs:
       safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}
     steps:
       - id: pr_scope
+        env:
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
         run: gh api example
   opencode-review:
     if: >-
@@ -66,6 +68,8 @@ jobs:
       safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}
     steps:
       - id: pr_scope
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh api example
   opencode:
     if: needs.check-enabled.outputs.safe_pr == 'true'

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -38,6 +38,10 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true
       - name: Run OpenCode PR review
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -49,6 +49,18 @@ jobs:
           use_github_token: true
 """
 
+SECURE_COMMAND_WORKFLOW = """\
+on:
+  workflow_call:
+jobs:
+  opencode:
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+"""
+
 
 class RolloutWorkflowFleetTest(unittest.TestCase):
     def test_branch_is_derived_from_release_ref(self) -> None:
@@ -151,6 +163,7 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
             workflow = repo / ".github/workflows/opencode-auto-review.yml"
             workflow.parent.mkdir(parents=True)
             workflow.write_text(SECURE_WORKFLOW)
+            (workflow.parent / "opencode.yml").write_text(SECURE_COMMAND_WORKFLOW)
             self.git(repo, "init", "-q")
             self.git(repo, "config", "user.name", "Test")
             self.git(repo, "config", "user.email", "test@example.com")
@@ -182,6 +195,7 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
             workflow = repo / ".github/workflows/opencode-auto-review.yml"
             workflow.parent.mkdir(parents=True)
             workflow.write_text(SECURE_WORKFLOW)
+            (workflow.parent / "opencode.yml").write_text(SECURE_COMMAND_WORKFLOW)
             self.git(repo, "init", "-q")
             self.git(repo, "config", "user.name", "Test")
             self.git(repo, "config", "user.email", "test@example.com")

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -44,6 +44,21 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
                 """
             )
         )
+        (self.repo / ".github/workflows/opencode.yml").write_text(
+            textwrap.dedent(
+                """\
+                on:
+                  workflow_call:
+                jobs:
+                  opencode:
+                    steps:
+                      - name: Checkout repository
+                        uses: actions/checkout@v4
+                        with:
+                          persist-credentials: true
+                """
+            )
+        )
         self.git("init", "-q")
         self.git("config", "user.name", "Test")
         self.git("config", "user.email", "test@example.com")
@@ -112,6 +127,21 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
         bad_commit = self.git("rev-parse", "HEAD").strip()
         self.git("tag", "-a", "v1.35", "-m", "bad")
         with self.assertRaisesRegex(ReleaseVerificationError, "private repository fetch"):
+            verify_release(self.repo, "v1.35", bad_commit)
+
+    def test_rejects_opencode_command_without_private_repo_fetch_auth(self) -> None:
+        self.git("tag", "-d", "v1.35")
+        path = self.repo / ".github/workflows/opencode.yml"
+        path.write_text(
+            path.read_text().replace(
+                "persist-credentials: true", "persist-credentials: false"
+            )
+        )
+        self.git("add", ".")
+        self.git("commit", "-qm", "break private command fetch")
+        bad_commit = self.git("rev-parse", "HEAD").strip()
+        self.git("tag", "-a", "v1.35", "-m", "bad")
+        with self.assertRaisesRegex(ReleaseVerificationError, "opencode.yml.*private"):
             verify_release(self.repo, "v1.35", bad_commit)
 
 

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -27,6 +27,9 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
                   workflow_call:
                 jobs:
                   opencode-review:
+                    if: >-
+                      github.event.pull_request.head.repo.fork == false &&
+                      github.event.pull_request.head.repo.full_name == github.repository
                     permissions:
                       contents: read
                       pull-requests: write
@@ -142,6 +145,22 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
         bad_commit = self.git("rev-parse", "HEAD").strip()
         self.git("tag", "-a", "v1.35", "-m", "bad")
         with self.assertRaisesRegex(ReleaseVerificationError, "opencode.yml.*private"):
+            verify_release(self.repo, "v1.35", bad_commit)
+
+    def test_rejects_auto_review_without_central_same_repo_guard(self) -> None:
+        self.git("tag", "-d", "v1.35")
+        path = self.repo / ".github/workflows/opencode-auto-review.yml"
+        path.write_text(
+            path.read_text().replace(
+                "github.event.pull_request.head.repo.full_name == github.repository",
+                "true",
+            )
+        )
+        self.git("add", ".")
+        self.git("commit", "-qm", "remove same repo guard")
+        bad_commit = self.git("rev-parse", "HEAD").strip()
+        self.git("tag", "-a", "v1.35", "-m", "bad")
+        with self.assertRaisesRegex(ReleaseVerificationError, "same-repository PR guard"):
             verify_release(self.repo, "v1.35", bad_commit)
 
 

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -32,6 +32,10 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
                       pull-requests: write
                       issues: write
                     steps:
+                      - name: Checkout repository
+                        uses: actions/checkout@v4
+                        with:
+                          persist-credentials: true
                       - name: Run OpenCode PR review
                         env:
                           GITHUB_TOKEN: ${{ github.token }}
@@ -93,6 +97,21 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
         bad_commit = self.git("rev-parse", "HEAD").strip()
         self.git("tag", "-a", "v1.35", "-m", "bad")
         with self.assertRaisesRegex(ReleaseVerificationError, "permissions"):
+            verify_release(self.repo, "v1.35", bad_commit)
+
+    def test_rejects_opencode_release_without_private_repo_fetch_auth(self) -> None:
+        self.git("tag", "-d", "v1.35")
+        path = self.repo / ".github/workflows/opencode-auto-review.yml"
+        path.write_text(
+            path.read_text().replace(
+                "persist-credentials: true", "persist-credentials: false"
+            )
+        )
+        self.git("add", ".")
+        self.git("commit", "-qm", "break private fetch")
+        bad_commit = self.git("rev-parse", "HEAD").strip()
+        self.git("tag", "-a", "v1.35", "-m", "bad")
+        with self.assertRaisesRegex(ReleaseVerificationError, "private repository fetch"):
             verify_release(self.repo, "v1.35", bad_commit)
 
 

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -31,6 +31,8 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
                       safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}
                     steps:
                       - id: pr_scope
+                        env:
+                          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
                         run: gh api example
                   opencode-review:
                     if: >-
@@ -63,6 +65,8 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
                       safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}
                     steps:
                       - id: pr_scope
+                        env:
+                          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
                         run: gh api example
                   opencode:
                     if: needs.check-enabled.outputs.safe_pr == 'true'
@@ -195,6 +199,22 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
         path.write_text(text)
         self.git("add", ".")
         self.git("commit", "-qm", "restore app token path")
+        bad_commit = self.git("rev-parse", "HEAD").strip()
+        self.git("tag", "-a", "v1.35", "-m", "bad")
+        with self.assertRaisesRegex(ReleaseVerificationError, "opencode.yml security"):
+            verify_release(self.repo, "v1.35", bad_commit)
+
+    def test_rejects_command_scope_without_inline_review_fallback(self) -> None:
+        self.git("tag", "-d", "v1.35")
+        path = self.repo / ".github/workflows/opencode.yml"
+        path.write_text(
+            path.read_text().replace(
+                "github.event.pull_request.number || github.event.issue.number",
+                "github.event.issue.number",
+            )
+        )
+        self.git("add", ".")
+        self.git("commit", "-qm", "break review comment scope")
         bad_commit = self.git("rev-parse", "HEAD").strip()
         self.git("tag", "-a", "v1.35", "-m", "bad")
         with self.assertRaisesRegex(ReleaseVerificationError, "opencode.yml security"):

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -26,10 +26,15 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
                 on:
                   workflow_call:
                 jobs:
+                  check-enabled:
+                    outputs:
+                      safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}
+                    steps:
+                      - id: pr_scope
+                        run: gh api example
                   opencode-review:
                     if: >-
-                      github.event.pull_request.head.repo.fork == false &&
-                      github.event.pull_request.head.repo.full_name == github.repository
+                      needs.check-enabled.outputs.safe_pr == 'true'
                     permissions:
                       contents: read
                       pull-requests: write
@@ -53,12 +58,28 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
                 on:
                   workflow_call:
                 jobs:
+                  check-enabled:
+                    outputs:
+                      safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}
+                    steps:
+                      - id: pr_scope
+                        run: gh api example
                   opencode:
+                    if: needs.check-enabled.outputs.safe_pr == 'true'
+                    permissions:
+                      contents: read
+                      pull-requests: write
+                      issues: write
                     steps:
                       - name: Checkout repository
                         uses: actions/checkout@v4
                         with:
                           persist-credentials: true
+                      - name: Run opencode
+                        env:
+                          GITHUB_TOKEN: ${{ github.token }}
+                        with:
+                          use_github_token: true
                 """
             )
         )
@@ -152,7 +173,7 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
         path = self.repo / ".github/workflows/opencode-auto-review.yml"
         path.write_text(
             path.read_text().replace(
-                "github.event.pull_request.head.repo.full_name == github.repository",
+                "needs.check-enabled.outputs.safe_pr == 'true'",
                 "true",
             )
         )
@@ -161,6 +182,22 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
         bad_commit = self.git("rev-parse", "HEAD").strip()
         self.git("tag", "-a", "v1.35", "-m", "bad")
         with self.assertRaisesRegex(ReleaseVerificationError, "same-repository PR guard"):
+            verify_release(self.repo, "v1.35", bad_commit)
+
+    def test_rejects_opencode_command_oidc_app_token_path(self) -> None:
+        self.git("tag", "-d", "v1.35")
+        path = self.repo / ".github/workflows/opencode.yml"
+        text = path.read_text().replace(
+            "    permissions:\n      contents: read",
+            "    permissions:\n      id-token: write\n      contents: read",
+        )
+        text = text.replace("use_github_token: true", "use_github_token: false")
+        path.write_text(text)
+        self.git("add", ".")
+        self.git("commit", "-qm", "restore app token path")
+        bad_commit = self.git("rev-parse", "HEAD").strip()
+        self.git("tag", "-a", "v1.35", "-m", "bad")
+        with self.assertRaisesRegex(ReleaseVerificationError, "opencode.yml security"):
             verify_release(self.repo, "v1.35", bad_commit)
 
 

--- a/tests/test_workflow_secret_contracts.py
+++ b/tests/test_workflow_secret_contracts.py
@@ -149,6 +149,21 @@ class WorkflowSecretContractsTest(unittest.TestCase):
         run_step = next(step for step in job["steps"] if step.get("name") == "Run opencode")
         self.assertEqual("true", run_step["with"]["use_github_token"])
         self.assertEqual("${{ github.token }}", run_step["env"]["GITHUB_TOKEN"])
+        scope_step = next(step for step in check["steps"] if step.get("id") == "pr_scope")
+        self.assertEqual(
+            "${{ github.event.pull_request.number || github.event.issue.number }}",
+            scope_step["env"]["PR_NUMBER"],
+        )
+
+    def test_opencode_baseline_caller_grants_only_required_review_permissions(self) -> None:
+        path = ROOT / "examples/baseline-workflows/.github/workflows/opencode.yml"
+        workflow = load_workflow(path)
+        job = workflow["jobs"]["opencode"]
+        self.assertEqual(
+            {"contents": "read", "pull-requests": "write", "issues": "write"},
+            job["permissions"],
+        )
+        self.assertNotIn("id-token", job["permissions"])
 
     def test_app_token_workflows_accept_an_explicit_app_id_with_legacy_fallback(self) -> None:
         for filename in APP_TOKEN_WORKFLOWS:

--- a/tests/test_workflow_secret_contracts.py
+++ b/tests/test_workflow_secret_contracts.py
@@ -119,6 +119,14 @@ class WorkflowSecretContractsTest(unittest.TestCase):
         )
         self.assertEqual("true", checkout["with"]["persist-credentials"])
 
+    def test_opencode_command_keeps_read_only_checkout_auth_for_private_repos(self) -> None:
+        workflow = load_workflow(WORKFLOWS / "opencode.yml")
+        job = workflow["jobs"]["opencode"]
+        checkout = next(
+            step for step in job["steps"] if step.get("name") == "Checkout repository"
+        )
+        self.assertEqual("true", checkout["with"]["persist-credentials"])
+
     def test_app_token_workflows_accept_an_explicit_app_id_with_legacy_fallback(self) -> None:
         for filename in APP_TOKEN_WORKFLOWS:
             with self.subTest(workflow=filename):

--- a/tests/test_workflow_secret_contracts.py
+++ b/tests/test_workflow_secret_contracts.py
@@ -111,6 +111,14 @@ class WorkflowSecretContractsTest(unittest.TestCase):
         self.assertEqual("true", run_step["with"]["use_github_token"])
         self.assertEqual("${{ github.token }}", run_step["env"]["GITHUB_TOKEN"])
 
+    def test_opencode_auto_review_keeps_read_only_checkout_auth_for_private_repos(self) -> None:
+        workflow = load_workflow(WORKFLOWS / "opencode-auto-review.yml")
+        job = workflow["jobs"]["opencode-review"]
+        checkout = next(
+            step for step in job["steps"] if step.get("name") == "Checkout repository"
+        )
+        self.assertEqual("true", checkout["with"]["persist-credentials"])
+
     def test_app_token_workflows_accept_an_explicit_app_id_with_legacy_fallback(self) -> None:
         for filename in APP_TOKEN_WORKFLOWS:
             with self.subTest(workflow=filename):

--- a/tests/test_workflow_secret_contracts.py
+++ b/tests/test_workflow_secret_contracts.py
@@ -119,6 +119,15 @@ class WorkflowSecretContractsTest(unittest.TestCase):
         )
         self.assertEqual("true", checkout["with"]["persist-credentials"])
 
+    def test_opencode_auto_review_enforces_same_repository_prs_centrally(self) -> None:
+        workflow = load_workflow(WORKFLOWS / "opencode-auto-review.yml")
+        condition = workflow["jobs"]["opencode-review"]["if"]
+        self.assertIn("github.event.pull_request.head.repo.fork == false", condition)
+        self.assertIn(
+            "github.event.pull_request.head.repo.full_name == github.repository",
+            condition,
+        )
+
     def test_opencode_command_keeps_read_only_checkout_auth_for_private_repos(self) -> None:
         workflow = load_workflow(WORKFLOWS / "opencode.yml")
         job = workflow["jobs"]["opencode"]

--- a/tests/test_workflow_secret_contracts.py
+++ b/tests/test_workflow_secret_contracts.py
@@ -121,12 +121,12 @@ class WorkflowSecretContractsTest(unittest.TestCase):
 
     def test_opencode_auto_review_enforces_same_repository_prs_centrally(self) -> None:
         workflow = load_workflow(WORKFLOWS / "opencode-auto-review.yml")
+        check = workflow["jobs"]["check-enabled"]
+        self.assertEqual("${{ steps.pr_scope.outputs.safe_pr }}", check["outputs"]["safe_pr"])
+        scope_step = next(step for step in check["steps"] if step.get("id") == "pr_scope")
+        self.assertIn("gh api", scope_step["run"])
         condition = workflow["jobs"]["opencode-review"]["if"]
-        self.assertIn("github.event.pull_request.head.repo.fork == false", condition)
-        self.assertIn(
-            "github.event.pull_request.head.repo.full_name == github.repository",
-            condition,
-        )
+        self.assertIn("needs.check-enabled.outputs.safe_pr == 'true'", condition)
 
     def test_opencode_command_keeps_read_only_checkout_auth_for_private_repos(self) -> None:
         workflow = load_workflow(WORKFLOWS / "opencode.yml")
@@ -135,6 +135,20 @@ class WorkflowSecretContractsTest(unittest.TestCase):
             step for step in job["steps"] if step.get("name") == "Checkout repository"
         )
         self.assertEqual("true", checkout["with"]["persist-credentials"])
+
+    def test_opencode_command_cannot_mint_app_token_and_requires_same_repo_pr(self) -> None:
+        workflow = load_workflow(WORKFLOWS / "opencode.yml")
+        check = workflow["jobs"]["check-enabled"]
+        self.assertEqual("${{ steps.pr_scope.outputs.safe_pr }}", check["outputs"]["safe_pr"])
+        job = workflow["jobs"]["opencode"]
+        self.assertEqual(
+            {"contents": "read", "pull-requests": "write", "issues": "write"},
+            job["permissions"],
+        )
+        self.assertIn("needs.check-enabled.outputs.safe_pr == 'true'", job["if"])
+        run_step = next(step for step in job["steps"] if step.get("name") == "Run opencode")
+        self.assertEqual("true", run_step["with"]["use_github_token"])
+        self.assertEqual("${{ github.token }}", run_step["env"]["GITHUB_TOKEN"])
 
     def test_app_token_workflows_accept_an_explicit_app_id_with_legacy_fallback(self) -> None:
         for filename in APP_TOKEN_WORKFLOWS:


### PR DESCRIPTION
OpenCode's GitHub action fetches the PR head branch after checkout. Private repositories need authenticated fetch, so the read-scoped checkout credential is retained.\n\nSecurity boundary:\n- both automatic review and manual /oc resolve PR metadata through the GitHub API and run only for same-repository, non-fork PRs\n- both force the job-scoped github.token\n- id-token is forbidden, preventing OIDC/App-token escalation\n- contents remains read-only; PR/issues write is limited to review output\n- fork/external PR review is intentionally no longer supported and reports a skipped summary\n\nValidation: pytest 50 passed; actionlint; py_compile; git diff --check.\n\nRelease plan: merge, create immutable v1.36 at the merge commit, verify locally/remotely, then update remaining fleet PRs. v1.35 is not moved.