### PR TITLE
fix(ci): give rereview gh commands repository context

### DIFF
--- a/.github/workflows/auto-rereview-request.yml
+++ b/.github/workflows/auto-rereview-request.yml
@@ -40,6 +40,9 @@ jobs:
       (github.event_name == 'workflow_dispatch' ||
        github.event.pull_request.user.login == github.event.sender.login)
     runs-on: ubuntu-latest
+    env:
+      # This job intentionally does not checkout the repository. Give gh explicit context.
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Determine PR number
         id: pr

--- a/tests/test_workflow_secret_contracts.py
+++ b/tests/test_workflow_secret_contracts.py
@@ -179,6 +179,14 @@ class WorkflowSecretContractsTest(unittest.TestCase):
                 text = path.read_text(encoding="utf-8")
                 self.assertIn("inputs.app_id || vars.APP_ID", text)
 
+    def test_auto_rereview_gh_cli_has_repository_context_without_checkout(self) -> None:
+        workflow = load_workflow(WORKFLOWS / "auto-rereview-request.yml")
+        job = workflow["jobs"]["notify-reviewers"]
+        self.assertEqual("${{ github.repository }}", job["env"]["GH_REPO"])
+        self.assertFalse(
+            any("actions/checkout@" in step.get("uses", "") for step in job["steps"])
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- set job-level `GH_REPO` for the checkout-free auto-rereview notification job
- preserve the intentional no-checkout design while allowing every `gh pr` command to resolve its repository
- add a contract test for explicit repository context and absence of checkout

## Evidence
- v1.38 canary now parses and starts jobs, then fails at `gh pr view`: `fatal: not a git repository`
- local `gh help environment` documents `GH_REPO` for commands that otherwise operate on a local repository
- `pytest -q`: 80 passed
- central YAML parse passed; actionlint baseline 62, candidate 62, new 0

## Release
Keep v1.38 immutable. After merge, publish a new tag and update only wlan-driver #10 before fleet rollout.
