### PR TITLE
fix(ci): remove empty GitHub expression from comment

### DIFF
--- a/.github/workflows/auto-rereview-request.yml
+++ b/.github/workflows/auto-rereview-request.yml
@@ -100,7 +100,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           # All untrusted/templated values come in via env above; the script never interpolates
-          # ${{ }} into shell, and the comment body is built with printf + --body-file (no inline
+          # GitHub expressions into shell, and the comment body is built with printf + --body-file (no inline
           # --body / heredoc), so a malicious commit message cannot reach the shell.
           OID=$(gh pr view "$PR_NUM" --json commits --jq '.commits[-1].oid')
           COMMIT_SHA="${OID:0:7}"

--- a/tests/test_action_pins.py
+++ b/tests/test_action_pins.py
@@ -61,6 +61,15 @@ class ActionPinsTest(unittest.TestCase):
         self.assertGreater(len(references), 0, "no managed checkout references found")
         self.assertEqual([], offenders)
 
+    def test_managed_workflows_do_not_contain_empty_github_expressions(self) -> None:
+        offenders: list[str] = []
+        pattern = re.compile(r"\$\{\{\s*\}\}")
+        for path in workflow_paths():
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if pattern.search(line):
+                    offenders.append(f"{path.relative_to(ROOT)}:{lineno}")
+        self.assertEqual([], offenders)
+
     def test_opencode_workflows_pin_cli_archive_and_cache_action(self) -> None:
         for filename, job_name, run_name in (
             ("opencode.yml", "opencode", "Run opencode"),


### PR DESCRIPTION
## Summary
- replace a literal empty GitHub expression in an `auto-rereview-request.yml` shell comment
- add a managed-workflow invariant that rejects `${{ }}` even inside comments

## Evidence
- GitHub rejects both automation v1.36 and v1.37 callers before creating jobs: `Line: 101, Col: 14: An expression was expected`
- `pytest -q`: 79 passed
- YAML parse: 37 files
- actionlint v1.7.12: diagnostics 63 -> 62, new 0; the removed diagnostic is the empty-expression parse failure

## Release
Do not move v1.37. After merge, publish v1.38 on the exact merge commit and update only the existing wlan-driver canary first.
