### PR TITLE
feat(fleet): retire 4 repos, add imx-vpu — generation-paired composition

### DIFF
--- a/scripts/workflow_catalog.py
+++ b/scripts/workflow_catalog.py
@@ -14,13 +14,32 @@ class CatalogError(ValueError):
 
 _CANONICAL_DIR = PurePosixPath("examples/baseline-workflows/.github")
 _CATALOG_PATH = "scripts/workflow-catalog.json"
-_REPOSITORY_NAMES = frozenset({
-    "gstApp", "max9296", "wlan-driver", "wlan-driver-v2", "wlan-bridge",
-    "wlan-package", "pim-package-jhw", "wlan-opc", "pcap-analyzer",
-    "wpa-supplicant", "sc16is7xx", "pim-check", "redmine", "jhw-notion",
-    "personal-ops", "cts-email-mcp-server", "cts-ta-mcp-server",
-    "cts-ta-webapp", "claude-config",
-})
+# 승인된 플릿 구성 세대: (repository set, bootstrap-allowed set) 쌍.
+# 릴리즈 검증기는 역사적 태그의 config도 현재 코드로 검증하므로, 구성 변경은 새 세대를
+# 추가하고 이전 세대를 보존한다 — 각 세대 안에서는 정확 일치(닫힌 집합)를 유지한다.
+_FLEET_GENERATIONS = (
+    # v1.40 ~ v1.43 (19 repos)
+    (
+        frozenset({
+            "gstApp", "max9296", "wlan-driver", "wlan-driver-v2", "wlan-bridge",
+            "wlan-package", "pim-package-jhw", "wlan-opc", "pcap-analyzer",
+            "wpa-supplicant", "sc16is7xx", "pim-check", "redmine", "jhw-notion",
+            "personal-ops", "cts-email-mcp-server", "cts-ta-mcp-server",
+            "cts-ta-webapp", "claude-config",
+        }),
+        frozenset({"wpa-supplicant", "cts-email-mcp-server"}),
+    ),
+    # v1.44+ (2026-08-19: wlan-driver 레거시 제외, cts-* 3종 미사용 제외, imx-vpu 추가)
+    (
+        frozenset({
+            "gstApp", "max9296", "imx-vpu", "wlan-driver-v2", "wlan-bridge",
+            "wlan-package", "pim-package-jhw", "wlan-opc", "pcap-analyzer",
+            "wpa-supplicant", "sc16is7xx", "pim-check", "redmine", "jhw-notion",
+            "personal-ops", "claude-config",
+        }),
+        frozenset({"wpa-supplicant"}),
+    ),
+)
 
 
 @dataclass(frozen=True)
@@ -185,7 +204,10 @@ def load_fleet_config(root: Path, catalog: WorkflowCatalog) -> FleetConfig:
     if _string(raw["catalog"], "catalog") != _CATALOG_PATH:
         raise CatalogError(f"invalid catalog path: {raw['catalog']}")
     repos = _mapping(raw["repos"], "repos")
-    if set(repos) != _REPOSITORY_NAMES:
+    generation = next(
+        (entry for entry in _FLEET_GENERATIONS if set(repos) == entry[0]), None
+    )
+    if generation is None:
         raise CatalogError(f"invalid repository set: {sorted(repos)}")
     optional_names = {entry.path.name for entry in catalog.entries if entry.kind == "optional"}
     profiles: dict[str, RepoProfile] = {}
@@ -209,7 +231,7 @@ def load_fleet_config(root: Path, catalog: WorkflowCatalog) -> FleetConfig:
         if allowed:
             bootstrap.add(name)
         profiles[name] = RepoProfile(name, "common-ai-v1", frozenset(optional), auth, allowed)
-    if bootstrap != {"wpa-supplicant", "cts-email-mcp-server"}:
+    if bootstrap != generation[1]:
         raise CatalogError(f"invalid bootstrap repositories: {sorted(bootstrap)}")
     return FleetConfig(_string(raw["gh_owner"], "gh_owner"), _string(raw["automation_ref"], "automation_ref"), canonical_dir, profiles)
 

--- a/scripts/workflow_catalog.py
+++ b/scripts/workflow_catalog.py
@@ -5,7 +5,7 @@ import dataclasses
 import json
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Literal, Mapping
+from typing import Literal, Mapping, NamedTuple
 
 
 class CatalogError(ValueError):
@@ -14,30 +14,35 @@ class CatalogError(ValueError):
 
 _CANONICAL_DIR = PurePosixPath("examples/baseline-workflows/.github")
 _CATALOG_PATH = "scripts/workflow-catalog.json"
-# 승인된 플릿 구성 세대: (repository set, bootstrap-allowed set) 쌍.
-# 릴리즈 검증기는 역사적 태그의 config도 현재 코드로 검증하므로, 구성 변경은 새 세대를
-# 추가하고 이전 세대를 보존한다 — 각 세대 안에서는 정확 일치(닫힌 집합)를 유지한다.
+class _FleetGeneration(NamedTuple):
+    repos: frozenset[str]
+    bootstrap: frozenset[str]
+
+
+# 승인된 플릿 구성 세대. 릴리즈 검증기는 역사적 태그의 config도 현재 코드로 검증하므로,
+# 구성 변경은 새 세대를 추가하고 이전 세대를 보존한다 — 각 세대 안에서는 정확 일치
+# (닫힌 집합)를 유지한다.
 _FLEET_GENERATIONS = (
     # v1.40 ~ v1.43 (19 repos)
-    (
-        frozenset({
+    _FleetGeneration(
+        repos=frozenset({
             "gstApp", "max9296", "wlan-driver", "wlan-driver-v2", "wlan-bridge",
             "wlan-package", "pim-package-jhw", "wlan-opc", "pcap-analyzer",
             "wpa-supplicant", "sc16is7xx", "pim-check", "redmine", "jhw-notion",
             "personal-ops", "cts-email-mcp-server", "cts-ta-mcp-server",
             "cts-ta-webapp", "claude-config",
         }),
-        frozenset({"wpa-supplicant", "cts-email-mcp-server"}),
+        bootstrap=frozenset({"wpa-supplicant", "cts-email-mcp-server"}),
     ),
     # v1.44+ (2026-08-19: wlan-driver 레거시 제외, cts-* 3종 미사용 제외, imx-vpu 추가)
-    (
-        frozenset({
+    _FleetGeneration(
+        repos=frozenset({
             "gstApp", "max9296", "imx-vpu", "wlan-driver-v2", "wlan-bridge",
             "wlan-package", "pim-package-jhw", "wlan-opc", "pcap-analyzer",
             "wpa-supplicant", "sc16is7xx", "pim-check", "redmine", "jhw-notion",
             "personal-ops", "claude-config",
         }),
-        frozenset({"wpa-supplicant"}),
+        bootstrap=frozenset({"wpa-supplicant"}),
     ),
 )
 
@@ -205,7 +210,7 @@ def load_fleet_config(root: Path, catalog: WorkflowCatalog) -> FleetConfig:
         raise CatalogError(f"invalid catalog path: {raw['catalog']}")
     repos = _mapping(raw["repos"], "repos")
     generation = next(
-        (entry for entry in _FLEET_GENERATIONS if set(repos) == entry[0]), None
+        (entry for entry in _FLEET_GENERATIONS if set(repos) == entry.repos), None
     )
     if generation is None:
         raise CatalogError(f"invalid repository set: {sorted(repos)}")
@@ -231,7 +236,7 @@ def load_fleet_config(root: Path, catalog: WorkflowCatalog) -> FleetConfig:
         if allowed:
             bootstrap.add(name)
         profiles[name] = RepoProfile(name, "common-ai-v1", frozenset(optional), auth, allowed)
-    if bootstrap != generation[1]:
+    if bootstrap != generation.bootstrap:
         raise CatalogError(f"invalid bootstrap repositories: {sorted(bootstrap)}")
     return FleetConfig(_string(raw["gh_owner"], "gh_owner"), _string(raw["automation_ref"], "automation_ref"), canonical_dir, profiles)
 

--- a/tests/fixtures/workflow-config-v1.40.json
+++ b/tests/fixtures/workflow-config-v1.40.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.41",
+  "automation_ref": "v1.40",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {
@@ -27,11 +27,10 @@
       "repo_write_auth": "github_app",
       "bootstrap_allowed": false
     },
-    "imx-vpu": {
+    "wlan-driver": {
       "profile": "common-ai-v1",
       "optional_workflows": [
         "auto-rereview-request.yml",
-        "gemini-chat.yml",
         "opencode.yml",
         "opencode-auto-review.yml"
       ],
@@ -123,6 +122,24 @@
       "profile": "common-ai-v1",
       "optional_workflows": [],
       "repo_write_auth": "github_app",
+      "bootstrap_allowed": false
+    },
+    "cts-email-mcp-server": {
+      "profile": "common-ai-v1",
+      "optional_workflows": [],
+      "repo_write_auth": "github_token",
+      "bootstrap_allowed": true
+    },
+    "cts-ta-mcp-server": {
+      "profile": "common-ai-v1",
+      "optional_workflows": [],
+      "repo_write_auth": "github_token",
+      "bootstrap_allowed": false
+    },
+    "cts-ta-webapp": {
+      "profile": "common-ai-v1",
+      "optional_workflows": [],
+      "repo_write_auth": "github_token",
       "bootstrap_allowed": false
     },
     "claude-config": {

--- a/tests/test_audit_workflow_fleet.py
+++ b/tests/test_audit_workflow_fleet.py
@@ -214,7 +214,7 @@ def test_fleet_cli_audits_all_profiles_with_refetch_and_no_remote_write(
     assert fetched == cloned
     assert all(command[:2] == ["switch", "--detach"] for command in commands)
     output = capsys.readouterr().out
-    assert "total=19" in output and "drift=19" in output and "blocked=0" in output
+    assert "total=16" in output and "drift=16" in output and "blocked=0" in output
     flattened = " ".join(" ".join(command) for command in commands)
     for forbidden in (
         "push",

--- a/tests/test_prepare_workflow_rollout.py
+++ b/tests/test_prepare_workflow_rollout.py
@@ -277,8 +277,10 @@ def test_quoted_literal_merge_spelling_is_preserved(
     assert quoted_merge in plan.after(".github/workflow-config.yml")
 
 
-def test_all_19_profiles_render_deterministically(tmp_path: Path) -> None:
-    assert len(PROFILES) == 19
+def test_all_16_profiles_render_deterministically(tmp_path: Path) -> None:
+    # 2026-08-19 구성 변경: wlan-driver(레거시)·cts-email/ta-mcp-server·cts-ta-webapp
+    # 제외, imx-vpu 추가 — 19 → 16.
+    assert len(PROFILES) == 16
     for name in PROFILES:
         first = render_profile(make_existing_repo(tmp_path / "first" / name), name)
         second = render_profile(make_existing_repo(tmp_path / "second" / name), name)
@@ -485,7 +487,7 @@ def test_missing_prerequisite_names_block_normal_repositories(tmp_path: Path) ->
     assert "APP_ID" in plan.reason
 
 
-@pytest.mark.parametrize("name", ["wpa-supplicant", "cts-email-mcp-server"])
+@pytest.mark.parametrize("name", ["wpa-supplicant"])
 def test_allowed_disabled_bootstrap_renders_required_callers_and_config_only(
     tmp_path: Path, name: str
 ) -> None:

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -184,7 +184,7 @@ def test_publish_requires_confirmation_and_explicit_repo(
             "--bootstrap-repo",
             "wpa-supplicant",
         ],
-        ["--repo", "wpa-supplicant", "--bootstrap-repo", "cts-email-mcp-server"],
+        ["--repo", "wpa-supplicant", "--bootstrap-repo", "pim-check"],
     ],
 )
 def test_bootstrap_requires_one_matching_allowed_repository_before_bundle_load(
@@ -822,12 +822,12 @@ def test_publish_refetches_each_repo_and_reports_partial_rerunnable_outcomes(
                 "--repo",
                 "max9296",
                 "--repo",
-                "wlan-driver",
+                "wlan-bridge",
             ]
         )
 
     assert rc == 1
-    assert calls == ["gstApp", "max9296", "wlan-driver"]
+    assert calls == ["gstApp", "max9296", "wlan-bridge"]
     report = json.loads((workspace / "rollout-manifest.json").read_text())
     assert [item["status"] for item in report] == ["published", "blocked", "reused"]
     assert report[0]["pr_url"].endswith("/gstApp/pull/1")

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -20,8 +20,6 @@ import scripts.verify_workflow_release as release_verifier
 from scripts.verify_workflow_release import ReleaseVerificationError, verify_release
 from scripts.workflow_release_inventory import RELEASE_PATHS
 
-from release_fixture_helpers import restore_historical_automation_ref
-
 ROOT = Path(__file__).resolve().parents[1]
 
 CANONICAL_REMOTE = "https://github.com/jhw7500/automation.git"
@@ -73,9 +71,12 @@ LEGACY_MANUAL_OUTPUT_BLOCK = """          echo "title<<EOF" >> "$GITHUB_OUTPUT"
 
 
 def restore_historical_v140_manual_outputs(repo: Path) -> None:
-    # v1.40 태그 픽스처는 그 시대의 fleet 상태를 담아야 한다: 라이브 트리의
-    # automation_ref 를 역사적 값으로 되돌려 v1.40 정책 스냅샷 해시를 보존한다.
-    restore_historical_automation_ref(repo, "v1.40")
+    # v1.40 태그 픽스처는 그 시대의 fleet 상태를 담아야 한다. v1.40 정책 스냅샷
+    # 해시는 workflow-config.json 전체 바이트를 커버하므로, 플릿 구성이 변한 뒤에는
+    # automation_ref 치환만으로 역사적 바이트를 재현할 수 없다 — 태그에서 뽑아 둔
+    # 스냅샷 픽스처(tests/fixtures/workflow-config-v1.40.json)를 통째로 복원한다.
+    snapshot = Path(__file__).parent / "fixtures" / "workflow-config-v1.40.json"
+    (repo / "scripts/workflow-config.json").write_bytes(snapshot.read_bytes())
     root = repo / "examples/baseline-workflows/.github/workflows"
     for filename in ("gemini-issue-triage.yml", "gemini-pr-review.yml"):
         path = root / filename

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -12,7 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 EXPECTED = {
     "gstApp": ({"auto-rereview-request.yml", "gemini-chat.yml", "opencode.yml", "opencode-auto-review.yml"}, "github_app", False),
     "max9296": ({"auto-rereview-request.yml", "gemini-chat.yml", "opencode.yml", "opencode-auto-review.yml"}, "github_app", False),
-    "wlan-driver": ({"auto-rereview-request.yml", "opencode.yml", "opencode-auto-review.yml"}, "github_token", False),
+    "imx-vpu": ({"auto-rereview-request.yml", "gemini-chat.yml", "opencode.yml", "opencode-auto-review.yml"}, "github_token", False),
     "wlan-driver-v2": ({"auto-rereview-request.yml", "opencode.yml", "opencode-auto-review.yml"}, "github_app", False),
     "wlan-bridge": ({"gemini-chat.yml", "opencode.yml", "opencode-auto-review.yml"}, "github_app", False),
     "wlan-package": ({"opencode.yml", "opencode-auto-review.yml"}, "github_app", False),
@@ -25,9 +25,6 @@ EXPECTED = {
     "redmine": (set(), "github_app", False),
     "jhw-notion": (set(), "github_app", False),
     "personal-ops": (set(), "github_app", False),
-    "cts-email-mcp-server": (set(), "github_token", True),
-    "cts-ta-mcp-server": (set(), "github_token", False),
-    "cts-ta-webapp": (set(), "github_token", False),
     "claude-config": (set(), "github_token", False),
 }
 
@@ -100,7 +97,7 @@ def test_catalog_rejects_invalid_entries(tmp_path: Path, entries: list[dict]) ->
     ),
     (
         lambda config: config["repos"]["wlan-package"].__setitem__("bootstrap_allowed", True),
-        "invalid bootstrap repositories: [\'cts-email-mcp-server\', \'wlan-package\', \'wpa-supplicant\']",
+        "invalid bootstrap repositories: [\'wlan-package\', \'wpa-supplicant\']",
     ),
 ])
 def test_fleet_rejects_invalid_profiles(tmp_path: Path, change: object, message: str) -> None:


### PR DESCRIPTION
## 구성 변경 (운영 결정 2026-08-19)

| 동작 | 리포 | 사유 |
| --- | --- | --- |
| 제외 | wlan-driver | 레거시 (기존 워크플로우는 리포에 유지, 관리 대상에서만 제외) |
| 제외 | cts-email-mcp-server · cts-ta-mcp-server · cts-ta-webapp | 현재 미사용 |
| 추가 | imx-vpu | v1.33 시절 구식 소비 리포 재편입 — 자체 config·전체 caller 보유(github_token, bootstrap 불필요) |

플릿: 19 → **16 리포**.

## 설계 포인트: 세대 쌍(generation-paired) 구성 검증

릴리즈 검증기는 역사적 태그(v1.40/v1.40.1)의 config를 **현재 코드**로 검증하므로, 리포 집합·bootstrap 집합의 단일 하드코딩 정확 일치는 구성 변경과 양립 불가. `(repository set, bootstrap set)` 쌍의 승인 세대 목록(`_FLEET_GENERATIONS`)으로 전환 — 각 세대 안에서는 기존과 동일한 닫힌 집합 정확 일치를 유지.

같은 이유로 v1.40 정책 스냅샷 해시(config 전체 바이트 커버)의 픽스처 복원을 automation_ref 문자열 치환 → **태그 추출 스냅샷 통복원**(`tests/fixtures/workflow-config-v1.40.json`, `git show v1.40:` 바이트 그대로)으로 교체.

## 검증

- `python3 -m pytest tests/ -q`: **502 passed + 48 subtests** (구성 변경 반영으로 파라미터 케이스 6건 감소)
- 후속: 머지 후 v1.44 태그 → 잔여 9개 + v1.43 6개 재핀 + imx-vpu = 16개 v1.44 통일 웨이브 → automation_ref 기록

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3b9UyPt68bySXZCKCoyUk