### PR TITLE
fix: retry guided Gemini quota responses

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -245,6 +245,7 @@ Edit the respective `gemini-*.yml` files to modify:
 ### Gemini workflows fail
 - Verify `GEMINI_API_KEY` is valid and not expired
 - Check API quota limits at https://aistudio.google.com
+- A quota response with provider retry guidance receives bounded backoff; a final `Reason: quota_exhausted` means all allowed attempts failed or the provider supplied no retry guidance
 - Ensure GCP credentials are correct (if using Vertex AI)
 - A sticky `Reason: provider_timeout` means the provider request exceeded its finite review deadline; inspect the linked run before rerunning
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -245,7 +245,8 @@ Edit the respective `gemini-*.yml` files to modify:
 ### Gemini workflows fail
 - Verify `GEMINI_API_KEY` is valid and not expired
 - Check API quota limits at https://aistudio.google.com
-- A quota response with positive provider retry guidance (seconds or milliseconds) receives bounded backoff only when the wait fits inside the remaining process watchdog; a final `Reason: quota_exhausted` means all allowed attempts failed, guidance was absent, or the guided wait could not fit
+- A quota response with positive provider retry guidance (seconds or milliseconds) receives bounded backoff; a final `Reason: quota_exhausted` means all allowed attempts failed or guidance was absent
+- Every 429 retry is skipped when its computed backoff cannot fit inside the remaining process watchdog, preserving `quota_exhausted` or `rate_limited` instead of timing out during sleep
 - Ensure GCP credentials are correct (if using Vertex AI)
 - A sticky `Reason: provider_timeout` means the provider request exceeded its finite review deadline; inspect the linked run before rerunning
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -245,7 +245,7 @@ Edit the respective `gemini-*.yml` files to modify:
 ### Gemini workflows fail
 - Verify `GEMINI_API_KEY` is valid and not expired
 - Check API quota limits at https://aistudio.google.com
-- A quota response with provider retry guidance receives bounded backoff; a final `Reason: quota_exhausted` means all allowed attempts failed or the provider supplied no retry guidance
+- A quota response with positive provider retry guidance (seconds or milliseconds) receives bounded backoff only when the wait fits inside the remaining process watchdog; a final `Reason: quota_exhausted` means all allowed attempts failed, guidance was absent, or the guided wait could not fit
 - Ensure GCP credentials are correct (if using Vertex AI)
 - A sticky `Reason: provider_timeout` means the provider request exceeded its finite review deadline; inspect the linked run before rerunning
 

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -274,6 +274,8 @@ jobs:
           import re
           import time
 
+          PROCESS_STARTED_AT = time.monotonic()
+
           try:
               import httpx
           except ImportError:
@@ -537,6 +539,10 @@ jobs:
           RETRY_SLEEP = float(os.environ.get("GEMINI_429_RETRY_SLEEP", "35"))
           RETRY_JITTER = float(os.environ.get("GEMINI_429_RETRY_JITTER", "5"))
           EMPTY_RETRY_SLEEP = float(os.environ.get("GEMINI_EMPTY_RETRY_SLEEP", "2"))
+          PROCESS_TIMEOUT = max(
+              float(os.environ.get("GEMINI_REVIEW_PROCESS_TIMEOUT", "450")), 0
+          )
+          RETRY_DEADLINE_MARGIN = 5.0
 
           # 429 판정은 SDK의 정식 예외 타입을 우선 보고, 메시지 문자열은 SDK 포맷 변화
           # 대비 보조 조건으로 남긴다. google.api_core는 google-generativeai의 의존성이라
@@ -553,12 +559,24 @@ jobs:
           def server_retry_delay(err):
               message = str(err)
               candidates = []
-              for pattern in (
-                  r"Please retry in\s+([0-9]+(?:\.[0-9]+)?)s",
-                  r"retry_delay\s*\{\s*seconds:\s*([0-9]+(?:\.[0-9]+)?)",
+              for value, unit in re.findall(
+                  r"Please retry in\s+([0-9]+(?:\.[0-9]+)?)(ms|s)\b", message, re.I
               ):
-                  candidates.extend(float(value) for value in re.findall(pattern, message, re.I))
+                  seconds = float(value) / 1000 if unit.lower() == "ms" else float(value)
+                  candidates.append(seconds)
+              candidates.extend(
+                  float(value)
+                  for value in re.findall(
+                      r"retry_delay\s*\{\s*seconds:\s*([0-9]+(?:\.[0-9]+)?)",
+                      message,
+                      re.I,
+                  )
+              )
               return max(candidates, default=0.0)
+
+          def retry_delay_fits_process_budget(delay):
+              remaining = PROCESS_TIMEOUT - (time.monotonic() - PROCESS_STARTED_AT)
+              return delay + RETRY_DEADLINE_MARGIN < remaining
 
           def is_daily_request_quota_exhausted(err):
               # Per-day request quotas cannot recover during this job. Gemini surfaces the
@@ -635,6 +653,12 @@ jobs:
                       # 서버 대기시간을 절대 줄이지 않으며, 지터는 동시 재시도만 분산한다.
                       delay_floor = max(RETRY_SLEEP * (2 ** attempt), server_retry_delay(error))
                       delay = delay_floor + random.uniform(0, max(RETRY_JITTER, 0))
+                      if not retry_delay_fits_process_budget(delay):
+                          print(
+                              f"Retry delay {delay:.2f}s does not fit within the remaining "
+                              "Gemini process budget; skipping retry"
+                          )
+                          raise
                       print(f"Rate limited (attempt {attempt + 1}/3): {error}; retrying in {delay:.2f}s")
                       time.sleep(delay)
                       continue

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -620,8 +620,15 @@ jobs:
                   try:
                       response = generate_content(prompt)
                   except Exception as error:
-                      if is_rate_limited(error) and is_daily_request_quota_exhausted(error):
-                          print("Daily Gemini request quota exhausted; skipping unrecoverable retries")
+                      if (
+                          is_rate_limited(error)
+                          and is_daily_request_quota_exhausted(error)
+                          and server_retry_delay(error) <= 0
+                      ):
+                          print(
+                              "Daily Gemini request quota exhausted without retry guidance; "
+                              "skipping unrecoverable retries"
+                          )
                           raise
                       if not is_rate_limited(error) or attempt == 2:
                           raise

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -298,10 +298,11 @@ Gemini 429 handling separates retry eligibility from the final failure classific
 provider `RetryInfo`/`Please retry in` delay remains authoritative even when the same response
 contains a requests-per-day quota ID. Second and millisecond guidance both use the existing
 three-attempt bounded backoff, and an eligible retry never waits less than the provider delay.
-A requests-per-day response without positive guidance, or with a delay that cannot fit inside the
-remaining process watchdog, is terminal for that job. If the bounded attempts are exhausted, a
-quota response is still published as `quota_exhausted`; retrying it does not weaken the sticky
-failure state or extend any of the nested deadlines above.
+A requests-per-day response without positive guidance is terminal for that job. For every 429,
+the computed backoff (including provider floor and jitter) must also fit inside the remaining
+process watchdog; otherwise the response remains terminal with its original `quota_exhausted` or
+`rate_limited` classification. Retrying does not weaken the sticky failure state or extend any of
+the nested deadlines above.
 
 Immediately before comment mutation, each reviewer refetches the PR head and requires it to
 equal `attempt_head`; it also refuses to write unless stored `(run_id, run_attempt)` is

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -296,11 +296,12 @@ without advancing `Reviewed`. The job timeout is the last-resort ceiling and rem
 
 Gemini 429 handling separates retry eligibility from the final failure classification. A positive
 provider `RetryInfo`/`Please retry in` delay remains authoritative even when the same response
-contains a requests-per-day quota ID: the reviewer follows the existing three-attempt bounded
-backoff and never waits less than the provider delay. A requests-per-day quota response without
-retry guidance is terminal for that job. If the bounded attempts are exhausted, a quota response
-is still published as `quota_exhausted`; retrying it does not weaken the sticky failure state or
-extend any of the nested deadlines above.
+contains a requests-per-day quota ID. Second and millisecond guidance both use the existing
+three-attempt bounded backoff, and an eligible retry never waits less than the provider delay.
+A requests-per-day response without positive guidance, or with a delay that cannot fit inside the
+remaining process watchdog, is terminal for that job. If the bounded attempts are exhausted, a
+quota response is still published as `quota_exhausted`; retrying it does not weaken the sticky
+failure state or extend any of the nested deadlines above.
 
 Immediately before comment mutation, each reviewer refetches the PR head and requires it to
 equal `attempt_head`; it also refuses to write unless stored `(run_id, run_attempt)` is

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -294,6 +294,14 @@ remains a generic provider failure. An SDK timeout or subprocess deadline record
 without advancing `Reviewed`. The job timeout is the last-resort ceiling and remains below the
 12-minute `/jhw:ship` review-round deadline.
 
+Gemini 429 handling separates retry eligibility from the final failure classification. A positive
+provider `RetryInfo`/`Please retry in` delay remains authoritative even when the same response
+contains a requests-per-day quota ID: the reviewer follows the existing three-attempt bounded
+backoff and never waits less than the provider delay. A requests-per-day quota response without
+retry guidance is terminal for that job. If the bounded attempts are exhausted, a quota response
+is still published as `quota_exhausted`; retrying it does not weaken the sticky failure state or
+extend any of the nested deadlines above.
+
 Immediately before comment mutation, each reviewer refetches the PR head and requires it to
 equal `attempt_head`; it also refuses to write unless stored `(run_id, run_attempt)` is
 strictly older. Per-reviewer/per-PR concurrency with cancellation reduces overlap. OpenCode

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -3420,6 +3420,47 @@ def test_gemini_rejects_retry_guidance_beyond_process_budget(tmp_path):
     assert (tmp_path / "gemini_failure_reason.txt").read_text() == "quota_exhausted"
 
 
+def test_gemini_rejects_non_daily_rate_limit_beyond_process_budget(tmp_path):
+    """The watchdog guard covers ordinary rate limits as well as daily quotas."""
+    (tmp_path / "gemini_review.py").write_text(_extract_gemini_python(), encoding="utf-8")
+    stub = tmp_path / "stub" / "google"
+    stub.mkdir(parents=True)
+    (stub / "__init__.py").write_text("", encoding="utf-8")
+    (stub / "generativeai.py").write_text(
+        "import pathlib\n"
+        "def configure(api_key=None): pass\n"
+        "class _R:\n"
+        "    text = 'SHOULD NOT RETRY'\n"
+        "class GenerativeModel:\n"
+        "    def __init__(self, name): pass\n"
+        "    def generate_content(self, prompt):\n"
+        "        counter = pathlib.Path('attempts.txt')\n"
+        "        n = int(counter.read_text()) if counter.exists() else 0\n"
+        "        counter.write_text(str(n + 1))\n"
+        "        if n == 0:\n"
+        "            raise RuntimeError('429 rate limited; Please retry in 0.02s')\n"
+        "        return _R()\n",
+        encoding="utf-8",
+    )
+    _write_gemini_script_inputs(tmp_path)
+    env = _gemini_script_env(tmp_path)
+    env.update({
+        "GEMINI_429_RETRY_SLEEP": "0",
+        "GEMINI_429_RETRY_JITTER": "0",
+        "GEMINI_REVIEW_PROCESS_TIMEOUT": "5.01",
+    })
+
+    result = subprocess.run(
+        ["python3", "gemini_review.py"],
+        cwd=tmp_path, env=env, check=False, capture_output=True, text=True,
+    )
+
+    assert result.returncode != 0
+    assert (tmp_path / "attempts.txt").read_text() == "1"
+    assert "retrying in" not in result.stdout
+    assert (tmp_path / "gemini_failure_reason.txt").read_text() == "rate_limited"
+
+
 def test_gemini_does_not_retry_daily_quota_without_server_retry_guidance(tmp_path):
     """A daily quota with no RetryInfo remains terminal inside the bounded job."""
     (tmp_path / "gemini_review.py").write_text(_extract_gemini_python(), encoding="utf-8")

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -3331,6 +3331,95 @@ def test_gemini_retries_daily_labeled_quota_with_server_retry_guidance(tmp_path)
     assert (tmp_path / "gemini_failure_reason.txt").read_text() == ""
 
 
+def test_gemini_retries_daily_labeled_quota_with_millisecond_guidance(tmp_path):
+    """The provider's sub-second RetryInfo text remains actionable."""
+    (tmp_path / "gemini_review.py").write_text(_extract_gemini_python(), encoding="utf-8")
+    stub = tmp_path / "stub" / "google"
+    stub.mkdir(parents=True)
+    (stub / "__init__.py").write_text("", encoding="utf-8")
+    (stub / "generativeai.py").write_text(
+        "import pathlib\n"
+        "def configure(api_key=None): pass\n"
+        "class _R:\n"
+        "    text = 'RECOVERED REVIEW'\n"
+        "class GenerativeModel:\n"
+        "    def __init__(self, name): pass\n"
+        "    def generate_content(self, prompt):\n"
+        "        counter = pathlib.Path('attempts.txt')\n"
+        "        n = int(counter.read_text()) if counter.exists() else 0\n"
+        "        counter.write_text(str(n + 1))\n"
+        "        if n == 0:\n"
+        "            raise RuntimeError(\n"
+        "                '429 Quota exceeded for metric: generate_content_free_tier_requests; ' \n"
+        "                'quotaId: GenerateRequestsPerDayPerProjectPerModel-FreeTier; ' \n"
+        "                'Please retry in 902.029958ms'\n"
+        "            )\n"
+        "        return _R()\n",
+        encoding="utf-8",
+    )
+    _write_gemini_script_inputs(tmp_path)
+    env = _gemini_script_env(tmp_path)
+    env.update({
+        "GEMINI_429_RETRY_SLEEP": "0",
+        "GEMINI_429_RETRY_JITTER": "0",
+    })
+
+    result = subprocess.run(
+        ["python3", "gemini_review.py"],
+        cwd=tmp_path, env=env, check=False, capture_output=True, text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (tmp_path / "attempts.txt").read_text() == "2"
+    assert "retrying in 0.90s" in result.stdout
+    assert (tmp_path / "gemini_review.md").read_text() == "RECOVERED REVIEW"
+
+
+def test_gemini_rejects_retry_guidance_beyond_process_budget(tmp_path):
+    """A retry sleep must not consume the watchdog and erase the quota reason."""
+    (tmp_path / "gemini_review.py").write_text(_extract_gemini_python(), encoding="utf-8")
+    stub = tmp_path / "stub" / "google"
+    stub.mkdir(parents=True)
+    (stub / "__init__.py").write_text("", encoding="utf-8")
+    (stub / "generativeai.py").write_text(
+        "import pathlib\n"
+        "def configure(api_key=None): pass\n"
+        "class _R:\n"
+        "    text = 'SHOULD NOT RETRY'\n"
+        "class GenerativeModel:\n"
+        "    def __init__(self, name): pass\n"
+        "    def generate_content(self, prompt):\n"
+        "        counter = pathlib.Path('attempts.txt')\n"
+        "        n = int(counter.read_text()) if counter.exists() else 0\n"
+        "        counter.write_text(str(n + 1))\n"
+        "        if n == 0:\n"
+        "            raise RuntimeError(\n"
+        "                '429 Quota exceeded for metric: generate_content_free_tier_requests; ' \n"
+        "                'quotaId: GenerateRequestsPerDayPerProjectPerModel-FreeTier; ' \n"
+        "                'Please retry in 0.02s'\n"
+        "            )\n"
+        "        return _R()\n",
+        encoding="utf-8",
+    )
+    _write_gemini_script_inputs(tmp_path)
+    env = _gemini_script_env(tmp_path)
+    env.update({
+        "GEMINI_429_RETRY_SLEEP": "0",
+        "GEMINI_429_RETRY_JITTER": "0",
+        "GEMINI_REVIEW_PROCESS_TIMEOUT": "5.01",
+    })
+
+    result = subprocess.run(
+        ["python3", "gemini_review.py"],
+        cwd=tmp_path, env=env, check=False, capture_output=True, text=True,
+    )
+
+    assert result.returncode != 0
+    assert (tmp_path / "attempts.txt").read_text() == "1"
+    assert "retrying in" not in result.stdout
+    assert (tmp_path / "gemini_failure_reason.txt").read_text() == "quota_exhausted"
+
+
 def test_gemini_does_not_retry_daily_quota_without_server_retry_guidance(tmp_path):
     """A daily quota with no RetryInfo remains terminal inside the bounded job."""
     (tmp_path / "gemini_review.py").write_text(_extract_gemini_python(), encoding="utf-8")

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -3279,8 +3279,60 @@ def test_gemini_uses_server_retry_delay_as_a_floor(tmp_path):
     assert "retrying in 0.05s" in result.stdout
 
 
-def test_gemini_does_not_retry_daily_request_quota_exhaustion(tmp_path):
-    """An exhausted per-day quota cannot recover inside the job, so spend one call only."""
+def test_gemini_retries_daily_labeled_quota_with_server_retry_guidance(tmp_path):
+    """A daily-labeled 429 with RetryInfo can be transient and must get a bounded retry."""
+    (tmp_path / "gemini_review.py").write_text(_extract_gemini_python(), encoding="utf-8")
+    stub = tmp_path / "stub" / "google"
+    stub.mkdir(parents=True)
+    (stub / "__init__.py").write_text("", encoding="utf-8")
+    (stub / "generativeai.py").write_text(
+        "import pathlib\n"
+        "def configure(api_key=None): pass\n"
+        "class _R:\n"
+        "    text = 'RECOVERED REVIEW'\n"
+        "class GenerativeModel:\n"
+        "    def __init__(self, name): pass\n"
+        "    def generate_content(self, prompt):\n"
+        "        counter = pathlib.Path('attempts.txt')\n"
+        "        n = int(counter.read_text()) if counter.exists() else 0\n"
+        "        counter.write_text(str(n + 1))\n"
+        "        if n == 0:\n"
+        "            raise RuntimeError(\n"
+        "                '429 Quota exceeded for metric: generate_content_free_tier_requests; ' \n"
+        "                'quotaId: GenerateRequestsPerDayPerProjectPerModel-FreeTier; ' \n"
+        "                'Please retry in 0.01s'\n"
+        "            )\n"
+        "        return _R()\n",
+        encoding="utf-8",
+    )
+    fixtures = {
+        "pr_title.txt": "T", "pr_body.txt": "B", "pr_number.txt": "7",
+        "review-full.diff": "+x\n", "prev_review.txt": "", "human_comments.txt": "",
+    }
+    for name, content in fixtures.items():
+        (tmp_path / name).write_text(content, encoding="utf-8")
+    env = dict(os.environ)
+    env.update({
+        "GEMINI_API_KEY": "stub",
+        "PYTHONPATH": str(tmp_path / "stub"),
+        "GEMINI_429_RETRY_SLEEP": "0",
+        "GEMINI_429_RETRY_JITTER": "0",
+        "REVIEW_DIFF_FILE": "review-full.diff",
+        "REVIEW_DIFF_MODE": "full",
+    })
+    result = subprocess.run(
+        ["python3", "gemini_review.py"],
+        cwd=tmp_path, env=env, check=False, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (tmp_path / "attempts.txt").read_text() == "2"
+    assert "retrying in 0.01s" in result.stdout
+    assert (tmp_path / "gemini_review.md").read_text() == "RECOVERED REVIEW"
+    assert (tmp_path / "gemini_failure_reason.txt").read_text() == ""
+
+
+def test_gemini_does_not_retry_daily_quota_without_server_retry_guidance(tmp_path):
+    """A daily quota with no RetryInfo remains terminal inside the bounded job."""
     (tmp_path / "gemini_review.py").write_text(_extract_gemini_python(), encoding="utf-8")
     stub = tmp_path / "stub" / "google"
     stub.mkdir(parents=True)
@@ -3296,8 +3348,7 @@ def test_gemini_does_not_retry_daily_request_quota_exhaustion(tmp_path):
         "        counter.write_text(str(n + 1))\n"
         "        raise RuntimeError(\n"
         "            '429 Quota exceeded for metric: generate_content_free_tier_requests; ' \n"
-        "            'quotaId: GenerateRequestsPerDayPerProjectPerModel-FreeTier; ' \n"
-        "            'Please retry in 0.01s'\n"
+        "            'quotaId: GenerateRequestsPerDayPerProjectPerModel-FreeTier'\n"
         "        )\n",
         encoding="utf-8",
     )


### PR DESCRIPTION
## Problem

Gemini can label a transient 429 with a daily request quota ID while also returning an explicit short RetryInfo delay. The previous shortcut treated every daily-labeled response as unrecoverable and ignored that provider guidance.

## Behavior

- Retry daily-labeled 429 responses only when the provider supplies a positive retry delay.
- Keep daily quota failures without retry guidance terminal.
- Reuse the existing bounded three-attempt backoff and preserve quota_exhausted as the final classification.

## Validation

- Regression test observed failing before the implementation and passing afterward.
- Full suite: 973 passed.
- Workflow YAML parsed successfully.
- actionlint 1.7.12 core checks passed.

Release target: v1.45.2. The existing pim-check v1.45.1 canary remains unmerged until its replacement is published.