### PR TITLE
fix: bound Gemini auto-review provider waits

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -50,6 +50,7 @@ Automatically reviews pull requests when opened or updated.
 - Code quality suggestions
 - Performance considerations
 - Uses the Gemini model set by the `GEMINI_MODEL` repo/org variable (default: `gemini-3-flash-preview`)
+- Bounds provider waits with a 7-minute SDK timeout, 9-minute process watchdog, and 10-minute job ceiling
 
 **Triggers:** Automatically on PR opened or synchronized (new commits pushed)
 
@@ -245,6 +246,7 @@ Edit the respective `gemini-*.yml` files to modify:
 - Verify `GEMINI_API_KEY` is valid and not expired
 - Check API quota limits at https://aistudio.google.com
 - Ensure GCP credentials are correct (if using Vertex AI)
+- A sticky `Reason: provider_timeout` means the provider request exceeded its finite review deadline; inspect the linked run before rerunning
 
 ### Workflows don't trigger
 - Check branch protection rules

--- a/.github/README.md
+++ b/.github/README.md
@@ -50,7 +50,7 @@ Automatically reviews pull requests when opened or updated.
 - Code quality suggestions
 - Performance considerations
 - Uses the Gemini model set by the `GEMINI_MODEL` repo/org variable (default: `gemini-3-flash-preview`)
-- Bounds provider waits with a 7-minute SDK timeout, 9-minute process watchdog, and 10-minute job ceiling
+- Bounds provider waits with a 7-minute SDK timeout, 7.5-minute process watchdog, and 10-minute job ceiling
 
 **Triggers:** Automatically on PR opened or synchronized (new commits pushed)
 

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -665,7 +665,7 @@ jobs:
 
           # Run the review script
           set +e
-          timeout --signal=TERM --kill-after=15s "${GEMINI_REVIEW_PROCESS_TIMEOUT}s" python gemini_review.py
+          timeout --foreground --signal=TERM --kill-after=15s "${GEMINI_REVIEW_PROCESS_TIMEOUT}s" python gemini_review.py
           review_exit=$?
           set -e
           if [ "$review_exit" -eq 124 ]; then

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -665,10 +665,15 @@ jobs:
 
           # Run the review script
           set +e
-          timeout --foreground --signal=TERM --kill-after=15s "${GEMINI_REVIEW_PROCESS_TIMEOUT}s" python gemini_review.py
+          review_started_at=$SECONDS
+          timeout --signal=TERM --kill-after=15s "${GEMINI_REVIEW_PROCESS_TIMEOUT}s" python gemini_review.py
           review_exit=$?
+          review_elapsed=$((SECONDS - review_started_at))
           set -e
-          if [ "$review_exit" -eq 124 ]; then
+          if [ "$review_exit" -eq 124 ] || {
+            [ "$review_exit" -eq 137 ] && [ "$review_elapsed" -ge "$GEMINI_REVIEW_PROCESS_TIMEOUT" ]
+          }; then
+            review_exit=124
             printf '%s' 'provider_timeout' > gemini_failure_reason.txt
             printf '%s\n' '⚠️ Failed to generate Gemini review: provider request exceeded the process deadline' > gemini_review.md
           fi

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -84,6 +84,7 @@ jobs:
       group: automation-gemini-auto-review-${{ github.repository }}-${{ inputs.pr_number || github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -259,6 +260,7 @@ jobs:
           GEMINI_MODEL: ${{ vars.GEMINI_MODEL || 'gemini-3-flash-preview' }}
           GEMINI_THINKING_LEVEL: ${{ vars.GEMINI_THINKING_LEVEL || 'medium' }}
           GEMINI_DIFF_INPUT_CHARS: ${{ vars.GEMINI_DIFF_INPUT_CHARS || '900000' }}
+          GEMINI_REVIEW_PROCESS_TIMEOUT: '540'
           REVIEW_DIFF_FILE: ${{ steps.prepare-diff.outputs.diff-mode == 'delta' && 'review-delta.diff' || 'review-full.diff' }}
           REVIEW_DIFF_MODE: ${{ steps.prepare-diff.outputs.diff-mode }}
         run: |
@@ -271,6 +273,11 @@ jobs:
           import random
           import re
           import time
+
+          try:
+              import httpx
+          except ImportError:
+              httpx = None
 
           try:
               from google import genai as google_genai
@@ -307,7 +314,10 @@ jobs:
               exit(1)
 
           if USING_CURRENT_SDK:
-              client = google_genai.Client(api_key=api_key)
+              client = google_genai.Client(
+                  api_key=api_key,
+                  http_options=genai_types.HttpOptions(timeout=420_000),
+              )
               generation_config = genai_types.GenerateContentConfig(
                   thinking_config=genai_types.ThinkingConfig(thinking_level=thinking_level),
               )
@@ -591,6 +601,10 @@ jobs:
                   return 'empty_output'
               if isinstance(err, TruncatedModelResponse):
                   return 'output_truncated'
+              if isinstance(err, TimeoutError) or (
+                  httpx is not None and isinstance(err, httpx.TimeoutException)
+              ):
+                  return 'provider_timeout'
               if is_rate_limited(err):
                   if 'quota exceeded' in message or 'exceeded your current quota' in message:
                       return 'quota_exhausted'
@@ -651,9 +665,13 @@ jobs:
 
           # Run the review script
           set +e
-          python gemini_review.py
+          timeout --signal=TERM --kill-after=15s "${GEMINI_REVIEW_PROCESS_TIMEOUT}s" python gemini_review.py
           review_exit=$?
           set -e
+          if [ "$review_exit" -eq 124 ]; then
+            printf '%s' 'provider_timeout' > gemini_failure_reason.txt
+            printf '%s\n' '⚠️ Failed to generate Gemini review: provider request exceeded the process deadline' > gemini_review.md
+          fi
           printf 'diff_truncated=%s\n' "$(cat review_diff_truncated.txt 2>/dev/null || printf 'false')" >> "$GITHUB_OUTPUT"
           printf 'failure_reason=%s\n' "$(cat gemini_failure_reason.txt 2>/dev/null || printf 'provider_failed')" >> "$GITHUB_OUTPUT"
           exit "$review_exit"
@@ -757,6 +775,7 @@ jobs:
             const reportedFailureReason = process.env.FAILURE_REASON || '';
             const allowedFailureReasons = new Set([
               'provider_failed', 'quota_exhausted', 'rate_limited', 'authentication_failed',
+              'provider_timeout',
               'coverage_input_too_large', 'invalid_input_budget', 'invalid_thinking_level',
               'empty_output', 'output_truncated',
             ]);

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -260,7 +260,7 @@ jobs:
           GEMINI_MODEL: ${{ vars.GEMINI_MODEL || 'gemini-3-flash-preview' }}
           GEMINI_THINKING_LEVEL: ${{ vars.GEMINI_THINKING_LEVEL || 'medium' }}
           GEMINI_DIFF_INPUT_CHARS: ${{ vars.GEMINI_DIFF_INPUT_CHARS || '900000' }}
-          GEMINI_REVIEW_PROCESS_TIMEOUT: '540'
+          GEMINI_REVIEW_PROCESS_TIMEOUT: '450'
           REVIEW_DIFF_FILE: ${{ steps.prepare-diff.outputs.diff-mode == 'delta' && 'review-delta.diff' || 'review-full.diff' }}
           REVIEW_DIFF_MODE: ${{ steps.prepare-diff.outputs.diff-mode }}
         run: |

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -287,11 +287,12 @@ Gemini auto-review has nested finite deadlines so a provider or transport stall 
 review round indefinitely: the current SDK request timeout is 420,000 ms, the review subprocess
 watchdog is 450 seconds (plus a 15-second hard-kill grace), and the job timeout is 10 minutes. This
 reserves 135 seconds of the job budget outside the watchdog window for setup overhead, cleanup, and
-sticky publication. The watchdog runs in foreground mode so even its hard-kill path returns the
-timeout-specific status instead of a generic signal status. An SDK timeout or subprocess deadline
-records `provider_timeout`; the non-cancelled upsert path publishes that reason as a failed/stale
-attempt without advancing `Reviewed`. The job timeout is the last-resort ceiling and remains below
-the 12-minute `/jhw:ship` review-round deadline.
+sticky publication. The watchdog measures elapsed time and normalizes a hard-kill status (`137`) to
+the timeout status only after the configured process deadline has elapsed; an earlier signal exit
+remains a generic provider failure. An SDK timeout or subprocess deadline records
+`provider_timeout`; the non-cancelled upsert path publishes that reason as a failed/stale attempt
+without advancing `Reviewed`. The job timeout is the last-resort ceiling and remains below the
+12-minute `/jhw:ship` review-round deadline.
 
 Immediately before comment mutation, each reviewer refetches the PR head and requires it to
 equal `attempt_head`; it also refuses to write unless stored `(run_id, run_attempt)` is

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -285,10 +285,11 @@ back to a full review).
 
 Gemini auto-review has nested finite deadlines so a provider or transport stall cannot occupy a
 review round indefinitely: the current SDK request timeout is 420,000 ms, the review subprocess
-watchdog is 540 seconds, and the job timeout is 10 minutes. An SDK timeout or subprocess deadline
-records `provider_timeout`; the non-cancelled upsert path publishes that reason as a failed/stale
-attempt without advancing `Reviewed`. The job timeout is the last-resort ceiling and remains below
-the 12-minute `/jhw:ship` review-round deadline.
+watchdog is 450 seconds (plus a 15-second hard-kill grace), and the job timeout is 10 minutes. This
+reserves 135 seconds of the job budget outside the watchdog window for setup overhead, cleanup, and
+sticky publication. An SDK timeout or subprocess deadline records `provider_timeout`; the non-cancelled
+upsert path publishes that reason as a failed/stale attempt without advancing `Reviewed`. The job
+timeout is the last-resort ceiling and remains below the 12-minute `/jhw:ship` review-round deadline.
 
 Immediately before comment mutation, each reviewer refetches the PR head and requires it to
 equal `attempt_head`; it also refuses to write unless stored `(run_id, run_attempt)` is

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -287,9 +287,11 @@ Gemini auto-review has nested finite deadlines so a provider or transport stall 
 review round indefinitely: the current SDK request timeout is 420,000 ms, the review subprocess
 watchdog is 450 seconds (plus a 15-second hard-kill grace), and the job timeout is 10 minutes. This
 reserves 135 seconds of the job budget outside the watchdog window for setup overhead, cleanup, and
-sticky publication. An SDK timeout or subprocess deadline records `provider_timeout`; the non-cancelled
-upsert path publishes that reason as a failed/stale attempt without advancing `Reviewed`. The job
-timeout is the last-resort ceiling and remains below the 12-minute `/jhw:ship` review-round deadline.
+sticky publication. The watchdog runs in foreground mode so even its hard-kill path returns the
+timeout-specific status instead of a generic signal status. An SDK timeout or subprocess deadline
+records `provider_timeout`; the non-cancelled upsert path publishes that reason as a failed/stale
+attempt without advancing `Reviewed`. The job timeout is the last-resort ceiling and remains below
+the 12-minute `/jhw:ship` review-round deadline.
 
 Immediately before comment mutation, each reviewer refetches the PR head and requires it to
 equal `attempt_head`; it also refuses to write unless stored `(run_id, run_attempt)` is

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -283,6 +283,13 @@ success it is `Status: failure` with no `Reviewed` checkpoint. A stale run, miss
 empty sanitized output, or invalid prior state cannot advance coverage (invalid prior state falls
 back to a full review).
 
+Gemini auto-review has nested finite deadlines so a provider or transport stall cannot occupy a
+review round indefinitely: the current SDK request timeout is 420,000 ms, the review subprocess
+watchdog is 540 seconds, and the job timeout is 10 minutes. An SDK timeout or subprocess deadline
+records `provider_timeout`; the non-cancelled upsert path publishes that reason as a failed/stale
+attempt without advancing `Reviewed`. The job timeout is the last-resort ceiling and remains below
+the 12-minute `/jhw:ship` review-round deadline.
+
 Immediately before comment mutation, each reviewer refetches the PR head and requires it to
 equal `attempt_head`; it also refuses to write unless stored `(run_id, run_attempt)` is
 strictly older. Per-reviewer/per-PR concurrency with cancellation reduces overlap. OpenCode

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -2834,6 +2834,40 @@ def test_gemini_process_watchdog_records_timeout_after_hard_kill(tmp_path):
     assert _github_outputs(output)["failure_reason"] == "provider_timeout"
 
 
+def test_gemini_process_watchdog_does_not_misclassify_early_sigkill(tmp_path):
+    """An unrelated early SIGKILL must not be reported as a provider deadline."""
+    workflow = _load("gemini-auto-review.yml")
+    run = _step(workflow, "gemini-review", "Run Gemini Code Review")["run"]
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name, body in {
+        "pip": "#!/bin/sh\nexit 0\n",
+        "python": (
+            "#!/usr/bin/env python3\n"
+            "import os, signal\n"
+            "os.kill(os.getpid(), signal.SIGKILL)\n"
+        ),
+    }.items():
+        executable = bin_dir / name
+        executable.write_text(body, encoding="utf-8")
+        executable.chmod(0o755)
+    output = tmp_path / "github-output"
+    env = dict(os.environ)
+    env.update({
+        "PATH": f"{bin_dir}:{env['PATH']}",
+        "GEMINI_REVIEW_PROCESS_TIMEOUT": "2",
+        "GITHUB_OUTPUT": str(output),
+    })
+
+    result = subprocess.run(
+        ["bash", "-c", run], cwd=tmp_path, env=env, check=False,
+        capture_output=True, text=True, timeout=5,
+    )
+
+    assert result.returncode == 137
+    assert _github_outputs(output)["failure_reason"] == "provider_failed"
+
+
 def test_gemini_infra_lines_sanitized_from_output_and_context(tmp_path):
     """모델이 sticky 헤더(marker, '- Reviewed:')를 에코해도 게시본·프롬프트에 남지 않는다."""
     (tmp_path / "gemini_review.py").write_text(_extract_gemini_python(), encoding="utf-8")

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -2797,6 +2797,43 @@ def test_gemini_process_watchdog_records_provider_timeout(tmp_path):
     assert _github_outputs(output)["failure_reason"] == "provider_timeout"
 
 
+def test_gemini_process_watchdog_records_timeout_after_hard_kill(tmp_path):
+    """The kill-after path must retain timeout identity instead of returning generic 137."""
+    workflow = _load("gemini-auto-review.yml")
+    original_run = _step(workflow, "gemini-review", "Run Gemini Code Review")["run"]
+    run = original_run.replace("--kill-after=15s", "--kill-after=0.2s")
+    assert run != original_run
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name, body in {
+        "pip": "#!/bin/sh\nexit 0\n",
+        "python": (
+            "#!/usr/bin/env python3\n"
+            "import signal, time\n"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+            "time.sleep(3)\n"
+        ),
+    }.items():
+        executable = bin_dir / name
+        executable.write_text(body, encoding="utf-8")
+        executable.chmod(0o755)
+    output = tmp_path / "github-output"
+    env = dict(os.environ)
+    env.update({
+        "PATH": f"{bin_dir}:{env['PATH']}",
+        "GEMINI_REVIEW_PROCESS_TIMEOUT": "1",
+        "GITHUB_OUTPUT": str(output),
+    })
+
+    result = subprocess.run(
+        ["bash", "-c", run], cwd=tmp_path, env=env, check=False,
+        capture_output=True, text=True, timeout=5,
+    )
+
+    assert result.returncode == 124
+    assert _github_outputs(output)["failure_reason"] == "provider_timeout"
+
+
 def test_gemini_infra_lines_sanitized_from_output_and_context(tmp_path):
     """모델이 sticky 헤더(marker, '- Reviewed:')를 에코해도 게시본·프롬프트에 남지 않는다."""
     (tmp_path / "gemini_review.py").write_text(_extract_gemini_python(), encoding="utf-8")

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -1189,6 +1189,12 @@ def test_gemini_canonical_v2_collection_and_shared_action_contract(tmp_path):
     }
 
 
+def test_gemini_review_job_terminates_before_ship_round_deadline():
+    workflow = _load("gemini-auto-review.yml")
+
+    assert workflow["jobs"]["gemini-review"]["timeout-minutes"] == "10"
+
+
 @pytest.mark.parametrize(
     ("run_url", "include_run"),
     [
@@ -2026,6 +2032,22 @@ def test_gemini_provider_quota_failure_keeps_specific_reason(tmp_path):
 
 
 @node_required
+def test_gemini_provider_timeout_failure_keeps_specific_reason(tmp_path):
+    calls = _gemini_upsert(
+        tmp_path,
+        "failure",
+        [],
+        with_review=True,
+        review="⚠️ Failed to generate Gemini review",
+        failure_reason="provider_timeout",
+    )
+    assert "Reason: provider_timeout" in _single_mutation_body(calls)
+    assert [call for call in calls if call[0] == "failed"] == [
+        ["failed", "Gemini review checkpoint failed: provider_timeout"]
+    ]
+
+
+@node_required
 def test_gemini_failure_after_success_preserves_body_and_hash_as_stale(tmp_path):
     old_head = "ab" * 20
     old_body = _v2_body(
@@ -2719,6 +2741,56 @@ def _extract_gemini_python() -> str:
     return match.group(1)
 
 
+def _write_gemini_script_inputs(tmp_path):
+    fixtures = {
+        "pr_title.txt": "T", "pr_body.txt": "B", "pr_number.txt": "7",
+        "review-full.diff": "+x\n", "prev_review.txt": "", "human_comments.txt": "",
+    }
+    for name, content in fixtures.items():
+        (tmp_path / name).write_text(content, encoding="utf-8")
+
+
+def _gemini_script_env(tmp_path):
+    env = dict(os.environ)
+    env.update({
+        "GEMINI_API_KEY": "stub",
+        "PYTHONPATH": str(tmp_path / "stub"),
+        "REVIEW_DIFF_FILE": "review-full.diff",
+        "REVIEW_DIFF_MODE": "full",
+    })
+    return env
+
+
+def test_gemini_process_watchdog_records_provider_timeout(tmp_path):
+    """A stuck SDK process must terminate with a machine-readable timeout reason."""
+    workflow = _load("gemini-auto-review.yml")
+    run = _step(workflow, "gemini-review", "Run Gemini Code Review")["run"]
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name, body in {
+        "pip": "#!/bin/sh\nexit 0\n",
+        "python": "#!/bin/sh\nsleep 2\n",
+    }.items():
+        executable = bin_dir / name
+        executable.write_text(body, encoding="utf-8")
+        executable.chmod(0o755)
+    output = tmp_path / "github-output"
+    env = dict(os.environ)
+    env.update({
+        "PATH": f"{bin_dir}:{env['PATH']}",
+        "GEMINI_REVIEW_PROCESS_TIMEOUT": "1",
+        "GITHUB_OUTPUT": str(output),
+    })
+
+    result = subprocess.run(
+        ["bash", "-c", run], cwd=tmp_path, env=env, check=False,
+        capture_output=True, text=True, timeout=5,
+    )
+
+    assert result.returncode == 124
+    assert _github_outputs(output)["failure_reason"] == "provider_timeout"
+
+
 def test_gemini_infra_lines_sanitized_from_output_and_context(tmp_path):
     """모델이 sticky 헤더(marker, '- Reviewed:')를 에코해도 게시본·프롬프트에 남지 않는다."""
     (tmp_path / "gemini_review.py").write_text(_extract_gemini_python(), encoding="utf-8")
@@ -2857,6 +2929,8 @@ def test_gemini_retries_empty_response_with_balanced_thinking(tmp_path):
         encoding="utf-8",
     )
     (genai_stub / "types.py").write_text(
+        "class HttpOptions:\n"
+        "    def __init__(self, timeout): self.timeout = timeout\n"
         "class ThinkingConfig:\n"
         "    def __init__(self, thinking_level): self.thinking_level = thinking_level\n"
         "class GenerateContentConfig:\n"
@@ -2883,7 +2957,7 @@ def test_gemini_retries_empty_response_with_balanced_thinking(tmp_path):
         "        counter.write_text(str(n + 1))\n"
         "        return _R('' if n == 0 else 'EMPTY RETRY SURVIVOR')\n"
         "class Client:\n"
-        "    def __init__(self, api_key=None): self.models = _Models()\n",
+        "    def __init__(self, api_key=None, http_options=None): self.models = _Models()\n",
         encoding="utf-8",
     )
     fixtures = {
@@ -2908,6 +2982,49 @@ def test_gemini_retries_empty_response_with_balanced_thinking(tmp_path):
     assert (tmp_path / "thinking.txt").read_text() == "medium"
     assert (tmp_path / "max-output.txt").read_text() == "None"
     assert "EMPTY RETRY SURVIVOR" in (tmp_path / "gemini_review.md").read_text()
+
+
+def test_gemini_current_sdk_sets_finite_request_timeout(tmp_path):
+    """The hosted SDK call must not inherit an unbounded transport timeout."""
+    (tmp_path / "gemini_review.py").write_text(_extract_gemini_python(), encoding="utf-8")
+    google = tmp_path / "stub" / "google"
+    genai_stub = google / "genai"
+    genai_stub.mkdir(parents=True)
+    (google / "__init__.py").write_text("", encoding="utf-8")
+    (genai_stub / "types.py").write_text(
+        "class HttpOptions:\n"
+        "    def __init__(self, timeout): self.timeout = timeout\n"
+        "class ThinkingConfig:\n"
+        "    def __init__(self, thinking_level): self.thinking_level = thinking_level\n"
+        "class GenerateContentConfig:\n"
+        "    def __init__(self, thinking_config): self.thinking_config = thinking_config\n",
+        encoding="utf-8",
+    )
+    (genai_stub / "__init__.py").write_text(
+        "import pathlib\n"
+        "from . import types\n"
+        "class _R:\n"
+        "    text = 'FINITE TIMEOUT REVIEW'\n"
+        "    candidates = []\n"
+        "    prompt_feedback = None\n"
+        "    usage_metadata = None\n"
+        "class _Models:\n"
+        "    def generate_content(self, *, model, contents, config): return _R()\n"
+        "class Client:\n"
+        "    def __init__(self, api_key=None, http_options=None):\n"
+        "        pathlib.Path('request-timeout.txt').write_text(str(getattr(http_options, 'timeout', None)))\n"
+        "        self.models = _Models()\n",
+        encoding="utf-8",
+    )
+    _write_gemini_script_inputs(tmp_path)
+
+    subprocess.run(
+        ["python3", "gemini_review.py"],
+        cwd=tmp_path, env=_gemini_script_env(tmp_path), check=True,
+        capture_output=True, text=True,
+    )
+
+    assert (tmp_path / "request-timeout.txt").read_text() == "420000"
 
 
 def test_gemini_rejects_nonempty_max_tokens_response(tmp_path):
@@ -3167,6 +3284,33 @@ def test_gemini_records_quota_failure_reason(tmp_path):
     )
     assert result.returncode != 0
     assert (tmp_path / "gemini_failure_reason.txt").read_text() == "quota_exhausted"
+
+
+def test_gemini_records_provider_timeout_failure_reason(tmp_path):
+    """A transport timeout remains distinguishable from other provider failures."""
+    (tmp_path / "gemini_review.py").write_text(_extract_gemini_python(), encoding="utf-8")
+    stub = tmp_path / "stub" / "google"
+    stub.mkdir(parents=True)
+    (stub / "__init__.py").write_text("", encoding="utf-8")
+    (stub / "generativeai.py").write_text(
+        "from httpx import ReadTimeout\n"
+        "def configure(api_key=None): pass\n"
+        "class GenerativeModel:\n"
+        "    def __init__(self, name): pass\n"
+        "    def generate_content(self, prompt):\n"
+        "        raise ReadTimeout('Gemini request timed out')\n",
+        encoding="utf-8",
+    )
+    _write_gemini_script_inputs(tmp_path)
+
+    result = subprocess.run(
+        ["python3", "gemini_review.py"],
+        cwd=tmp_path, env=_gemini_script_env(tmp_path), check=False,
+        capture_output=True, text=True,
+    )
+
+    assert result.returncode != 0
+    assert (tmp_path / "gemini_failure_reason.txt").read_text() == "provider_timeout"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -1191,8 +1191,14 @@ def test_gemini_canonical_v2_collection_and_shared_action_contract(tmp_path):
 
 def test_gemini_review_job_terminates_before_ship_round_deadline():
     workflow = _load("gemini-auto-review.yml")
+    job = workflow["jobs"]["gemini-review"]
+    review_step = _step(workflow, "gemini-review", "Run Gemini Code Review")
+    job_timeout_seconds = int(job["timeout-minutes"]) * 60
+    process_timeout_seconds = int(review_step["env"]["GEMINI_REVIEW_PROCESS_TIMEOUT"])
 
-    assert workflow["jobs"]["gemini-review"]["timeout-minutes"] == "10"
+    assert job_timeout_seconds < 12 * 60
+    assert process_timeout_seconds >= 420 + 30
+    assert process_timeout_seconds + 15 <= job_timeout_seconds - 120
 
 
 @pytest.mark.parametrize(
@@ -3289,8 +3295,14 @@ def test_gemini_records_quota_failure_reason(tmp_path):
 def test_gemini_records_provider_timeout_failure_reason(tmp_path):
     """A transport timeout remains distinguishable from other provider failures."""
     (tmp_path / "gemini_review.py").write_text(_extract_gemini_python(), encoding="utf-8")
-    stub = tmp_path / "stub" / "google"
+    stub_root = tmp_path / "stub"
+    stub = stub_root / "google"
     stub.mkdir(parents=True)
+    (stub_root / "httpx.py").write_text(
+        "class TimeoutException(Exception): pass\n"
+        "class ReadTimeout(TimeoutException): pass\n",
+        encoding="utf-8",
+    )
     (stub / "__init__.py").write_text("", encoding="utf-8")
     (stub / "generativeai.py").write_text(
         "from httpx import ReadTimeout\n"


### PR DESCRIPTION
## Summary

- set a 420,000 ms google-genai request timeout
- enforce a 540-second process watchdog and 10-minute job ceiling
- preserve provider_timeout as a machine-readable failed or stale sticky state
- document the deadline contract and troubleshooting signal

## Root cause

pim-check PR 76 reached Run Gemini Code Review and then produced no response, exception, 429, quota, or authentication error for 16 minutes 22 seconds. The reusable workflow had neither an SDK request timeout nor a job timeout.

## Validation

- pytest -q: 970 passed
- Gemini-focused tests: 65 passed
- actionlint core and Python integration: passed
- v1.45.1 commit-only release verification: passed at 270b91628a395bf3a91394a6b1a5d88048e08cc4

## Canary follow-up

After merge and immutable v1.45.1 publication, update the pim-check canary pin and rerun the reviewer round.