### PR TITLE
feat(fleet): support explicit existing-secret refresh

### DIFF
--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -81,7 +81,7 @@ ZHIPU_API_KEY=... python3 scripts/rollout_workflow_fleet.py \
 `plan`과 `prepare`에서는 `--sync-missing-secrets`를 지정할 수 없으며 parser가 즉시
 거부한다. 실제 repository secret write는 `publish + --sync-missing-secrets +
 --confirm` 조합에서만 가능하다. `--refresh-secret`은 기존 secret도 의도적으로 덮어쓰므로
-대상 저장소를 `--repo`로 좁혀 실행하는 것을 권장한다.
+실수로 전체 fleet를 덮어쓰지 않도록 하나 이상의 대상 `--repo`를 반드시 지정해야 한다.
 
 각 실행은 `rollout-manifest.json`에 base/head/PR/blocked 결과를 남긴다. 한 저장소가
 blocked여도 다른 저장소의 준비는 계속하지만 명령은 non-zero로 끝난다.

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -3,7 +3,8 @@
 `scripts/rollout_workflow_fleet.py`는 중앙 reusable workflow caller와 필요한
 repository secret 전제조건을 한 실행에서 조율한다. GitHub는 Git PR과 secret write를
 하나의 transaction으로 제공하지 않으므로, 도구는 둘을 원자적이라고 주장하지 않는다.
-대신 secret 전제조건을 먼저 통과한 저장소만 독립 branch/PR로 게시한다.
+대신 저장소 metadata와 caller 계약을 준비·검증한 뒤 secret을 쓰고, 검증을 통과한
+저장소만 독립 branch/PR로 게시한다.
 
 ## 보존하는 것
 
@@ -26,6 +27,8 @@ repository secret 전제조건을 한 실행에서 조율한다. GitHub는 Git P
   이 옵션은 `publish + --confirm + --sync-missing-secrets`에서만 허용되고, 같은 이름의
   `--allow-env-secret NAME`(또는 Claude 전용 fan-out 승인)이 반드시 필요하다. 기존 값은
   읽지 않으며 새 값도 argv, 로그, manifest에 기록하지 않는다.
+- refresh 이름은 해당 저장소의 managed caller가 실제 요구하는 secret이어야 하며,
+  metadata/caller/actionlint 검증이 실패하거나 caller가 없으면 값을 쓰지 않는다.
 - 개인 Claude OAuth token fan-out은 추가로 `--allow-personal-oauth-fanout`을 명시해야
   한다. 이 옵션은 저장소마다 자격증명을 복제해 blast radius를 넓히므로, 이미 배포된
   `personal-ops/claude-token-sync`의 대상/rotation 정책을 승인한 운영에서만 사용한다.

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -27,7 +27,7 @@ repository secret 전제조건을 한 실행에서 조율한다. GitHub는 Git P
   이 옵션은 `publish + --confirm + --sync-missing-secrets`에서만 허용되고, 같은 이름의
   `--allow-env-secret NAME`(또는 Claude 전용 fan-out 승인)이 반드시 필요하다. 기존 값은
   읽지 않으며 새 값도 argv, 로그, manifest에 기록하지 않는다.
-- refresh 이름은 해당 저장소의 managed caller가 실제 요구하는 secret이어야 하며,
+- refresh 이름은 해당 저장소의 managed caller 계약에 선언된 secret이어야 하며,
   metadata/caller/actionlint 검증이 실패하거나 caller가 없으면 값을 쓰지 않는다.
 - 개인 Claude OAuth token fan-out은 추가로 `--allow-personal-oauth-fanout`을 명시해야
   한다. 이 옵션은 저장소마다 자격증명을 복제해 blast radius를 넓히므로, 이미 배포된

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -8,7 +8,8 @@ repository secret 전제조건을 한 실행에서 조율한다. GitHub는 Git P
 ## 보존하는 것
 
 - 기존 workflow 파일과 caller job만 처리하고 새 workflow를 강제로 추가하지 않는다.
-- 저장소별 trigger, `if` guard, `permissions`, 기존 `with` 입력을 보존한다.
+- 저장소별 trigger, `if` guard, 기존 `with` 입력을 보존한다. `permissions`도 보존하되,
+  OpenCode 두 caller는 OIDC 제거와 review 출력에 필요한 최소 계약으로 정규화한다.
 - 중앙 release ref, `secrets` mapping, 지원되는 `app_id`, `automation_ref`만 변경한다.
 - caller가 없는 저장소는 skip한다.
 - required secret이 없고 안전한 source도 없으면 해당 저장소만 blocked 처리한다.
@@ -21,6 +22,10 @@ repository secret 전제조건을 한 실행에서 조율한다. GitHub는 Git P
   그 이름을 이번 실행에 명시 승인했을 때만 쓸 수 있다. 승인된 이름은 값 없이
   preflight 출력에 표시된다.
 - `--sync-missing-secrets`가 없으면 이름 검사만 하며 어떠한 secret도 쓰지 않는다.
+- 이름은 존재하지만 값이 만료된 키는 `--refresh-secret NAME`으로 명시 회전할 수 있다.
+  이 옵션은 `publish + --confirm + --sync-missing-secrets`에서만 허용되고, 같은 이름의
+  `--allow-env-secret NAME`(또는 Claude 전용 fan-out 승인)이 반드시 필요하다. 기존 값은
+  읽지 않으며 새 값도 argv, 로그, manifest에 기록하지 않는다.
 - 개인 Claude OAuth token fan-out은 추가로 `--allow-personal-oauth-fanout`을 명시해야
   한다. 이 옵션은 저장소마다 자격증명을 복제해 blast radius를 넓히므로, 이미 배포된
   `personal-ops/claude-token-sync`의 대상/rotation 정책을 승인한 운영에서만 사용한다.
@@ -57,11 +62,26 @@ python3 scripts/rollout_workflow_fleet.py \
   --allow-env-secret GEMINI_API_KEY \
   --confirm \
   --actionlint /path/to/actionlint
+
+# 만료된 기존 키 교체 + 누락 키 보충 + workflow PR 생성을 한 번에 수행
+ZHIPU_API_KEY=... python3 scripts/rollout_workflow_fleet.py \
+  --workspace /path/to/disposable-fleet \
+  --ref v1.36 \
+  --mode publish \
+  --sync-missing-secrets \
+  --allow-env-secret ZHIPU_API_KEY \
+  --refresh-secret ZHIPU_API_KEY \
+  --repo wlan-driver \
+  --repo wlan-driver-v2 \
+  --repo wlan-opc \
+  --confirm \
+  --actionlint /path/to/actionlint
 ```
 
 `plan`과 `prepare`에서는 `--sync-missing-secrets`를 지정할 수 없으며 parser가 즉시
 거부한다. 실제 repository secret write는 `publish + --sync-missing-secrets +
---confirm` 조합에서만 가능하다.
+--confirm` 조합에서만 가능하다. `--refresh-secret`은 기존 secret도 의도적으로 덮어쓰므로
+대상 저장소를 `--repo`로 좁혀 실행하는 것을 권장한다.
 
 각 실행은 `rollout-manifest.json`에 base/head/PR/blocked 결과를 남긴다. 한 저장소가
 blocked여도 다른 저장소의 준비는 계속하지만 명령은 non-zero로 끝난다.

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -85,6 +85,8 @@ ZHIPU_API_KEY=... python3 scripts/rollout_workflow_fleet.py \
 
 각 실행은 `rollout-manifest.json`에 base/head/PR/blocked 결과를 남긴다. 한 저장소가
 blocked여도 다른 저장소의 준비는 계속하지만 명령은 non-zero로 끝난다.
+여러 secret 중 일부를 쓴 뒤 후속 secret write나 workflow 준비가 실패한 경우에도,
+실제로 완료된 secret **이름**은 blocked 항목에 남긴다(값은 기록하지 않는다).
 동일 release branch를 다시 게시할 때는 push 직전 원격 SHA를 조회해 exact
 `--force-with-lease=<ref>:<sha>`로 보호하므로 다른 실행이나 사람이 갱신한 branch를
 덮어쓰지 않는다.

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -527,13 +527,12 @@ def main(argv: list[str] | None = None) -> int:
             refreshed_progress: list[str] = []
             synced_progress: list[str] = []
             try:
-                refreshed: tuple[str, ...] = ()
                 if args.refresh_secret:
                     if repo_config[name].get("secrets", True) is False:
                         raise RolloutError(
                             f"{name}: secret writes are disabled by config"
                         )
-                    refreshed = refresh_secrets(
+                    refresh_secrets(
                         owner,
                         name,
                         set(args.refresh_secret),
@@ -541,16 +540,13 @@ def main(argv: list[str] | None = None) -> int:
                         allowed_env_secrets,
                         refreshed_progress,
                     )
-                    refreshed_progress.extend(
-                        item for item in refreshed if item not in refreshed_progress
-                    )
                 if repo_config[name].get("workflows", True) is False:
                     outcomes.append(
                         RepoOutcome(
                             name,
                             "skipped",
                             "workflows disabled by config",
-                            synced_secrets=refreshed,
+                            synced_secrets=tuple(refreshed_progress),
                         )
                     )
                     continue
@@ -564,7 +560,7 @@ def main(argv: list[str] | None = None) -> int:
                     if args.mode == "plan":
                         preview = preview_copy(repo)
                         target = Path(preview.name)
-                    result, synced = prepare_with_prerequisites(
+                    result, _ = prepare_with_prerequisites(
                         target,
                         contract_source,
                         args.ref,
@@ -576,9 +572,6 @@ def main(argv: list[str] | None = None) -> int:
                         args.allow_personal_oauth_fanout,
                         allowed_env_secrets,
                         synced_progress,
-                    )
-                    synced_progress.extend(
-                        item for item in synced if item not in synced_progress
                     )
                     written_secrets = tuple(
                         dict.fromkeys(refreshed_progress + synced_progress)

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -199,6 +199,7 @@ def sync_missing(
     enabled: bool,
     allow_personal_oauth_fanout: bool,
     allowed_env_secrets: set[str],
+    completed: list[str] | None = None,
 ) -> tuple[set[str], tuple[str, ...]]:
     available = remote_names(owner, repo, "secret")
     synced: list[str] = []
@@ -218,6 +219,8 @@ def sync_missing(
         )
         available.add(name)
         synced.append(name)
+        if completed is not None:
+            completed.append(name)
     return available, tuple(synced)
 
 
@@ -227,6 +230,7 @@ def refresh_secrets(
     names: set[str],
     allow_personal_oauth_fanout: bool,
     allowed_env_secrets: set[str],
+    completed: list[str] | None = None,
 ) -> tuple[str, ...]:
     refreshed: list[str] = []
     for name in sorted(names):
@@ -242,6 +246,8 @@ def refresh_secrets(
             input_text=value,
         )
         refreshed.append(name)
+        if completed is not None:
+            completed.append(name)
     return tuple(refreshed)
 
 
@@ -254,6 +260,7 @@ def prepare_with_prerequisites(
     sync_missing_enabled: bool,
     allow_personal_oauth_fanout: bool,
     allowed_env_secrets: set[str],
+    completed: list[str] | None = None,
 ) -> tuple[object, tuple[str, ...]]:
     secrets = remote_names(owner, repo, "secret")
     variables = remote_names(owner, repo, "variable")
@@ -271,6 +278,7 @@ def prepare_with_prerequisites(
                 enabled=sync_missing_enabled,
                 allow_personal_oauth_fanout=allow_personal_oauth_fanout,
                 allowed_env_secrets=allowed_env_secrets,
+                completed=completed,
             )
             synced_all.extend(name for name in synced if name not in synced_all)
             if secrets == previous:
@@ -514,6 +522,8 @@ def main(argv: list[str] | None = None) -> int:
         )
     try:
         for name in repos:
+            refreshed_progress: list[str] = []
+            synced_progress: list[str] = []
             try:
                 refreshed: tuple[str, ...] = ()
                 if args.refresh_secret:
@@ -527,6 +537,10 @@ def main(argv: list[str] | None = None) -> int:
                         set(args.refresh_secret),
                         args.allow_personal_oauth_fanout,
                         allowed_env_secrets,
+                        refreshed_progress,
+                    )
+                    refreshed_progress.extend(
+                        item for item in refreshed if item not in refreshed_progress
                     )
                 if repo_config[name].get("workflows", True) is False:
                     outcomes.append(
@@ -559,6 +573,13 @@ def main(argv: list[str] | None = None) -> int:
                         and repo_config[name].get("secrets", True) is not False,
                         args.allow_personal_oauth_fanout,
                         allowed_env_secrets,
+                        synced_progress,
+                    )
+                    synced_progress.extend(
+                        item for item in synced if item not in synced_progress
+                    )
+                    written_secrets = tuple(
+                        dict.fromkeys(refreshed_progress + synced_progress)
                     )
                     if result.callers == 0:
                         outcomes.append(
@@ -567,7 +588,7 @@ def main(argv: list[str] | None = None) -> int:
                                 "skipped",
                                 "no existing central callers",
                                 base,
-                                synced_secrets=refreshed + synced,
+                                synced_secrets=written_secrets,
                             )
                         )
                     elif not result.changed_files:
@@ -577,7 +598,7 @@ def main(argv: list[str] | None = None) -> int:
                                 "current",
                                 "already matches contract",
                                 base,
-                                synced_secrets=refreshed + synced,
+                                synced_secrets=written_secrets,
                             )
                         )
                     else:
@@ -592,23 +613,35 @@ def main(argv: list[str] | None = None) -> int:
                                 repo, owner, name, default, args.ref, branch
                             )
                             outcomes.append(
-                                RepoOutcome(name, "published", f"{result.callers} callers", base, head, url, refreshed + synced)
+                                RepoOutcome(name, "published", f"{result.callers} callers", base, head, url, written_secrets)
                             )
                         else:
                             outcomes.append(
-                                RepoOutcome(name, args.mode, f"{result.callers} callers", base, synced_secrets=refreshed + synced)
+                                RepoOutcome(name, args.mode, f"{result.callers} callers", base, synced_secrets=written_secrets)
                             )
                 finally:
                     if preview is not None:
                         preview.cleanup()
             except (CommandError, RolloutError, OSError, json.JSONDecodeError) as exc:
-                outcomes.append(RepoOutcome(name, "blocked", str(exc)))
+                outcomes.append(
+                    RepoOutcome(
+                        name,
+                        "blocked",
+                        str(exc),
+                        synced_secrets=tuple(
+                            dict.fromkeys(refreshed_progress + synced_progress)
+                        ),
+                    )
+                )
             except Exception as exc:
                 outcomes.append(
                     RepoOutcome(
                         name,
                         "blocked",
                         f"unexpected {type(exc).__name__}: {exc}",
+                        synced_secrets=tuple(
+                            dict.fromkeys(refreshed_progress + synced_progress)
+                        ),
                     )
                 )
     finally:

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -260,9 +260,11 @@ def prepare_with_prerequisites(
     sync_missing_enabled: bool,
     allow_personal_oauth_fanout: bool,
     allowed_env_secrets: set[str],
+    deferred_secrets: set[str] | None = None,
     completed: list[str] | None = None,
 ) -> tuple[object, tuple[str, ...]]:
-    secrets = remote_names(owner, repo, "secret")
+    deferred_secrets = deferred_secrets or set()
+    secrets = remote_names(owner, repo, "secret") | deferred_secrets
     variables = remote_names(owner, repo, "variable")
     synced_all: list[str] = []
     while True:
@@ -280,6 +282,7 @@ def prepare_with_prerequisites(
                 allowed_env_secrets=allowed_env_secrets,
                 completed=completed,
             )
+            secrets |= deferred_secrets
             synced_all.extend(name for name in synced if name not in synced_all)
             if secrets == previous:
                 raise error
@@ -527,18 +530,12 @@ def main(argv: list[str] | None = None) -> int:
             refreshed_progress: list[str] = []
             synced_progress: list[str] = []
             try:
-                if args.refresh_secret:
-                    if repo_config[name].get("secrets", True) is False:
-                        raise RolloutError(
-                            f"{name}: secret writes are disabled by config"
-                        )
-                    refresh_secrets(
-                        owner,
-                        name,
-                        set(args.refresh_secret),
-                        args.allow_personal_oauth_fanout,
-                        allowed_env_secrets,
-                        refreshed_progress,
+                if (
+                    args.refresh_secret
+                    and repo_config[name].get("secrets", True) is False
+                ):
+                    raise RolloutError(
+                        f"{name}: secret writes are disabled by config"
                     )
                 if repo_config[name].get("workflows", True) is False:
                     outcomes.append(
@@ -546,7 +543,6 @@ def main(argv: list[str] | None = None) -> int:
                             name,
                             "skipped",
                             "workflows disabled by config",
-                            synced_secrets=tuple(refreshed_progress),
                         )
                     )
                     continue
@@ -571,10 +567,8 @@ def main(argv: list[str] | None = None) -> int:
                         and repo_config[name].get("secrets", True) is not False,
                         args.allow_personal_oauth_fanout,
                         allowed_env_secrets,
+                        set(args.refresh_secret),
                         synced_progress,
-                    )
-                    written_secrets = tuple(
-                        dict.fromkeys(refreshed_progress + synced_progress)
                     )
                     if result.callers == 0:
                         outcomes.append(
@@ -583,10 +577,40 @@ def main(argv: list[str] | None = None) -> int:
                                 "skipped",
                                 "no existing central callers",
                                 base,
-                                synced_secrets=written_secrets,
+                                synced_secrets=tuple(synced_progress),
                             )
                         )
-                    elif not result.changed_files:
+                        continue
+                    unrequired_refresh = set(args.refresh_secret) - set(
+                        result.required_secrets
+                    )
+                    if unrequired_refresh:
+                        raise RolloutError(
+                            f"{name}: refresh secrets not required by managed callers: "
+                            + ", ".join(sorted(unrequired_refresh))
+                        )
+                    if result.changed_files:
+                        validate_repository(
+                            target,
+                            contract_source,
+                            args.actionlint,
+                            baseline_repo=repo if args.mode == "plan" else None,
+                        )
+                    if args.refresh_secret:
+                        refresh_names = set(args.refresh_secret) - set(synced_progress)
+                        if refresh_names:
+                            refresh_secrets(
+                                owner,
+                                name,
+                                refresh_names,
+                                args.allow_personal_oauth_fanout,
+                                allowed_env_secrets,
+                                refreshed_progress,
+                            )
+                    written_secrets = tuple(
+                        dict.fromkeys(refreshed_progress + synced_progress)
+                    )
+                    if not result.changed_files:
                         outcomes.append(
                             RepoOutcome(
                                 name,
@@ -597,12 +621,6 @@ def main(argv: list[str] | None = None) -> int:
                             )
                         )
                     else:
-                        validate_repository(
-                            target,
-                            contract_source,
-                            args.actionlint,
-                            baseline_repo=repo if args.mode == "plan" else None,
-                        )
                         if args.mode == "publish":
                             head, url = publish_repository(
                                 repo, owner, name, default, args.ref, branch

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -221,6 +221,30 @@ def sync_missing(
     return available, tuple(synced)
 
 
+def refresh_secrets(
+    owner: str,
+    repo: str,
+    names: set[str],
+    allow_personal_oauth_fanout: bool,
+    allowed_env_secrets: set[str],
+) -> tuple[str, ...]:
+    refreshed: list[str] = []
+    for name in sorted(names):
+        value = secret_source(
+            name, allow_personal_oauth_fanout, allowed_env_secrets
+        )
+        if value is None:
+            raise RolloutError(
+                f"{owner}/{repo}: no explicitly allowed source for refresh secret {name}"
+            )
+        run(
+            ["gh", "secret", "set", name, "-R", f"{owner}/{repo}", "--body", "-"],
+            input_text=value,
+        )
+        refreshed.append(name)
+    return tuple(refreshed)
+
+
 def prepare_with_prerequisites(
     repo_path: Path,
     automation: Path,
@@ -402,6 +426,13 @@ def main(argv: list[str] | None = None) -> int:
         metavar="NAME",
         help="allow this exact environment variable as a missing-secret source",
     )
+    parser.add_argument(
+        "--refresh-secret",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="replace this existing or missing secret from an explicitly allowed source",
+    )
     parser.add_argument("--actionlint", type=Path)
     parser.add_argument("--confirm", action="store_true")
     parser.add_argument("--manifest", type=Path)
@@ -430,11 +461,36 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--allow-personal-oauth-fanout requires --sync-missing-secrets")
     if args.allow_env_secret and not args.sync_missing_secrets:
         parser.error("--allow-env-secret requires --sync-missing-secrets")
+    if args.refresh_secret and (
+        args.mode != "publish" or not args.sync_missing_secrets
+    ):
+        parser.error(
+            "--refresh-secret requires --mode publish and --sync-missing-secrets"
+        )
     invalid_env_names = [
         name for name in args.allow_env_secret if re.fullmatch(r"[A-Z][A-Z0-9_]*", name) is None
     ]
     if invalid_env_names:
         parser.error(f"invalid secret environment names: {', '.join(invalid_env_names)}")
+    invalid_refresh_names = [
+        name for name in args.refresh_secret if re.fullmatch(r"[A-Z][A-Z0-9_]*", name) is None
+    ]
+    if invalid_refresh_names:
+        parser.error(f"invalid refresh secret names: {', '.join(invalid_refresh_names)}")
+    refresh_without_source = sorted(
+        name
+        for name in set(args.refresh_secret)
+        if name not in set(args.allow_env_secret)
+        and not (
+            name == "CLAUDE_CODE_OAUTH_TOKEN"
+            and args.allow_personal_oauth_fanout
+        )
+    )
+    if refresh_without_source:
+        parser.error(
+            "--refresh-secret requires an exact --allow-env-secret source: "
+            + ", ".join(refresh_without_source)
+        )
 
     marker = args.workspace / ".automation-fleet-workspace"
     if not marker.is_file():
@@ -459,9 +515,27 @@ def main(argv: list[str] | None = None) -> int:
     try:
         for name in repos:
             try:
+                refreshed: tuple[str, ...] = ()
+                if args.refresh_secret:
+                    if repo_config[name].get("secrets", True) is False:
+                        raise RolloutError(
+                            f"{name}: secret writes are disabled by config"
+                        )
+                    refreshed = refresh_secrets(
+                        owner,
+                        name,
+                        set(args.refresh_secret),
+                        args.allow_personal_oauth_fanout,
+                        allowed_env_secrets,
+                    )
                 if repo_config[name].get("workflows", True) is False:
                     outcomes.append(
-                        RepoOutcome(name, "skipped", "workflows disabled by config")
+                        RepoOutcome(
+                            name,
+                            "skipped",
+                            "workflows disabled by config",
+                            synced_secrets=refreshed,
+                        )
                     )
                     continue
                 default = default_branch(owner, name)
@@ -487,9 +561,25 @@ def main(argv: list[str] | None = None) -> int:
                         allowed_env_secrets,
                     )
                     if result.callers == 0:
-                        outcomes.append(RepoOutcome(name, "skipped", "no existing central callers", base))
+                        outcomes.append(
+                            RepoOutcome(
+                                name,
+                                "skipped",
+                                "no existing central callers",
+                                base,
+                                synced_secrets=refreshed + synced,
+                            )
+                        )
                     elif not result.changed_files:
-                        outcomes.append(RepoOutcome(name, "current", "already matches contract", base))
+                        outcomes.append(
+                            RepoOutcome(
+                                name,
+                                "current",
+                                "already matches contract",
+                                base,
+                                synced_secrets=refreshed + synced,
+                            )
+                        )
                     else:
                         validate_repository(
                             target,
@@ -502,11 +592,11 @@ def main(argv: list[str] | None = None) -> int:
                                 repo, owner, name, default, args.ref, branch
                             )
                             outcomes.append(
-                                RepoOutcome(name, "published", f"{result.callers} callers", base, head, url, synced)
+                                RepoOutcome(name, "published", f"{result.callers} callers", base, head, url, refreshed + synced)
                             )
                         else:
                             outcomes.append(
-                                RepoOutcome(name, args.mode, f"{result.callers} callers", base, synced_secrets=synced)
+                                RepoOutcome(name, args.mode, f"{result.callers} callers", base, synced_secrets=refreshed + synced)
                             )
                 finally:
                     if preview is not None:

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -475,6 +475,8 @@ def main(argv: list[str] | None = None) -> int:
         parser.error(
             "--refresh-secret requires --mode publish and --sync-missing-secrets"
         )
+    if args.refresh_secret and not args.repo:
+        parser.error("--refresh-secret requires at least one explicit --repo")
     invalid_env_names = [
         name for name in args.allow_env_secret if re.fullmatch(r"[A-Z][A-Z0-9_]*", name) is None
     ]

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -581,13 +581,13 @@ def main(argv: list[str] | None = None) -> int:
                             )
                         )
                         continue
-                    unrequired_refresh = set(args.refresh_secret) - set(
+                    undeclared_refresh = set(args.refresh_secret) - set(
                         result.required_secrets
                     )
-                    if unrequired_refresh:
+                    if undeclared_refresh:
                         raise RolloutError(
-                            f"{name}: refresh secrets not required by managed callers: "
-                            + ", ".join(sorted(unrequired_refresh))
+                            f"{name}: refresh secrets not declared by managed callers: "
+                            + ", ".join(sorted(undeclared_refresh))
                         )
                     if result.changed_files:
                         validate_repository(
@@ -597,16 +597,14 @@ def main(argv: list[str] | None = None) -> int:
                             baseline_repo=repo if args.mode == "plan" else None,
                         )
                     if args.refresh_secret:
-                        refresh_names = set(args.refresh_secret) - set(synced_progress)
-                        if refresh_names:
-                            refresh_secrets(
-                                owner,
-                                name,
-                                refresh_names,
-                                args.allow_personal_oauth_fanout,
-                                allowed_env_secrets,
-                                refreshed_progress,
-                            )
+                        refresh_secrets(
+                            owner,
+                            name,
+                            set(args.refresh_secret),
+                            args.allow_personal_oauth_fanout,
+                            allowed_env_secrets,
+                            refreshed_progress,
+                        )
                     written_secrets = tuple(
                         dict.fromkeys(refreshed_progress + synced_progress)
                     )

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -189,6 +189,44 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
                 )
             materialize.assert_not_called()
 
+    def test_refresh_secret_requires_an_exact_allowed_source_before_side_effects(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            (workspace / ".automation-fleet-workspace").write_text("managed\n")
+            config = root / "config.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "gh_owner": "owner",
+                        "repos": {"repo": {"workflows": True, "secrets": True}},
+                    }
+                )
+            )
+            with patch(
+                "scripts.rollout_workflow_fleet.materialize_release_contract"
+            ) as materialize, self.assertRaises(SystemExit):
+                main(
+                    [
+                        "--automation",
+                        str(ROOT),
+                        "--config",
+                        str(config),
+                        "--workspace",
+                        str(workspace),
+                        "--mode",
+                        "publish",
+                        "--confirm",
+                        "--sync-missing-secrets",
+                        "--refresh-secret",
+                        "ZHIPU_API_KEY",
+                        "--repo",
+                        "repo",
+                    ]
+                )
+            materialize.assert_not_called()
+
     def test_refresh_secret_overwrites_existing_value_via_stdin_only(self) -> None:
         calls: list[tuple[list[str], str | None]] = []
 
@@ -477,12 +515,19 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
             )
             release_temp = Mock()
             current = RolloutResult(1, (), frozenset({"ZHIPU_API_KEY"}))
+
+            def complete_refresh(*args: object) -> tuple[str, ...]:
+                completed = args[-1]
+                self.assertIsInstance(completed, list)
+                completed.append("ZHIPU_API_KEY")  # type: ignore[union-attr]
+                return ("ZHIPU_API_KEY",)
+
             with patch(
                 "scripts.rollout_workflow_fleet.materialize_release_contract",
                 return_value=(release_temp, Path("/contract"), "release-sha"),
             ), patch(
                 "scripts.rollout_workflow_fleet.refresh_secrets",
-                return_value=("ZHIPU_API_KEY",),
+                side_effect=complete_refresh,
             ) as refresh, patch(
                 "scripts.rollout_workflow_fleet.default_branch", return_value="main"
             ), patch(
@@ -583,12 +628,19 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
                 )
             )
             release_temp = Mock()
+
+            def complete_refresh(*args: object) -> tuple[str, ...]:
+                completed = args[-1]
+                self.assertIsInstance(completed, list)
+                completed.append("ZHIPU_API_KEY")  # type: ignore[union-attr]
+                return ("ZHIPU_API_KEY",)
+
             with patch(
                 "scripts.rollout_workflow_fleet.materialize_release_contract",
                 return_value=(release_temp, Path("/contract"), "release-sha"),
             ), patch(
                 "scripts.rollout_workflow_fleet.refresh_secrets",
-                return_value=("ZHIPU_API_KEY",),
+                side_effect=complete_refresh,
             ), patch(
                 "scripts.rollout_workflow_fleet.default_branch",
                 side_effect=CommandError("metadata unavailable"),

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -127,6 +127,50 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
                 secret_source("GEMINI_API_KEY", False, {"GEMINI_API_KEY"}),
             )
 
+    def test_refresh_secret_requires_publish_sync_and_exact_source_allowlist(self) -> None:
+        cases = [
+            ["--mode", "plan", "--refresh-secret", "ZHIPU_API_KEY"],
+            ["--mode", "publish", "--confirm", "--refresh-secret", "ZHIPU_API_KEY"],
+            [
+                "--mode",
+                "publish",
+                "--confirm",
+                "--sync-missing-secrets",
+                "--refresh-secret",
+                "ZHIPU_API_KEY",
+            ],
+        ]
+        with tempfile.TemporaryDirectory() as temp, patch(
+            "scripts.rollout_workflow_fleet.materialize_release_contract"
+        ) as materialize:
+            for extra in cases:
+                with self.subTest(extra=extra), self.assertRaises(SystemExit):
+                    main(["--workspace", temp, *extra])
+            materialize.assert_not_called()
+
+    def test_refresh_secret_overwrites_existing_value_via_stdin_only(self) -> None:
+        calls: list[tuple[list[str], str | None]] = []
+
+        def fake_run(args: list[str], **kwargs: object) -> str:
+            calls.append((args, kwargs.get("input_text")))  # type: ignore[arg-type]
+            return ""
+
+        with patch.dict(os.environ, {"ZHIPU_API_KEY": "rotated-value"}), patch(
+            "scripts.rollout_workflow_fleet.run", side_effect=fake_run
+        ):
+            from scripts.rollout_workflow_fleet import refresh_secrets
+
+            refreshed = refresh_secrets(
+                "owner",
+                "repo",
+                {"ZHIPU_API_KEY"},
+                False,
+                {"ZHIPU_API_KEY"},
+            )
+        self.assertEqual(("ZHIPU_API_KEY",), refreshed)
+        self.assertEqual("rotated-value", calls[0][1])
+        self.assertNotIn("rotated-value", calls[0][0])
+
     def test_missing_default_branch_becomes_a_command_error(self) -> None:
         with patch(
             "scripts.rollout_workflow_fleet.gh_json",
@@ -331,6 +375,63 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
             self.assertEqual(["published", "blocked"], [item["status"] for item in manifest])
             self.assertEqual("https://example.test/pr/1", manifest[0]["pr_url"])
             self.assertIn("unexpected ValueError", manifest[1]["detail"])
+            release_temp.cleanup.assert_called_once()
+
+    def test_main_refreshes_existing_secret_before_current_contract_result(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            (workspace / ".automation-fleet-workspace").write_text("managed\n")
+            config = root / "config.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "gh_owner": "owner",
+                        "repos": {"repo": {"workflows": True, "secrets": True}},
+                    }
+                )
+            )
+            release_temp = Mock()
+            current = RolloutResult(1, (), frozenset({"ZHIPU_API_KEY"}))
+            with patch(
+                "scripts.rollout_workflow_fleet.materialize_release_contract",
+                return_value=(release_temp, Path("/contract"), "release-sha"),
+            ), patch(
+                "scripts.rollout_workflow_fleet.refresh_secrets",
+                return_value=("ZHIPU_API_KEY",),
+            ) as refresh, patch(
+                "scripts.rollout_workflow_fleet.default_branch", return_value="main"
+            ), patch(
+                "scripts.rollout_workflow_fleet.clone_or_reset",
+                return_value=(Path("/clone/repo"), "base-sha"),
+            ), patch(
+                "scripts.rollout_workflow_fleet.prepare_with_prerequisites",
+                return_value=(current, ()),
+            ):
+                rc = main(
+                    [
+                        "--automation",
+                        str(ROOT),
+                        "--config",
+                        str(config),
+                        "--workspace",
+                        str(workspace),
+                        "--mode",
+                        "publish",
+                        "--confirm",
+                        "--sync-missing-secrets",
+                        "--allow-env-secret",
+                        "ZHIPU_API_KEY",
+                        "--refresh-secret",
+                        "ZHIPU_API_KEY",
+                    ]
+                )
+            self.assertEqual(0, rc)
+            refresh.assert_called_once()
+            manifest = json.loads((workspace / "rollout-manifest.json").read_text())
+            self.assertEqual("current", manifest[0]["status"])
+            self.assertEqual(["ZHIPU_API_KEY"], manifest[0]["synced_secrets"])
             release_temp.cleanup.assert_called_once()
 
     @staticmethod

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -24,8 +24,11 @@ from scripts.rollout_workflow_fleet import (
     secret_source,
     sync_missing,
 )
-from scripts.prepare_workflow_rollout import SecretPrerequisiteError
-from scripts.prepare_workflow_rollout import RolloutResult
+from scripts.prepare_workflow_rollout import (
+    RolloutError,
+    RolloutResult,
+    SecretPrerequisiteError,
+)
 
 
 SECURE_WORKFLOW = """\
@@ -171,6 +174,26 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
         self.assertEqual("rotated-value", calls[0][1])
         self.assertNotIn("rotated-value", calls[0][0])
 
+    def test_refresh_secret_reports_partial_writes_when_a_later_source_is_missing(self) -> None:
+        completed: list[str] = []
+        with patch(
+            "scripts.rollout_workflow_fleet.secret_source",
+            side_effect=["first-value", None],
+        ), patch("scripts.rollout_workflow_fleet.run") as run:
+            from scripts.rollout_workflow_fleet import refresh_secrets
+
+            with self.assertRaisesRegex(RolloutError, "no explicitly allowed source"):
+                refresh_secrets(
+                    "owner",
+                    "repo",
+                    {"FIRST", "SECOND"},
+                    False,
+                    {"FIRST", "SECOND"},
+                    completed,
+                )
+        self.assertEqual(["FIRST"], completed)
+        run.assert_called_once()
+
     def test_missing_default_branch_becomes_a_command_error(self) -> None:
         with patch(
             "scripts.rollout_workflow_fleet.gh_json",
@@ -196,6 +219,28 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
         self.assertEqual(("TOKEN",), synced)
         self.assertEqual("sensitive-value", calls[0][1])
         self.assertNotIn("sensitive-value", calls[0][0])
+
+    def test_sync_missing_reports_partial_writes_when_a_later_write_fails(self) -> None:
+        completed: list[str] = []
+        with patch(
+            "scripts.rollout_workflow_fleet.remote_names", return_value=set()
+        ), patch(
+            "scripts.rollout_workflow_fleet.secret_source", return_value="value"
+        ), patch(
+            "scripts.rollout_workflow_fleet.run",
+            side_effect=["", CommandError("second write failed")],
+        ):
+            with self.assertRaisesRegex(CommandError, "second write failed"):
+                sync_missing(
+                    "owner",
+                    "repo",
+                    {"FIRST", "SECOND"},
+                    True,
+                    False,
+                    {"FIRST", "SECOND"},
+                    completed,
+                )
+        self.assertEqual(["FIRST"], completed)
 
     def test_multiple_missing_secrets_are_synced_until_prepare_succeeds(self) -> None:
         first = SecretPrerequisiteError("missing first", {"FIRST_TOKEN"})
@@ -432,6 +477,111 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
             manifest = json.loads((workspace / "rollout-manifest.json").read_text())
             self.assertEqual("current", manifest[0]["status"])
             self.assertEqual(["ZHIPU_API_KEY"], manifest[0]["synced_secrets"])
+            release_temp.cleanup.assert_called_once()
+
+    def test_main_records_refreshed_secret_when_a_later_step_is_blocked(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            (workspace / ".automation-fleet-workspace").write_text("managed\n")
+            config = root / "config.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "gh_owner": "owner",
+                        "repos": {"repo": {"workflows": True, "secrets": True}},
+                    }
+                )
+            )
+            release_temp = Mock()
+            with patch(
+                "scripts.rollout_workflow_fleet.materialize_release_contract",
+                return_value=(release_temp, Path("/contract"), "release-sha"),
+            ), patch(
+                "scripts.rollout_workflow_fleet.refresh_secrets",
+                return_value=("ZHIPU_API_KEY",),
+            ), patch(
+                "scripts.rollout_workflow_fleet.default_branch",
+                side_effect=CommandError("metadata unavailable"),
+            ):
+                rc = main(
+                    [
+                        "--automation",
+                        str(ROOT),
+                        "--config",
+                        str(config),
+                        "--workspace",
+                        str(workspace),
+                        "--mode",
+                        "publish",
+                        "--confirm",
+                        "--sync-missing-secrets",
+                        "--allow-env-secret",
+                        "ZHIPU_API_KEY",
+                        "--refresh-secret",
+                        "ZHIPU_API_KEY",
+                    ]
+                )
+            self.assertEqual(1, rc)
+            manifest = json.loads((workspace / "rollout-manifest.json").read_text())
+            self.assertEqual("blocked", manifest[0]["status"])
+            self.assertEqual(["ZHIPU_API_KEY"], manifest[0]["synced_secrets"])
+            release_temp.cleanup.assert_called_once()
+
+    def test_main_records_partially_synced_secret_when_prepare_is_blocked(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            (workspace / ".automation-fleet-workspace").write_text("managed\n")
+            config = root / "config.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "gh_owner": "owner",
+                        "repos": {"repo": {"workflows": True, "secrets": True}},
+                    }
+                )
+            )
+            release_temp = Mock()
+
+            def fail_after_sync(*args: object) -> object:
+                completed = args[-1]
+                self.assertIsInstance(completed, list)
+                completed.append("FIRST")  # type: ignore[union-attr]
+                raise CommandError("second write failed")
+
+            with patch(
+                "scripts.rollout_workflow_fleet.materialize_release_contract",
+                return_value=(release_temp, Path("/contract"), "release-sha"),
+            ), patch(
+                "scripts.rollout_workflow_fleet.default_branch", return_value="main"
+            ), patch(
+                "scripts.rollout_workflow_fleet.clone_or_reset",
+                return_value=(Path("/clone/repo"), "base-sha"),
+            ), patch(
+                "scripts.rollout_workflow_fleet.prepare_with_prerequisites",
+                side_effect=fail_after_sync,
+            ):
+                rc = main(
+                    [
+                        "--automation",
+                        str(ROOT),
+                        "--config",
+                        str(config),
+                        "--workspace",
+                        str(workspace),
+                        "--mode",
+                        "publish",
+                        "--confirm",
+                        "--sync-missing-secrets",
+                    ]
+                )
+            self.assertEqual(1, rc)
+            manifest = json.loads((workspace / "rollout-manifest.json").read_text())
+            self.assertEqual("blocked", manifest[0]["status"])
+            self.assertEqual(["FIRST"], manifest[0]["synced_secrets"])
             release_temp.cleanup.assert_called_once()
 
     @staticmethod

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -816,7 +816,7 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
             self.assertEqual(["ZHIPU_API_KEY"], manifest[0]["synced_secrets"])
             release_temp.cleanup.assert_called_once()
 
-    def test_main_blocks_refresh_name_not_required_by_managed_callers(self) -> None:
+    def test_main_blocks_refresh_name_not_declared_by_managed_callers(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             workspace = root / "workspace"
@@ -871,7 +871,7 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
             refresh.assert_not_called()
             manifest = json.loads((workspace / "rollout-manifest.json").read_text())
             self.assertEqual("blocked", manifest[0]["status"])
-            self.assertIn("not required by managed callers", manifest[0]["detail"])
+            self.assertIn("not declared by managed callers", manifest[0]["detail"])
 
     def test_main_records_partially_synced_secret_when_prepare_is_blocked(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -151,6 +151,44 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
                     main(["--workspace", temp, *extra])
             materialize.assert_not_called()
 
+    def test_refresh_secret_requires_an_explicit_repository_before_side_effects(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            (workspace / ".automation-fleet-workspace").write_text("managed\n")
+            config = root / "config.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "gh_owner": "owner",
+                        "repos": {"repo": {"workflows": True, "secrets": True}},
+                    }
+                )
+            )
+            with patch(
+                "scripts.rollout_workflow_fleet.materialize_release_contract"
+            ) as materialize, self.assertRaises(SystemExit):
+                main(
+                    [
+                        "--automation",
+                        str(ROOT),
+                        "--config",
+                        str(config),
+                        "--workspace",
+                        str(workspace),
+                        "--mode",
+                        "publish",
+                        "--confirm",
+                        "--sync-missing-secrets",
+                        "--allow-env-secret",
+                        "ZHIPU_API_KEY",
+                        "--refresh-secret",
+                        "ZHIPU_API_KEY",
+                    ]
+                )
+            materialize.assert_not_called()
+
     def test_refresh_secret_overwrites_existing_value_via_stdin_only(self) -> None:
         calls: list[tuple[list[str], str | None]] = []
 
@@ -470,6 +508,8 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
                         "ZHIPU_API_KEY",
                         "--refresh-secret",
                         "ZHIPU_API_KEY",
+                        "--repo",
+                        "repo",
                     ]
                 )
             self.assertEqual(0, rc)
@@ -477,6 +517,54 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
             manifest = json.loads((workspace / "rollout-manifest.json").read_text())
             self.assertEqual("current", manifest[0]["status"])
             self.assertEqual(["ZHIPU_API_KEY"], manifest[0]["synced_secrets"])
+            release_temp.cleanup.assert_called_once()
+
+    def test_main_blocks_refresh_when_secret_writes_are_disabled_by_config(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            (workspace / ".automation-fleet-workspace").write_text("managed\n")
+            config = root / "config.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "gh_owner": "owner",
+                        "repos": {"repo": {"workflows": True, "secrets": False}},
+                    }
+                )
+            )
+            release_temp = Mock()
+            with patch(
+                "scripts.rollout_workflow_fleet.materialize_release_contract",
+                return_value=(release_temp, Path("/contract"), "release-sha"),
+            ), patch("scripts.rollout_workflow_fleet.refresh_secrets") as refresh:
+                rc = main(
+                    [
+                        "--automation",
+                        str(ROOT),
+                        "--config",
+                        str(config),
+                        "--workspace",
+                        str(workspace),
+                        "--mode",
+                        "publish",
+                        "--confirm",
+                        "--sync-missing-secrets",
+                        "--allow-env-secret",
+                        "ZHIPU_API_KEY",
+                        "--refresh-secret",
+                        "ZHIPU_API_KEY",
+                        "--repo",
+                        "repo",
+                    ]
+                )
+            self.assertEqual(1, rc)
+            refresh.assert_not_called()
+            manifest = json.loads((workspace / "rollout-manifest.json").read_text())
+            self.assertEqual("blocked", manifest[0]["status"])
+            self.assertIn("secret writes are disabled", manifest[0]["detail"])
+            self.assertEqual([], manifest[0]["synced_secrets"])
             release_temp.cleanup.assert_called_once()
 
     def test_main_records_refreshed_secret_when_a_later_step_is_blocked(self) -> None:
@@ -521,6 +609,8 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
                         "ZHIPU_API_KEY",
                         "--refresh-secret",
                         "ZHIPU_API_KEY",
+                        "--repo",
+                        "repo",
                     ]
                 )
             self.assertEqual(1, rc)

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -349,6 +349,35 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
         self.assertEqual(("FIRST_TOKEN", "SECOND_TOKEN"), synced)
         self.assertEqual(2, sync.call_count)
 
+    def test_deferred_refresh_secret_is_available_to_prepare_without_early_write(self) -> None:
+        prepared = object()
+        completed: list[str] = []
+        with patch(
+            "scripts.rollout_workflow_fleet.remote_names",
+            side_effect=[set(), set()],
+        ), patch(
+            "scripts.rollout_workflow_fleet.prepare_repository",
+            return_value=prepared,
+        ) as prepare, patch(
+            "scripts.rollout_workflow_fleet.sync_missing"
+        ) as sync:
+            result, synced = prepare_with_prerequisites(
+                Path("/tmp/repo"),
+                Path("/tmp/automation"),
+                "v1.35",
+                "owner",
+                "repo",
+                True,
+                False,
+                {"TOKEN"},
+                {"TOKEN"},
+                completed,
+            )
+        self.assertIs(prepared, result)
+        self.assertEqual((), synced)
+        self.assertEqual({"TOKEN"}, prepare.call_args.args[3])
+        sync.assert_not_called()
+
     def test_release_contract_is_read_from_verified_tag_not_newer_head(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             repo = Path(temp) / "repo"
@@ -612,7 +641,54 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
             self.assertEqual([], manifest[0]["synced_secrets"])
             release_temp.cleanup.assert_called_once()
 
-    def test_main_records_refreshed_secret_when_a_later_step_is_blocked(self) -> None:
+    def test_main_skips_refresh_when_workflows_are_disabled_by_config(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            (workspace / ".automation-fleet-workspace").write_text("managed\n")
+            config = root / "config.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "gh_owner": "owner",
+                        "repos": {"repo": {"workflows": False, "secrets": True}},
+                    }
+                )
+            )
+            release_temp = Mock()
+            with patch(
+                "scripts.rollout_workflow_fleet.materialize_release_contract",
+                return_value=(release_temp, Path("/contract"), "release-sha"),
+            ), patch("scripts.rollout_workflow_fleet.refresh_secrets") as refresh:
+                rc = main(
+                    [
+                        "--automation",
+                        str(ROOT),
+                        "--config",
+                        str(config),
+                        "--workspace",
+                        str(workspace),
+                        "--mode",
+                        "publish",
+                        "--confirm",
+                        "--sync-missing-secrets",
+                        "--allow-env-secret",
+                        "ZHIPU_API_KEY",
+                        "--refresh-secret",
+                        "ZHIPU_API_KEY",
+                        "--repo",
+                        "repo",
+                    ]
+                )
+            self.assertEqual(0, rc)
+            refresh.assert_not_called()
+            manifest = json.loads((workspace / "rollout-manifest.json").read_text())
+            self.assertEqual("skipped", manifest[0]["status"])
+            self.assertEqual([], manifest[0]["synced_secrets"])
+            release_temp.cleanup.assert_called_once()
+
+    def test_main_does_not_refresh_secret_when_repository_metadata_is_blocked(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             workspace = root / "workspace"
@@ -629,19 +705,12 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
             )
             release_temp = Mock()
 
-            def complete_refresh(*args: object) -> tuple[str, ...]:
-                completed = args[-1]
-                self.assertIsInstance(completed, list)
-                completed.append("ZHIPU_API_KEY")  # type: ignore[union-attr]
-                return ("ZHIPU_API_KEY",)
-
             with patch(
                 "scripts.rollout_workflow_fleet.materialize_release_contract",
                 return_value=(release_temp, Path("/contract"), "release-sha"),
             ), patch(
                 "scripts.rollout_workflow_fleet.refresh_secrets",
-                side_effect=complete_refresh,
-            ), patch(
+            ) as refresh, patch(
                 "scripts.rollout_workflow_fleet.default_branch",
                 side_effect=CommandError("metadata unavailable"),
             ):
@@ -668,8 +737,141 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
             self.assertEqual(1, rc)
             manifest = json.loads((workspace / "rollout-manifest.json").read_text())
             self.assertEqual("blocked", manifest[0]["status"])
+            self.assertEqual([], manifest[0]["synced_secrets"])
+            refresh.assert_not_called()
+            release_temp.cleanup.assert_called_once()
+
+    def test_main_records_refresh_when_publish_is_blocked_after_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            (workspace / ".automation-fleet-workspace").write_text("managed\n")
+            config = root / "config.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "gh_owner": "owner",
+                        "repos": {"repo": {"workflows": True, "secrets": True}},
+                    }
+                )
+            )
+            release_temp = Mock()
+            changed = RolloutResult(
+                1,
+                (Path(".github/workflows/opencode.yml"),),
+                frozenset({"ZHIPU_API_KEY"}),
+            )
+
+            def complete_refresh(*args: object) -> tuple[str, ...]:
+                completed = args[-1]
+                self.assertIsInstance(completed, list)
+                completed.append("ZHIPU_API_KEY")  # type: ignore[union-attr]
+                return ("ZHIPU_API_KEY",)
+
+            with patch(
+                "scripts.rollout_workflow_fleet.materialize_release_contract",
+                return_value=(release_temp, Path("/contract"), "release-sha"),
+            ), patch(
+                "scripts.rollout_workflow_fleet.default_branch", return_value="main"
+            ), patch(
+                "scripts.rollout_workflow_fleet.clone_or_reset",
+                return_value=(Path("/clone/repo"), "base-sha"),
+            ), patch(
+                "scripts.rollout_workflow_fleet.prepare_with_prerequisites",
+                return_value=(changed, ()),
+            ), patch(
+                "scripts.rollout_workflow_fleet.validate_repository"
+            ) as validate, patch(
+                "scripts.rollout_workflow_fleet.refresh_secrets",
+                side_effect=complete_refresh,
+            ), patch(
+                "scripts.rollout_workflow_fleet.publish_repository",
+                side_effect=CommandError("push failed"),
+            ):
+                rc = main(
+                    [
+                        "--automation",
+                        str(ROOT),
+                        "--config",
+                        str(config),
+                        "--workspace",
+                        str(workspace),
+                        "--mode",
+                        "publish",
+                        "--confirm",
+                        "--sync-missing-secrets",
+                        "--allow-env-secret",
+                        "ZHIPU_API_KEY",
+                        "--refresh-secret",
+                        "ZHIPU_API_KEY",
+                        "--repo",
+                        "repo",
+                    ]
+                )
+            self.assertEqual(1, rc)
+            validate.assert_called_once()
+            manifest = json.loads((workspace / "rollout-manifest.json").read_text())
+            self.assertEqual("blocked", manifest[0]["status"])
             self.assertEqual(["ZHIPU_API_KEY"], manifest[0]["synced_secrets"])
             release_temp.cleanup.assert_called_once()
+
+    def test_main_blocks_refresh_name_not_required_by_managed_callers(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            (workspace / ".automation-fleet-workspace").write_text("managed\n")
+            config = root / "config.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "gh_owner": "owner",
+                        "repos": {"repo": {"workflows": True, "secrets": True}},
+                    }
+                )
+            )
+            release_temp = Mock()
+            current = RolloutResult(1, (), frozenset())
+            with patch(
+                "scripts.rollout_workflow_fleet.materialize_release_contract",
+                return_value=(release_temp, Path("/contract"), "release-sha"),
+            ), patch(
+                "scripts.rollout_workflow_fleet.default_branch", return_value="main"
+            ), patch(
+                "scripts.rollout_workflow_fleet.clone_or_reset",
+                return_value=(Path("/clone/repo"), "base-sha"),
+            ), patch(
+                "scripts.rollout_workflow_fleet.prepare_with_prerequisites",
+                return_value=(current, ()),
+            ), patch(
+                "scripts.rollout_workflow_fleet.refresh_secrets"
+            ) as refresh:
+                rc = main(
+                    [
+                        "--automation",
+                        str(ROOT),
+                        "--config",
+                        str(config),
+                        "--workspace",
+                        str(workspace),
+                        "--mode",
+                        "publish",
+                        "--confirm",
+                        "--sync-missing-secrets",
+                        "--allow-env-secret",
+                        "ZHIPU_API_KEY",
+                        "--refresh-secret",
+                        "ZHIPU_API_KEY",
+                        "--repo",
+                        "repo",
+                    ]
+                )
+            self.assertEqual(1, rc)
+            refresh.assert_not_called()
+            manifest = json.loads((workspace / "rollout-manifest.json").read_text())
+            self.assertEqual("blocked", manifest[0]["status"])
+            self.assertIn("not required by managed callers", manifest[0]["detail"])
 
     def test_main_records_partially_synced_secret_when_prepare_is_blocked(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
Add a fail-closed `--refresh-secret` path so an operator can rotate an existing expired key, fill missing copies, and publish workflow PRs in one staged command.

Safety gates:
- `publish + --confirm + --sync-missing-secrets` required
- at least one explicit `--repo` is required; refresh can never default to the whole configured fleet
- exact `--allow-env-secret NAME` required (or explicit Claude OAuth fan-out consent)
- refresh names must be declared by an existing managed caller contract (required or optional)
- repository metadata, caller preparation, and changed-workflow validation complete before refresh writes
- workflow-disabled/callerless repositories are not refreshed
- secret values go through stdin only and never logs/argv/manifest
- per-repo config can disable writes; failures remain isolated
- completed secret names remain in the manifest even when a later write or PR publish fails

This addresses the observed wlan-driver ZHIPU secret whose name exists but value returns 401, while wlan-driver-v2 and wlan-opc lack the same secret name entirely. No key value is available in this environment, so this PR adds the safe operation but does not perform the rotation.

Also documents the previously shipped OpenCode caller permission normalization behavior.

Validation: pytest 68 passed; py_compile; git diff --check; local and remote v1.36 release verification passed. Full-repository actionlint still reports pre-existing workflow diagnostics unrelated to this Python/docs-only change.