### PR TITLE
chore(fleet): record automation_ref v1.41 after fleet rollout

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.40",
+  "automation_ref": "v1.41",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -71,6 +71,15 @@ LEGACY_MANUAL_OUTPUT_BLOCK = """          echo "title<<EOF" >> "$GITHUB_OUTPUT"
 
 
 def restore_historical_v140_manual_outputs(repo: Path) -> None:
+    # v1.40 태그 픽스처는 그 시대의 fleet 상태를 담아야 한다: 라이브 트리의
+    # automation_ref(v1.41)를 역사적 값으로 되돌려 v1.40 정책 스냅샷 해시를 보존한다.
+    config_path = repo / "scripts/workflow-config.json"
+    config_text = config_path.read_text(encoding="utf-8")
+    assert config_text.count('"automation_ref": "v1.41"') == 1
+    config_path.write_text(
+        config_text.replace('"automation_ref": "v1.41"', '"automation_ref": "v1.40"', 1),
+        encoding="utf-8",
+    )
     root = repo / "examples/baseline-workflows/.github/workflows"
     for filename in ("gemini-issue-triage.yml", "gemini-pr-review.yml"):
         path = root / filename

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -36,7 +36,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.40"
+    assert config.automation_ref == "v1.41"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():

--- a/tests/test_workflow_release_bundle.py
+++ b/tests/test_workflow_release_bundle.py
@@ -114,6 +114,15 @@ def release_repo(tmp_path: Path) -> tuple[Path, str]:
             shutil.copytree(source, target)
         else:
             shutil.copy2(source, target)
+    # v1.40 태그 픽스처의 역사적 automation_ref 복원 (test_verify_workflow_release의
+    # restore_historical_v140_manual_outputs와 같은 취지 — 이 파일은 config 값만 필요).
+    config_path = repo / "scripts/workflow-config.json"
+    config_text = config_path.read_text(encoding="utf-8")
+    assert config_text.count('"automation_ref": "v1.41"') == 1
+    config_path.write_text(
+        config_text.replace('"automation_ref": "v1.41"', '"automation_ref": "v1.40"', 1),
+        encoding="utf-8",
+    )
     git(repo, "init", "-q")
     git(repo, "config", "user.name", "Test")
     git(repo, "config", "user.email", "test@example.com")


### PR DESCRIPTION
v1.41 플릿 롤아웃 완료(audit current=19/drift=0/blocked=0) 후 fleet 상태 기록 정합화.

- `scripts/workflow-config.json`: `automation_ref` v1.40 → v1.41 (배포된 실제 버전)
- v1.40 태그 픽스처들은 역사적 automation_ref를 복원해 v1.40 정책 스냅샷 해시 보존
  (기존 manual-output 복원과 동일 메커니즘)
- 라이브 트리를 읽는 catalog 기대값만 v1.41로 갱신

전체 스위트 493 passed + 48 subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bum7NehmFNfrs2w66ZKQqm