### PR TITLE
feat(fleet): ratchet managed checkout actions

### DIFF
--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -11,7 +11,12 @@ repository secret 전제조건을 한 실행에서 조율한다. GitHub는 Git P
 - 기존 workflow 파일과 caller job만 처리하고 새 workflow를 강제로 추가하지 않는다.
 - 저장소별 trigger, `if` guard, 기존 `with` 입력을 보존한다. `permissions`도 보존하되,
   OpenCode 두 caller는 OIDC 제거와 review 출력에 필요한 최소 계약으로 정규화한다.
-- 중앙 release ref, `secrets` mapping, 지원되는 `app_id`, `automation_ref`만 변경한다.
+- 중앙 release ref, `secrets` mapping, 지원되는 `app_id`, `automation_ref`와 승인된
+  GitHub Action pin만 변경한다.
+- 중앙 caller가 있는 workflow와 `bump-automation-ref.yml` 안의 `actions/checkout`은
+  `v7.0.1`의 전체 commit SHA로 정규화한다. 중앙 caller가 없는 저장소 고유 workflow는
+  건드리지 않으며, YAML에는 checkout action이 있지만 안전한 단일행 형태로 편집할 수
+  없으면 해당 저장소를 fail-closed로 blocked 처리한다.
 - caller가 없는 저장소는 skip한다.
 - required secret이 없고 안전한 source도 없으면 해당 저장소만 blocked 처리한다.
 

--- a/scripts/prepare_workflow_rollout.py
+++ b/scripts/prepare_workflow_rollout.py
@@ -3,7 +3,8 @@
 
 This module deliberately does not add workflows or replace whole caller files. It keeps
 repository-owned triggers, guards, permissions and inputs, changing only the central
-release ref, secret mapping, optional app_id forwarding and automation_ref config.
+release ref, secret mapping, optional app_id forwarding, approved action pins and
+automation_ref config.
 """
 
 from __future__ import annotations
@@ -26,6 +27,14 @@ CONFIG_REF_RE = re.compile(
     r"(?m)^(?P<prefix>automation_ref:[ \t]*)\S+"
     r"(?P<suffix>[ \t]*(?:#.*)?)$"
 )
+CHECKOUT_USE_RE = re.compile(
+    r"^(?P<prefix>[ \t]*(?:-[ \t]+)?uses:[ \t]*)(?P<quote>['\"]?)"
+    r"actions/checkout@(?P<ref>[^\s'\"#]+)(?P=quote)"
+    r"(?P<suffix>[ \t]*(?:#.*)?)(?P<newline>\r?\n?)$"
+)
+CHECKOUT_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+CHECKOUT_VERSION = "v7.0.1"
+BUMP_WORKFLOW = "bump-automation-ref.yml"
 GEMINI_AUTH_SECRETS = {"APP_PRIVATE_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"}
 OPENCODE_WORKFLOWS = {"opencode.yml", "opencode-auto-review.yml"}
 OPENCODE_CALLER_PERMISSIONS = (
@@ -257,6 +266,41 @@ def replace_job_segment(
     return segment
 
 
+def yaml_checkout_count(value: object) -> int:
+    if isinstance(value, dict):
+        count = int(
+            isinstance(value.get("uses"), str)
+            and value["uses"].startswith("actions/checkout@")
+        )
+        return count + sum(yaml_checkout_count(item) for item in value.values())
+    if isinstance(value, list):
+        return sum(yaml_checkout_count(item) for item in value)
+    return 0
+
+
+def ratchet_checkout_references(text: str, path: Path, workflow: dict) -> str:
+    """Pin every checkout step in a managed workflow or fail closed."""
+    lines = text.splitlines(keepends=True)
+    matches = [CHECKOUT_USE_RE.match(line) for line in lines]
+    editable = sum(match is not None for match in matches)
+    declared = yaml_checkout_count(workflow)
+    if editable != declared:
+        raise RolloutError(
+            f"{path.name}: found {declared} checkout action(s) but "
+            f"can safely rewrite only {editable}"
+        )
+
+    for index, match in enumerate(matches):
+        if match is None:
+            continue
+        lines[index] = (
+            f"{match.group('prefix')}{match.group('quote')}"
+            f"actions/checkout@{CHECKOUT_SHA}{match.group('quote')} "
+            f"# {CHECKOUT_VERSION}{match.group('newline')}"
+        )
+    return "".join(lines)
+
+
 def transform_workflow(
     path: Path,
     automation: Path,
@@ -311,7 +355,15 @@ def transform_workflow(
         segment = replace_job_segment(lines[index:end], indent, new_ref, names, pass_app_id)
         lines[index:end] = segment
 
-    return "".join(lines), len(uses), required
+    transformed = "".join(lines)
+    if uses or path.name == BUMP_WORKFLOW:
+        transformed_workflow = yaml.load(transformed, Loader=yaml.BaseLoader)
+        if not isinstance(transformed_workflow, dict):
+            transformed_workflow = {}
+        transformed = ratchet_checkout_references(
+            transformed, path, transformed_workflow
+        )
+    return transformed, len(uses), required
 
 
 def prepare_repository(

--- a/tests/test_action_pins.py
+++ b/tests/test_action_pins.py
@@ -3,15 +3,19 @@
 
 from pathlib import Path
 import re
+import sys
 import unittest
 
 import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
 
 from scripts.prepare_workflow_rollout import CHECKOUT_SHA as FLEET_CHECKOUT_SHA
 from scripts.verify_workflow_release import CHECKOUT_ACTION
 
 
-ROOT = Path(__file__).resolve().parents[1]
 CHECKOUT_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
 CACHE_SHA = "55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
 OPENCODE_VERSION = "1.18.17"

--- a/tests/test_action_pins.py
+++ b/tests/test_action_pins.py
@@ -7,6 +7,9 @@ import unittest
 
 import yaml
 
+from scripts.prepare_workflow_rollout import CHECKOUT_SHA as FLEET_CHECKOUT_SHA
+from scripts.verify_workflow_release import CHECKOUT_ACTION
+
 
 ROOT = Path(__file__).resolve().parents[1]
 CHECKOUT_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
@@ -31,6 +34,10 @@ def workflow_paths() -> list[Path]:
 
 
 class ActionPinsTest(unittest.TestCase):
+    def test_release_and_fleet_gates_use_the_source_checkout_pin(self) -> None:
+        self.assertEqual(CHECKOUT_SHA, FLEET_CHECKOUT_SHA)
+        self.assertEqual(f"actions/checkout@{CHECKOUT_SHA}", CHECKOUT_ACTION)
+
     def test_all_managed_checkout_references_use_the_approved_sha(self) -> None:
         references: list[tuple[Path, int, str]] = []
         offenders: list[str] = []

--- a/tests/test_prepare_workflow_rollout.py
+++ b/tests/test_prepare_workflow_rollout.py
@@ -13,6 +13,9 @@ sys.path.insert(0, str(ROOT))
 from scripts.prepare_workflow_rollout import RolloutError, prepare_repository
 
 
+CHECKOUT_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+
+
 class PrepareWorkflowRolloutTest(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = tempfile.TemporaryDirectory()
@@ -112,6 +115,80 @@ class PrepareWorkflowRolloutTest(unittest.TestCase):
             set(),
         )
         self.assertIn("claude.yml@v1.35' # pinned", p.read_text())
+
+    def test_ratchets_checkout_in_managed_callers_and_bump_workflow(self) -> None:
+        caller = self.write("notice.yml", """\
+            jobs:
+              inspect:
+                steps:
+                  - uses: actions/checkout@v4
+                    with:
+                      fetch-depth: 1
+              call:
+                uses: jhw7500/automation/.github/workflows/notice.yml@v1.33
+                secrets: inherit
+        """)
+        bump = self.write("bump-automation-ref.yml", """\
+            jobs:
+              bump:
+                steps:
+                  - uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # v5
+        """)
+
+        result = prepare_repository(self.repo, self.automation, "v1.37", set(), set())
+
+        approved = f"actions/checkout@{CHECKOUT_SHA}"
+        caller_yaml = yaml.load(caller.read_text(), Loader=yaml.BaseLoader)
+        bump_yaml = yaml.load(bump.read_text(), Loader=yaml.BaseLoader)
+        self.assertEqual(approved, caller_yaml["jobs"]["inspect"]["steps"][0]["uses"])
+        self.assertEqual(
+            "1", caller_yaml["jobs"]["inspect"]["steps"][0]["with"]["fetch-depth"]
+        )
+        self.assertEqual(approved, bump_yaml["jobs"]["bump"]["steps"][0]["uses"])
+        self.assertIn("# v7.0.1", caller.read_text())
+        self.assertIn("# v7.0.1", bump.read_text())
+        self.assertIn(Path(".github/workflows/notice.yml"), result.changed_files)
+        self.assertIn(
+            Path(".github/workflows/bump-automation-ref.yml"), result.changed_files
+        )
+
+    def test_leaves_checkout_in_unmanaged_workflow_unchanged(self) -> None:
+        unmanaged = self.write("custom-build.yml", """\
+            jobs:
+              build:
+                steps:
+                  - uses: actions/checkout@v4
+        """)
+        self.write("notice.yml", """\
+            jobs:
+              call:
+                uses: jhw7500/automation/.github/workflows/notice.yml@v1.33
+                secrets: inherit
+        """)
+
+        prepare_repository(self.repo, self.automation, "v1.37", set(), set())
+
+        self.assertIn("actions/checkout@v4", unmanaged.read_text())
+
+    def test_uneditable_checkout_in_managed_workflow_fails_before_writing(self) -> None:
+        caller = self.write("notice.yml", """\
+            jobs:
+              inspect:
+                steps:
+                  - uses: >-
+                      actions/checkout@v4
+              call:
+                uses: jhw7500/automation/.github/workflows/notice.yml@v1.33
+                secrets: inherit
+        """)
+        before = caller.read_text()
+
+        with self.assertRaisesRegex(
+            RolloutError, "found 1 checkout action.*safely rewrite only 0"
+        ):
+            prepare_repository(self.repo, self.automation, "v1.37", set(), set())
+
+        self.assertEqual(before, caller.read_text())
 
     def test_app_id_and_private_key_are_mapped_only_when_app_id_variable_exists(self) -> None:
         p = self.write("gemini.yml", """\


### PR DESCRIPTION
## Summary
- update `actions/checkout` in managed caller workflows and `bump-automation-ref.yml` to the approved v7.0.1 full SHA during the existing one-command fleet rollout
- leave repository-owned workflows without central callers unchanged
- fail closed when YAML declares a checkout action that cannot be safely edited as a single-line `uses`
- preserve checkout `with:` blocks and validate all generated YAML before writing

## Validation
- `python3 -m pytest -q`: 78 passed, 24 subtests passed
- real `wlan-driver` v1.37 prepare: 13 callers, 4 checkout refs ratcheted, actionlint gate passed, blocked 0
- first real dry-run exposed a newline-consumption bug; regression test with `with:` was added before fixing `[ \t]`/CRLF handling
- no secret writes

## Rollback
This operator-tool change has no release-tag mutation. Revert this commit to stop action ratcheting; already-open consumer PRs can be closed and their branches deleted independently.
