### PR TITLE
fix(secrets): read values from stdin

### DIFF
--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -214,7 +214,7 @@ def sync_missing(
         if value is None:
             continue
         run(
-            ["gh", "secret", "set", name, "-R", f"{owner}/{repo}", "--body", "-"],
+            ["gh", "secret", "set", name, "-R", f"{owner}/{repo}"],
             input_text=value,
         )
         available.add(name)
@@ -242,7 +242,7 @@ def refresh_secrets(
                 f"{owner}/{repo}: no explicitly allowed source for refresh secret {name}"
             )
         run(
-            ["gh", "secret", "set", name, "-R", f"{owner}/{repo}", "--body", "-"],
+            ["gh", "secret", "set", name, "-R", f"{owner}/{repo}"],
             input_text=value,
         )
         refreshed.append(name)

--- a/scripts/sync-secrets.sh
+++ b/scripts/sync-secrets.sh
@@ -55,7 +55,7 @@ echo ""
 
 for repo in "${REPOS[@]}"; do
     echo -n "  $repo ... "
-    if echo "$TOKEN" | gh secret set "$SECRET_NAME" --repo "$repo" --body - 2>/dev/null; then
+    if printf '%s' "$TOKEN" | gh secret set "$SECRET_NAME" --repo "$repo" 2>/dev/null; then
         echo "OK"
     else
         echo "FAILED (check permissions)"

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -249,6 +249,7 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
         self.assertEqual(("ZHIPU_API_KEY",), refreshed)
         self.assertEqual("rotated-value", calls[0][1])
         self.assertNotIn("rotated-value", calls[0][0])
+        self.assertNotIn("--body", calls[0][0])
 
     def test_refresh_secret_reports_partial_writes_when_a_later_source_is_missing(self) -> None:
         completed: list[str] = []
@@ -295,6 +296,11 @@ class RolloutWorkflowFleetTest(unittest.TestCase):
         self.assertEqual(("TOKEN",), synced)
         self.assertEqual("sensitive-value", calls[0][1])
         self.assertNotIn("sensitive-value", calls[0][0])
+        self.assertNotIn("--body", calls[0][0])
+
+    def test_legacy_bulk_sync_reads_secret_from_stdin_not_literal_dash(self) -> None:
+        script = (ROOT / "scripts/sync-secrets.sh").read_text(encoding="utf-8")
+        self.assertNotIn("--body -", script)
 
     def test_sync_missing_reports_partial_writes_when_a_later_write_fails(self) -> None:
         completed: list[str] = []


### PR DESCRIPTION
Fix a production-impacting gh CLI misuse: `gh secret set --body -` stores the literal dash instead of reading stdin. Remove `--body` so gh reads the supplied subprocess stdin, cover both fleet refresh/missing sync paths, and fix the legacy bulk sync script.\n\nObserved evidence: newly refreshed OpenCode runs masked every hyphen and returned Z.AI 401, while pim-package-jhw retained an older working secret.\n\nValidation: pytest 69 passed; bash -n; py_compile; git diff --check.