### PR TITLE
ci: harden Actions runtimes and pin OpenCode CLI

### DIFF
--- a/.github/workflows/auto-rereview-request.yml
+++ b/.github/workflows/auto-rereview-request.yml
@@ -21,7 +21,7 @@ jobs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,7 @@ jobs:
       model: ${{ steps.model.outputs.model }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,7 @@ jobs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 
@@ -59,7 +59,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -27,7 +27,7 @@ jobs:
       auto_enabled: ${{ steps.auto_mode.outputs.auto_enabled }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/gemini-chat.yml
+++ b/.github/workflows/gemini-chat.yml
@@ -33,7 +33,7 @@ jobs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 
@@ -72,7 +72,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -43,7 +43,7 @@ jobs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 
@@ -99,7 +99,7 @@ jobs:
       auto_pr_review_enabled: '${{ steps.check_config.outputs.auto_pr_review_enabled }}'
     steps:
       - name: 'Checkout for config'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 
@@ -275,7 +275,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup authentication
         id: auth
@@ -606,7 +606,7 @@ jobs:
           prompt: '/gemini-triage'
 
       - name: Checkout for actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 
@@ -662,7 +662,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -65,7 +65,7 @@ jobs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 
@@ -87,7 +87,7 @@ jobs:
       pull-requests: 'write'
     steps:
       - name: 'Checkout repository'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -71,7 +71,7 @@ jobs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: 'Checkout repository (sparse)'
         if: vars.GEMINI_SPARSE_CHECKOUT == 'true' && vars.GEMINI_SPARSE_CHECKOUT_PATTERNS != ''
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           lfs: false
@@ -106,7 +106,7 @@ jobs:
 
       - name: 'Checkout repository'
         if: vars.GEMINI_SPARSE_CHECKOUT != 'true'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           lfs: false

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -54,7 +54,7 @@ jobs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -57,7 +57,7 @@ jobs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 
@@ -166,7 +166,7 @@ jobs:
       pull-requests: 'write'
     steps:
       - name: 'Checkout for actions'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -87,11 +87,14 @@ jobs:
     permissions:
       # id-token 없음(의도) — 이게 있으면 액션이 OIDC 토큰을 발급받아
       # api.opencode.ai 에서 App 토큰으로 교환할 수 있고, 그 토큰은 아래 contents: read
-      # 의 통제를 받지 않는다. use_github_token: true 와 함께 이중으로 막는다:
+      # 의 통제를 받지 않는다. USE_GITHUB_TOKEN=true 와 함께 이중으로 막는다:
       # 플래그가 기대대로 동작하지 않더라도 OIDC 발급 자체가 불가능(fail-closed).
       contents: read
       pull-requests: write
       issues: write
+    env:
+      OPENCODE_VERSION: '1.18.17'
+      OPENCODE_ARCHIVE_SHA256: '3f14a4c61c7f6b0d3b6d933d1d212e64e19683eba6fa453ad98e46303afe144a'
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -99,26 +102,49 @@ jobs:
           fetch-depth: 1
           # OpenCode fetches the PR head branch after checkout. Private repositories
           # require authenticated fetch. This same token is intentionally passed to the
-          # action below; contents: read prevents code pushes, while PR/issues write is
+          # CLI below; contents: read prevents code pushes, while PR/issues write is
           # limited to review output. Consumer callers admit same-repository PRs only.
           persist-credentials: true
 
-      # use_github_token: OIDC 교환(api.opencode.ai → opencode-agent App 토큰)을 건너뛰고
+      - name: Cache pinned OpenCode CLI archive
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/opencode/opencode-linux-x64-${{ env.OPENCODE_VERSION }}.tar.gz
+          key: opencode-cli-linux-x64-${{ env.OPENCODE_VERSION }}-${{ env.OPENCODE_ARCHIVE_SHA256 }}
+
+      - name: Install pinned OpenCode CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          cache_dir="$HOME/.cache/opencode"
+          archive="$cache_dir/opencode-linux-x64-${OPENCODE_VERSION}.tar.gz"
+          install_dir="$RUNNER_TEMP/opencode-${OPENCODE_VERSION}"
+          mkdir -p "$cache_dir" "$install_dir"
+          if [[ ! -f "$archive" ]]; then
+            curl --fail --location --silent --show-error --retry 3 \
+              --output "$archive" \
+              "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz"
+          fi
+          echo "${OPENCODE_ARCHIVE_SHA256}  ${archive}" | sha256sum --check -
+          tar -xzf "$archive" -C "$install_dir"
+          [[ "$("$install_dir/opencode" --version)" == "$OPENCODE_VERSION" ]]
+          echo "$install_dir" >> "$GITHUB_PATH"
+
+      # USE_GITHUB_TOKEN: OIDC 교환(api.opencode.ai → opencode-agent App 토큰)을 건너뛰고
       # 이 잡의 GITHUB_TOKEN 을 쓴다. App 토큰은 App 설치 권한만 따르므로 위 permissions
       # 블록(contents: read)이 무력했다 — 실제로 자동 리뷰가 PR 브랜치에 코드 커밋을 푸시한
       # 사례가 있다(wlan-package #163, 게다가 실패하는 테스트였다). GITHUB_TOKEN 으로
       # 바꾸면 permissions 블록이 그대로 강제되어 리뷰는 쓰되(pull-requests/issues: write)
       # 코드는 못 쓴다(contents: read).
-      # 액션은 GITHUB_TOKEN 을 자동 주입하지 않으므로 env 로 명시해야 한다.
+      # CLI에는 GITHUB_TOKEN과 USE_GITHUB_TOKEN을 모두 명시한다.
       - name: Run OpenCode PR review
-        uses: anomalyco/opencode/github@bbc7bdb3fd5078d0add23273e0fdae436b9b47e4 # v1.1.43
+        run: opencode github run
         env:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          use_github_token: true
-          model: zai-coding-plan/glm-4.7
-          prompt: |
+          USE_GITHUB_TOKEN: 'true'
+          MODEL: zai-coding-plan/glm-4.7
+          PROMPT: |
             Review this pull request. Focus on:
             - correctness and regressions
             - security issues

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -31,7 +31,7 @@ jobs:
       safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 
@@ -94,7 +94,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           # OpenCode fetches the PR head branch after checkout. Private repositories

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -26,7 +26,7 @@ jobs:
       safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
 
@@ -73,7 +73,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # The action fetches PR branches itself; private repositories require the
           # contents: read job token to remain available for that authenticated fetch.

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -71,22 +71,48 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+    env:
+      OPENCODE_VERSION: '1.18.17'
+      OPENCODE_ARCHIVE_SHA256: '3f14a4c61c7f6b0d3b6d933d1d212e64e19683eba6fa453ad98e46303afe144a'
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # The action fetches PR branches itself; private repositories require the
+          # The CLI fetches PR branches itself; private repositories require the
           # contents: read job token to remain available for that authenticated fetch.
           persist-credentials: true
 
+      - name: Cache pinned OpenCode CLI archive
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/opencode/opencode-linux-x64-${{ env.OPENCODE_VERSION }}.tar.gz
+          key: opencode-cli-linux-x64-${{ env.OPENCODE_VERSION }}-${{ env.OPENCODE_ARCHIVE_SHA256 }}
+
+      - name: Install pinned OpenCode CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          cache_dir="$HOME/.cache/opencode"
+          archive="$cache_dir/opencode-linux-x64-${OPENCODE_VERSION}.tar.gz"
+          install_dir="$RUNNER_TEMP/opencode-${OPENCODE_VERSION}"
+          mkdir -p "$cache_dir" "$install_dir"
+          if [[ ! -f "$archive" ]]; then
+            curl --fail --location --silent --show-error --retry 3 \
+              --output "$archive" \
+              "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz"
+          fi
+          echo "${OPENCODE_ARCHIVE_SHA256}  ${archive}" | sha256sum --check -
+          tar -xzf "$archive" -C "$install_dir"
+          [[ "$("$install_dir/opencode" --version)" == "$OPENCODE_VERSION" ]]
+          echo "$install_dir" >> "$GITHUB_PATH"
+
       - name: Run opencode
-        uses: anomalyco/opencode/github@bbc7bdb3fd5078d0add23273e0fdae436b9b47e4 # v1.1.43
+        run: opencode github run
         env:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          use_github_token: true
-          model: zai-coding-plan/glm-4.7
+          USE_GITHUB_TOKEN: 'true'
+          MODEL: zai-coding-plan/glm-4.7
 
   skipped:
     name: Workflow Skipped

--- a/.github/workflows/test-fleet-tools.yml
+++ b/.github/workflows/test-fleet-tools.yml
@@ -20,7 +20,7 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/docs/superpowers/plans/2026-08-13-actions-runtime-hardening.md
+++ b/docs/superpowers/plans/2026-08-13-actions-runtime-hardening.md
@@ -1,0 +1,74 @@
+# Actions Runtime Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove deprecated checkout runtimes and make the OpenCode CLI artifact reproducible without weakening the existing GitHub-token security boundary.
+
+**Architecture:** Central reusable workflows remain the only fleet integration point. Every managed checkout reference is pinned to the verified `actions/checkout` v7.0.1 commit, while the two OpenCode workflows download one tested Linux x64 release archive, verify its published SHA-256 digest, and invoke `opencode github run` with the same restricted token environment as today.
+
+**Tech Stack:** GitHub Actions YAML, Python `unittest`/`pytest`, PyYAML, actionlint, GitHub release artifacts.
+
+## Global Constraints
+
+- Use `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1` (`v7.0.1`) everywhere managed by this repository.
+- Pin OpenCode CLI to `1.18.17` and verify archive SHA-256 `3f14a4c61c7f6b0d3b6d933d1d212e64e19683eba6fa453ad98e46303afe144a` before extraction.
+- Keep `contents: read`, `pull-requests: write`, `issues: write`, no `id-token`, and `GITHUB_TOKEN: ${{ github.token }}` for both OpenCode execution jobs.
+- Do not publish or move a release tag until the central PR is merged and the merge commit passes local release verification.
+- Preserve unrelated changes in the original `automation`, `wlan-package`, and `personal-ops` checkouts.
+
+---
+
+### Task 1: Pin checkout v7.0.1
+
+**Files:**
+- Create: `tests/test_action_pins.py`
+- Modify: `.github/workflows/*.yml`
+- Modify: `examples/baseline-workflows/workflows/bump-automation-ref.yml`
+- Modify: `examples/baseline-workflows/.github/workflows/bump-automation-ref.yml`
+
+**Interfaces:**
+- Consumes: the upstream v7.0.1 tag resolved to commit `3d3c42e5aac5ba805825da76410c181273ba90b1`.
+- Produces: `test_all_managed_checkout_references_use_the_approved_sha`, a fleet-wide invariant over central and baseline workflow YAML.
+
+- [ ] **Step 1: Add a failing test that reports every checkout reference not equal to the approved full SHA.**
+- [ ] **Step 2: Run `python3 -m pytest -q tests/test_action_pins.py` and confirm it fails on the current v4/v5 references.**
+- [ ] **Step 3: Replace all reported references with the approved SHA and retain an inline `# v7.0.1` version comment.**
+- [ ] **Step 4: Run the focused test, full pytest suite, YAML parsing, and actionlint regression comparison.**
+- [ ] **Step 5: Commit the checkout migration independently.**
+
+### Task 2: Pin and verify the OpenCode CLI artifact
+
+**Files:**
+- Modify: `.github/workflows/opencode.yml`
+- Modify: `.github/workflows/opencode-auto-review.yml`
+- Modify: `scripts/verify_workflow_release.py`
+- Modify: `tests/test_workflow_secret_contracts.py`
+- Modify: `tests/test_verify_workflow_release.py`
+- Modify: `tests/test_action_pins.py`
+
+**Interfaces:**
+- Consumes: GitHub release asset `v1.18.17/opencode-linux-x64.tar.gz` and its GitHub-published SHA-256 digest.
+- Produces: identical `Install pinned OpenCode CLI` and `Run ...` step contracts in both reusable workflows; `verify_tag_content()` rejects version, digest, token, permission, or OIDC regressions.
+
+- [ ] **Step 1: Add failing contract tests for the exact version, URL, digest, cache action SHA, checksum check, and `USE_GITHUB_TOKEN=true` runtime environment.**
+- [ ] **Step 2: Run the focused tests and confirm failure against the dynamic upstream-action implementation.**
+- [ ] **Step 3: Add a Node.js 24 cache step for the exact archive, download it only on cache miss, verify SHA-256 on every run, extract to a runner-temporary directory, and invoke `opencode github run` directly.**
+- [ ] **Step 4: Update release verification and its fixtures so any unpinned version/digest or weakened GitHub-token contract fails closed.**
+- [ ] **Step 5: Download the actual release asset, verify its SHA-256, extract it, and confirm `opencode --version` prints `1.18.17`.**
+- [ ] **Step 6: Run full pytest, YAML parsing, actionlint regression comparison, `git diff --check`, and release-content verification against the candidate commit.**
+- [ ] **Step 7: Commit the CLI pin separately and publish a PR only after every gate succeeds.**
+
+### Task 3: Staged release and canary
+
+**Files:**
+- Modify after execution evidence: `docs/workflows/contracts.md` or rollout result documentation if operational notes change.
+
+**Interfaces:**
+- Consumes: the merged automation commit and the existing `verify_workflow_release.py` release gate.
+- Produces: one new immutable automation tag and one same-repository OpenCode canary before any fleet ref bump.
+
+- [ ] **Step 1: Merge the reviewed central PR and fetch only `origin/main` without overwriting existing local tags.**
+- [ ] **Step 2: Re-run all local gates on the merge commit.**
+- [ ] **Step 3: Create a new annotated tag on that exact merge commit and run local verification before pushing it.**
+- [ ] **Step 4: Push the tag, run remote verification, then execute one enabled same-repository OpenCode canary.**
+- [ ] **Step 5: Stop on any mismatch or canary failure; never move the tag. Roll back consumers by restoring their prior automation ref, and correct central code only through a newer release tag.**

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -61,10 +61,30 @@ checkout credential required by OpenCode's internal branch fetch without exposin
 processing external contributor content.
 
 Both OpenCode workflows force the job-scoped `github.token`; `id-token: write` is forbidden,
-so the action cannot exchange OIDC for an App token outside the declared job permissions.
+so the CLI cannot exchange OIDC for an App token outside the declared job permissions.
 Consumer OpenCode jobs must grant exactly `contents: read`, `pull-requests: write`, and
 `issues: write`. The fleet rollout tool normalizes these two caller permission blocks; this
 is the intentional exception to its general rule of preserving repository-owned permissions.
+
+### OpenCode runtime pin
+
+The central workflows, not consumer repositories, own the OpenCode CLI version. They download
+the Linux x64 archive for exactly `1.18.17`, verify SHA-256
+`3f14a4c61c7f6b0d3b6d933d1d212e64e19683eba6fa453ad98e46303afe144a`, and only then extract
+and run it. The cache stores the archive rather than an unchecked executable, and the digest is
+verified after every cache restore. Consumers must not add an independent OpenCode installer.
+
+To update the CLI, change the version and GitHub release asset digest together in both OpenCode
+workflows, update the release verifier constants and tests, then publish a new immutable
+`automation` release only after a same-repository canary succeeds. Never replace a release tag
+or change the version to `latest`.
+
+### Action runtime pins
+
+Managed central and baseline workflows pin `actions/checkout` v7.0.1 and `actions/cache` v6.1.0
+to their full commit SHAs. `tests/test_action_pins.py` prevents tag, branch, and mixed-major drift.
+When updating either action, verify the upstream release tag resolves to the selected commit,
+run actionlint and the complete test suite, and ship the change through a new immutable release.
 
 ## Variables (consumer repository)
 

--- a/examples/baseline-workflows/.github/workflows/bump-automation-ref.yml
+++ b/examples/baseline-workflows/.github/workflows/bump-automation-ref.yml
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ steps.tok.outputs.token }}

--- a/examples/baseline-workflows/workflows/bump-automation-ref.yml
+++ b/examples/baseline-workflows/workflows/bump-automation-ref.yml
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ steps.tok.outputs.token }}

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -12,6 +12,14 @@ import sys
 import yaml
 
 
+CHECKOUT_ACTION = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+CACHE_ACTION = "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
+OPENCODE_VERSION = "1.18.17"
+OPENCODE_ARCHIVE_SHA256 = (
+    "3f14a4c61c7f6b0d3b6d933d1d212e64e19683eba6fa453ad98e46303afe144a"
+)
+
+
 class ReleaseVerificationError(RuntimeError):
     """The requested release is absent, points elsewhere, or violates invariants."""
 
@@ -55,6 +63,48 @@ def verify_remote_tag(repo: Path, remote: str, ref: str, expected: str) -> None:
         )
 
 
+def verify_opencode_runtime(job: dict, step_name: str, workflow_name: str) -> dict:
+    """Require a digest-verified CLI and the restricted repository token path."""
+    try:
+        cache = next(
+            item
+            for item in job["steps"]
+            if item.get("name") == "Cache pinned OpenCode CLI archive"
+        )
+        install = next(
+            item
+            for item in job["steps"]
+            if item.get("name") == "Install pinned OpenCode CLI"
+        )
+        run_step = next(item for item in job["steps"] if item.get("name") == step_name)
+    except (KeyError, TypeError, StopIteration) as exc:
+        raise ReleaseVerificationError(
+            f"{workflow_name} pinned OpenCode runtime structure is missing"
+        ) from exc
+
+    job_env = job.get("env", {})
+    install_script = install.get("run", "")
+    expected_url = (
+        "releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz"
+    )
+    runtime_is_pinned = (
+        job_env.get("OPENCODE_VERSION") == OPENCODE_VERSION
+        and job_env.get("OPENCODE_ARCHIVE_SHA256") == OPENCODE_ARCHIVE_SHA256
+        and cache.get("uses") == CACHE_ACTION
+        and expected_url in install_script
+        and "sha256sum --check -" in install_script
+        and '"$install_dir/opencode" --version' in install_script
+        and run_step.get("run") == "opencode github run"
+        and run_step.get("env", {}).get("USE_GITHUB_TOKEN") == "true"
+        and run_step.get("env", {}).get("MODEL") == "zai-coding-plan/glm-4.7"
+    )
+    if not runtime_is_pinned:
+        raise ReleaseVerificationError(
+            f"{workflow_name} does not pin and verify the approved OpenCode CLI runtime"
+        )
+    return run_step
+
+
 def verify_tag_content(repo: Path, ref: str) -> None:
     names = git(repo, "ls-tree", "-r", "--name-only", ref, ".github/workflows").splitlines()
     workflows = [name for name in names if name.endswith((".yml", ".yaml"))]
@@ -66,6 +116,12 @@ def verify_tag_content(repo: Path, ref: str) -> None:
         text = git(repo, "show", f"{ref}:{name}")
         if "secrets.GITHUB_TOKEN" in text:
             raise ReleaseVerificationError(f"{name} uses secrets.GITHUB_TOKEN")
+        for match in re.finditer(r"actions/checkout@([^'\"\s#]+)", text):
+            checkout = f"actions/checkout@{match.group(1)}"
+            if checkout != CHECKOUT_ACTION:
+                raise ReleaseVerificationError(
+                    f"{name} checkout reference is not the approved immutable commit"
+                )
         data = yaml.load(text, Loader=yaml.BaseLoader)
         documents[Path(name).name] = data if isinstance(data, dict) else {}
 
@@ -79,11 +135,11 @@ def verify_tag_content(repo: Path, ref: str) -> None:
         checkout = next(
             item for item in job["steps"] if item.get("name") == "Checkout repository"
         )
-        step = next(
-            item for item in job["steps"] if item.get("name") == "Run OpenCode PR review"
-        )
     except (KeyError, TypeError, StopIteration) as exc:
         raise ReleaseVerificationError("OpenCode security structure is missing") from exc
+    step = verify_opencode_runtime(
+        job, "Run OpenCode PR review", "opencode-auto-review.yml"
+    )
     expected_permissions = {
         "contents": "read",
         "pull-requests": "write",
@@ -112,8 +168,6 @@ def verify_tag_content(repo: Path, ref: str) -> None:
         raise ReleaseVerificationError(
             "OpenCode auto review cannot authenticate private repository fetch"
         )
-    if step.get("with", {}).get("use_github_token") != "true":
-        raise ReleaseVerificationError("OpenCode auto review does not force use_github_token")
     if step.get("env", {}).get("GITHUB_TOKEN") != "${{ github.token }}":
         raise ReleaseVerificationError("OpenCode auto review does not use github.token")
 
@@ -126,11 +180,9 @@ def verify_tag_content(repo: Path, ref: str) -> None:
             for item in command_job["steps"]
             if item.get("name") == "Checkout repository"
         )
-        command_step = next(
-            item for item in command_job["steps"] if item.get("name") == "Run opencode"
-        )
     except (KeyError, TypeError, StopIteration) as exc:
         raise ReleaseVerificationError("opencode.yml structure is missing") from exc
+    command_step = verify_opencode_runtime(command_job, "Run opencode", "opencode.yml")
     if command_checkout.get("with", {}).get("persist-credentials") != "true":
         raise ReleaseVerificationError(
             "opencode.yml cannot authenticate private repository fetch"
@@ -154,7 +206,7 @@ def verify_tag_content(repo: Path, ref: str) -> None:
         and isinstance(command_condition, str)
         and "needs.check-enabled.outputs.safe_pr == 'true'" in command_condition
         and command_job.get("permissions") == command_permissions
-        and command_step.get("with", {}).get("use_github_token") == "true"
+        and command_step.get("env", {}).get("USE_GITHUB_TOKEN") == "true"
         and command_step.get("env", {}).get("GITHUB_TOKEN") == "${{ github.token }}"
     )
     if not command_is_secure:

--- a/tests/test_action_pins.py
+++ b/tests/test_action_pins.py
@@ -5,9 +5,16 @@ from pathlib import Path
 import re
 import unittest
 
+import yaml
+
 
 ROOT = Path(__file__).resolve().parents[1]
 CHECKOUT_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+CACHE_SHA = "55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
+OPENCODE_VERSION = "1.18.17"
+OPENCODE_ARCHIVE_SHA256 = (
+    "3f14a4c61c7f6b0d3b6d933d1d212e64e19683eba6fa453ad98e46303afe144a"
+)
 MANAGED_WORKFLOW_ROOTS = (
     ROOT / ".github" / "workflows",
     ROOT / "examples" / "baseline-workflows" / "workflows",
@@ -42,6 +49,40 @@ class ActionPinsTest(unittest.TestCase):
 
         self.assertGreater(len(references), 0, "no managed checkout references found")
         self.assertEqual([], offenders)
+
+    def test_opencode_workflows_pin_cli_archive_and_cache_action(self) -> None:
+        for filename, job_name, run_name in (
+            ("opencode.yml", "opencode", "Run opencode"),
+            ("opencode-auto-review.yml", "opencode-review", "Run OpenCode PR review"),
+        ):
+            with self.subTest(workflow=filename):
+                path = ROOT / ".github" / "workflows" / filename
+                text = path.read_text(encoding="utf-8")
+                workflow = yaml.load(text, Loader=yaml.BaseLoader)
+                job = workflow["jobs"][job_name]
+                self.assertNotIn("anomalyco/opencode/github@", text)
+                self.assertEqual(OPENCODE_VERSION, job["env"]["OPENCODE_VERSION"])
+                self.assertEqual(
+                    OPENCODE_ARCHIVE_SHA256,
+                    job["env"]["OPENCODE_ARCHIVE_SHA256"],
+                )
+                cache_step = next(
+                    step
+                    for step in job["steps"]
+                    if step.get("name") == "Cache pinned OpenCode CLI archive"
+                )
+                self.assertEqual(f"actions/cache@{CACHE_SHA}", cache_step["uses"])
+                self.assertIn(
+                    'releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz',
+                    text,
+                )
+                self.assertIn("sha256sum --check -", text)
+                self.assertIn('"$install_dir/opencode" --version', text)
+                run_step = next(
+                    step for step in job["steps"] if step.get("name") == run_name
+                )
+                self.assertEqual("opencode github run", run_step["run"])
+                self.assertEqual("true", run_step["env"]["USE_GITHUB_TOKEN"])
 
 
 if __name__ == "__main__":

--- a/tests/test_action_pins.py
+++ b/tests/test_action_pins.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Immutable reference checks for actions used by managed workflows."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKOUT_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+MANAGED_WORKFLOW_ROOTS = (
+    ROOT / ".github" / "workflows",
+    ROOT / "examples" / "baseline-workflows" / "workflows",
+    ROOT / "examples" / "baseline-workflows" / ".github" / "workflows",
+)
+
+
+def workflow_paths() -> list[Path]:
+    return sorted(
+        path
+        for directory in MANAGED_WORKFLOW_ROOTS
+        for path in directory.glob("*.y*ml")
+    )
+
+
+class ActionPinsTest(unittest.TestCase):
+    def test_all_managed_checkout_references_use_the_approved_sha(self) -> None:
+        references: list[tuple[Path, int, str]] = []
+        offenders: list[str] = []
+        pattern = re.compile(r"uses:\s*['\"]?actions/checkout@([^'\"\s]+)")
+
+        for path in workflow_paths():
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                match = pattern.search(line)
+                if match is None:
+                    continue
+                ref = match.group(1)
+                references.append((path, lineno, ref))
+                if ref != CHECKOUT_SHA:
+                    relative = path.relative_to(ROOT)
+                    offenders.append(f"{relative}:{lineno}: {ref}")
+
+        self.assertGreater(len(references), 0, "no managed checkout references found")
+        self.assertEqual([], offenders)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -50,16 +50,27 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+    env:
+      OPENCODE_VERSION: '1.18.17'
+      OPENCODE_ARCHIVE_SHA256: '3f14a4c61c7f6b0d3b6d933d1d212e64e19683eba6fa453ad98e46303afe144a'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: true
+      - name: Cache pinned OpenCode CLI archive
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      - name: Install pinned OpenCode CLI
+        run: |
+          curl "releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz"
+          sha256sum --check -
+          "$install_dir/opencode" --version
       - name: Run OpenCode PR review
+        run: opencode github run
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          use_github_token: true
+          USE_GITHUB_TOKEN: 'true'
+          MODEL: zai-coding-plan/glm-4.7
 """
 
 SECURE_COMMAND_WORKFLOW = """\
@@ -80,16 +91,27 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+    env:
+      OPENCODE_VERSION: '1.18.17'
+      OPENCODE_ARCHIVE_SHA256: '3f14a4c61c7f6b0d3b6d933d1d212e64e19683eba6fa453ad98e46303afe144a'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: true
+      - name: Cache pinned OpenCode CLI archive
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      - name: Install pinned OpenCode CLI
+        run: |
+          curl "releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz"
+          sha256sum --check -
+          "$install_dir/opencode" --version
       - name: Run opencode
+        run: opencode github run
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          use_github_token: true
+          USE_GITHUB_TOKEN: 'true'
+          MODEL: zai-coding-plan/glm-4.7
 """
 
 

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -41,16 +41,27 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
                       contents: read
                       pull-requests: write
                       issues: write
+                    env:
+                      OPENCODE_VERSION: '1.18.17'
+                      OPENCODE_ARCHIVE_SHA256: '3f14a4c61c7f6b0d3b6d933d1d212e64e19683eba6fa453ad98e46303afe144a'
                     steps:
                       - name: Checkout repository
-                        uses: actions/checkout@v4
+                        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
                         with:
                           persist-credentials: true
+                      - name: Cache pinned OpenCode CLI archive
+                        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+                      - name: Install pinned OpenCode CLI
+                        run: |
+                          curl "releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz"
+                          sha256sum --check -
+                          "$install_dir/opencode" --version
                       - name: Run OpenCode PR review
+                        run: opencode github run
                         env:
                           GITHUB_TOKEN: ${{ github.token }}
-                        with:
-                          use_github_token: true
+                          USE_GITHUB_TOKEN: 'true'
+                          MODEL: zai-coding-plan/glm-4.7
                 """
             )
         )
@@ -74,16 +85,27 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
                       contents: read
                       pull-requests: write
                       issues: write
+                    env:
+                      OPENCODE_VERSION: '1.18.17'
+                      OPENCODE_ARCHIVE_SHA256: '3f14a4c61c7f6b0d3b6d933d1d212e64e19683eba6fa453ad98e46303afe144a'
                     steps:
                       - name: Checkout repository
-                        uses: actions/checkout@v4
+                        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
                         with:
                           persist-credentials: true
+                      - name: Cache pinned OpenCode CLI archive
+                        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+                      - name: Install pinned OpenCode CLI
+                        run: |
+                          curl "releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz"
+                          sha256sum --check -
+                          "$install_dir/opencode" --version
                       - name: Run opencode
+                        run: opencode github run
                         env:
                           GITHUB_TOKEN: ${{ github.token }}
-                        with:
-                          use_github_token: true
+                          USE_GITHUB_TOKEN: 'true'
+                          MODEL: zai-coding-plan/glm-4.7
                 """
             )
         )
@@ -142,6 +164,51 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
         with self.assertRaisesRegex(ReleaseVerificationError, "permissions"):
             verify_release(self.repo, "v1.35", bad_commit)
 
+    def test_rejects_release_with_unpinned_checkout(self) -> None:
+        self.git("tag", "-d", "v1.35")
+        path = self.repo / ".github/workflows/opencode-auto-review.yml"
+        path.write_text(
+            path.read_text().replace(
+                "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+                "actions/checkout@v7",
+                1,
+            )
+        )
+        self.git("add", ".")
+        self.git("commit", "-qm", "unpin checkout")
+        bad_commit = self.git("rev-parse", "HEAD").strip()
+        self.git("tag", "-a", "v1.35", "-m", "bad")
+        with self.assertRaisesRegex(ReleaseVerificationError, "checkout reference"):
+            verify_release(self.repo, "v1.35", bad_commit)
+
+    def test_rejects_release_with_opencode_version_drift(self) -> None:
+        self.git("tag", "-d", "v1.35")
+        path = self.repo / ".github/workflows/opencode-auto-review.yml"
+        path.write_text(path.read_text().replace("1.18.17", "latest", 1))
+        self.git("add", ".")
+        self.git("commit", "-qm", "unpin opencode")
+        bad_commit = self.git("rev-parse", "HEAD").strip()
+        self.git("tag", "-a", "v1.35", "-m", "bad")
+        with self.assertRaisesRegex(ReleaseVerificationError, "approved OpenCode CLI"):
+            verify_release(self.repo, "v1.35", bad_commit)
+
+    def test_rejects_release_with_opencode_digest_drift(self) -> None:
+        self.git("tag", "-d", "v1.35")
+        path = self.repo / ".github/workflows/opencode-auto-review.yml"
+        path.write_text(
+            path.read_text().replace(
+                "3f14a4c61c7f6b0d3b6d933d1d212e64e19683eba6fa453ad98e46303afe144a",
+                "0" * 64,
+                1,
+            )
+        )
+        self.git("add", ".")
+        self.git("commit", "-qm", "change opencode digest")
+        bad_commit = self.git("rev-parse", "HEAD").strip()
+        self.git("tag", "-a", "v1.35", "-m", "bad")
+        with self.assertRaisesRegex(ReleaseVerificationError, "approved OpenCode CLI"):
+            verify_release(self.repo, "v1.35", bad_commit)
+
     def test_rejects_opencode_release_without_private_repo_fetch_auth(self) -> None:
         self.git("tag", "-d", "v1.35")
         path = self.repo / ".github/workflows/opencode-auto-review.yml"
@@ -195,13 +262,13 @@ class VerifyWorkflowReleaseTest(unittest.TestCase):
             "    permissions:\n      contents: read",
             "    permissions:\n      id-token: write\n      contents: read",
         )
-        text = text.replace("use_github_token: true", "use_github_token: false")
+        text = text.replace("USE_GITHUB_TOKEN: 'true'", "USE_GITHUB_TOKEN: 'false'")
         path.write_text(text)
         self.git("add", ".")
         self.git("commit", "-qm", "restore app token path")
         bad_commit = self.git("rev-parse", "HEAD").strip()
         self.git("tag", "-a", "v1.35", "-m", "bad")
-        with self.assertRaisesRegex(ReleaseVerificationError, "opencode.yml security"):
+        with self.assertRaisesRegex(ReleaseVerificationError, "opencode.yml"):
             verify_release(self.repo, "v1.35", bad_commit)
 
     def test_rejects_command_scope_without_inline_review_fallback(self) -> None:

--- a/tests/test_workflow_secret_contracts.py
+++ b/tests/test_workflow_secret_contracts.py
@@ -108,7 +108,8 @@ class WorkflowSecretContractsTest(unittest.TestCase):
         run_step = next(
             step for step in job["steps"] if step.get("name") == "Run OpenCode PR review"
         )
-        self.assertEqual("true", run_step["with"]["use_github_token"])
+        self.assertEqual("opencode github run", run_step["run"])
+        self.assertEqual("true", run_step["env"]["USE_GITHUB_TOKEN"])
         self.assertEqual("${{ github.token }}", run_step["env"]["GITHUB_TOKEN"])
 
     def test_opencode_auto_review_keeps_read_only_checkout_auth_for_private_repos(self) -> None:
@@ -147,7 +148,8 @@ class WorkflowSecretContractsTest(unittest.TestCase):
         )
         self.assertIn("needs.check-enabled.outputs.safe_pr == 'true'", job["if"])
         run_step = next(step for step in job["steps"] if step.get("name") == "Run opencode")
-        self.assertEqual("true", run_step["with"]["use_github_token"])
+        self.assertEqual("opencode github run", run_step["run"])
+        self.assertEqual("true", run_step["env"]["USE_GITHUB_TOKEN"])
         self.assertEqual("${{ github.token }}", run_step["env"]["GITHUB_TOKEN"])
         scope_step = next(step for step in check["steps"] if step.get("id") == "pr_scope")
         self.assertEqual(


### PR DESCRIPTION
## Summary
- pin every managed `actions/checkout` reference to the immutable v7.0.1 commit
- replace the OpenCode Action's dynamic `latest` CLI install with OpenCode 1.18.17
- cache the release archive, verify its GitHub-published SHA-256 on every run, then extract and execute it
- extend release verification to reject checkout drift, CLI version/digest drift, cache-action drift, OIDC/App-token access, and permission drift

## Validation
- `python3 -m pytest -q`: 74 passed, 24 subtests passed
- YAML parse: 37 files
- pinned install scripts: `bash -n` passed for both workflows
- actionlint v1.7.12: baseline 63 diagnostics, candidate 63, normalized new 0
- actual OpenCode release archive digest verified; extracted binary reports `1.18.17`
- `verify_tag_content(..., HEAD)`: passed

## Rollout / rollback
No tag or consumer repository is changed by this PR. After merge, create a new immutable tag on the merge commit, verify it locally and remotely, then run one same-repository OpenCode canary. On failure, do not move the tag; fix via a newer release and leave consumers on v1.36.
