### PR TITLE
chore(fleet): record automation_ref v1.44 after fleet rollout

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.41",
+  "automation_ref": "v1.44",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -33,7 +33,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.41"
+    assert config.automation_ref == "v1.44"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
v1.44 플릿 롤아웃 완료 후 릴리즈 정체성 기록 (v1.41 사이클 PR #33과 동일 패턴).

- 감사: `audit --ref v1.44` → **total=16 current=15 drift=0 blocked=1**
- blocked 1건 = imx-vpu (ZHIPU_API_KEY 시크릿 대기 — 설정 후 합류)
- 전체 테스트 502 + 48 subtests 통과 (CLI --ref 기본값·픽스처는 config 단일 출처라 이 PR 외 갱신 지점 없음; 카탈로그 승인 핀만 함께 갱신)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3b9UyPt68bySXZCKCoyUk