### PR TITLE
fix(claude): pin recovered action runtime

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -268,7 +268,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         if: ${{ steps.prepare-diff.outputs.diff-ready == 'true' && steps.prepare-diff.outputs.diff-mode != 'unchanged' }}
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6bcfb8263aca9b0eab0aba20d96dddd74de2875f # ratchet:anthropics/claude-code-action@v1.0.204
         env:
           REVIEW_DIFF_FILE: ${{ steps.prepare-diff.outputs.diff-mode == 'delta' && 'review-delta.diff' || 'review-full.diff' }}
         with:
@@ -360,7 +360,7 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # model은 claude_args 로 전달 (claude-code-action@v1 에서 'model' input 미지원)
+          # model은 claude_args 로 전달 (claude-code-action v1.0.204 에서 'model' input 미지원)
           # Read + 단일 파일 Write(claude-review.md)만 허용: 모델은 리뷰 본문을 claude-review.md에
           # 쓰기만 하고, 게시는 아래 'Upsert review comment' 스텝이 sticky 코멘트 제자리 갱신으로
           # 수행한다(라운드마다 새 코멘트가 쌓이지 않음). 모델의 직접 게시(gh pr review)를 제거해

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6bcfb8263aca9b0eab0aba20d96dddd74de2875f # ratchet:anthropics/claude-code-action@v1.0.204
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -206,6 +206,10 @@ that anchor. A real current line without PR causality is insufficient; a disprov
 `Retracted`, while `Resolved` requires a code change.
 
 Claude and Gemini enforce this as a prompt contract over their exclusive prepared artifact.
+The Claude command and review model steps use `anthropics/claude-code-action` v1.0.204 at the
+immutable commit `6bcfb8263aca9b0eab0aba20d96dddd74de2875f`. Moving major tags are not accepted:
+the release gate for v1.45.3 and later requires both exact action references so an upstream CLI
+bump cannot change runner behavior between otherwise identical workflow attempts.
 OpenCode additionally enforces it in the clean canonicalizer. A candidate must contain exactly one
 `### New findings` section whose body is exactly `None` or one or more `####` finding blocks. Every
 block needs at least one canonical one-line JSON anchor, exactly

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -39,6 +39,10 @@ from scripts.workflow_release_inventory import (
 
 
 CHECKOUT_ACTION = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+CLAUDE_CODE_ACTION = (
+    "anthropics/claude-code-action@"
+    "6bcfb8263aca9b0eab0aba20d96dddd74de2875f"
+)
 CACHE_ACTION = "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
 UPLOAD_ARTIFACT_ACTION = "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
 DOWNLOAD_ARTIFACT_ACTION = "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"
@@ -1450,6 +1454,35 @@ def _verify_prepare_review_diff_action(tree: VerifiedCommitTree) -> None:
         )
 
 
+def _verify_claude_code_action_pin(
+    ref: str, documents: dict[str, dict]
+) -> None:
+    if _release_version(ref) < (1, 45, 3):
+        return
+    expected_by_workflow = {
+        "claude-code-review.yml": [
+            ("claude-review", "Run Claude Code Review", CLAUDE_CODE_ACTION)
+        ],
+        "claude.yml": [
+            ("claude", "Run Claude Code", CLAUDE_CODE_ACTION)
+        ],
+    }
+    for filename, expected in expected_by_workflow.items():
+        workflow = documents.get(filename, {})
+        references = []
+        for job_name, job in workflow.get("jobs", {}).items():
+            for step in job.get("steps", []):
+                uses = step.get("uses", "")
+                if isinstance(uses, str) and uses.lower().startswith(
+                    "anthropics/claude-code-action@"
+                ):
+                    references.append((job_name, step.get("name"), uses))
+        if references != expected:
+            raise ReleaseVerificationError(
+                "Claude Code action is not the approved immutable commit"
+            )
+
+
 def _verify_tag_catalog(
     tree: VerifiedCommitTree, ref: str
 ) -> WorkflowCatalog | None:
@@ -1987,8 +2020,13 @@ def _verify_commit_content(
                     f"{name} checkout reference is not the approved immutable commit"
                 )
         data = yaml.load(text, Loader=yaml.BaseLoader)
-        documents[Path(name).name] = data if isinstance(data, dict) else {}
+        workflow_path = PurePosixPath(name)
+        if workflow_path.parent == PurePosixPath(".github/workflows"):
+            documents[workflow_path.name] = (
+                data if isinstance(data, dict) else {}
+            )
 
+    _verify_claude_code_action_pin(ref, documents)
     _verify_prepare_review_diff_dependencies(ref, documents)
 
     if catalog is not None:

--- a/tests/test_action_pins.py
+++ b/tests/test_action_pins.py
@@ -13,7 +13,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from scripts.prepare_workflow_rollout import CHECKOUT_SHA as FLEET_CHECKOUT_SHA
-from scripts.verify_workflow_release import CHECKOUT_ACTION
+from scripts.verify_workflow_release import CHECKOUT_ACTION, CLAUDE_CODE_ACTION
 
 
 CHECKOUT_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
@@ -68,6 +68,36 @@ class ActionPinsTest(unittest.TestCase):
                 if pattern.search(line):
                     offenders.append(f"{path.relative_to(ROOT)}:{lineno}")
         self.assertEqual([], offenders)
+
+    def test_all_managed_claude_actions_use_the_approved_commit(self) -> None:
+        references: list[tuple[Path, str, str]] = []
+        for path in workflow_paths():
+            workflow = yaml.load(
+                path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader
+            )
+            for job in workflow.get("jobs", {}).values():
+                for step in job.get("steps", []):
+                    uses = step.get("uses", "")
+                    if isinstance(uses, str) and uses.lower().startswith(
+                        "anthropics/claude-code-action@"
+                    ):
+                        references.append((path, step.get("name"), uses))
+
+        self.assertEqual(
+            [
+                (
+                    ROOT / ".github/workflows/claude-code-review.yml",
+                    "Run Claude Code Review",
+                    CLAUDE_CODE_ACTION,
+                ),
+                (
+                    ROOT / ".github/workflows/claude.yml",
+                    "Run Claude Code",
+                    CLAUDE_CODE_ACTION,
+                ),
+            ],
+            references,
+        )
 
     def test_opencode_workflows_pin_cli_archive_and_cache_action(self) -> None:
         for filename, job_name, run_name in (

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -162,6 +162,58 @@ def current_release_repo(tmp_path: Path) -> tuple[Path, str]:
     return repo, commit(repo, "current release")
 
 
+def test_v1453_commit_gate_accepts_pinned_claude_action(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, current = current_release_repo
+
+    assert (
+        release_verifier.verify_commit_content(repo, "v1.45.3", current)
+        == current
+    )
+
+
+@pytest.mark.parametrize(
+    "filename", ("claude-code-review.yml", "claude.yml")
+)
+def test_v1453_commit_gate_rejects_moving_claude_action(
+    current_release_repo: tuple[Path, str],
+    filename: str,
+) -> None:
+    repo, _ = current_release_repo
+    path = repo / ".github/workflows" / filename
+    replace(
+        path,
+        "anthropics/claude-code-action@6bcfb8263aca9b0eab0aba20d96dddd74de2875f",
+        "anthropics/claude-code-action@v1",
+        count=1,
+    )
+    bad_commit = commit(repo, "restore moving Claude action tag")
+
+    with pytest.raises(ReleaseVerificationError, match="Claude Code action"):
+        release_verifier.verify_commit_content(repo, "v1.45.3", bad_commit)
+
+
+def test_v1453_commit_gate_cannot_be_spoofed_by_nested_workflow_basename(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    root_workflow = repo / ".github/workflows/claude-code-review.yml"
+    nested_workflow = repo / ".github/workflows/zz/claude-code-review.yml"
+    nested_workflow.parent.mkdir(parents=True)
+    shutil.copy2(root_workflow, nested_workflow)
+    replace(
+        root_workflow,
+        "anthropics/claude-code-action@6bcfb8263aca9b0eab0aba20d96dddd74de2875f",
+        "anthropics/claude-code-action@v1",
+        count=1,
+    )
+    bad_commit = commit(repo, "spoof root Claude action pin")
+
+    with pytest.raises(ReleaseVerificationError, match="Claude Code action"):
+        release_verifier.verify_commit_content(repo, "v1.45.3", bad_commit)
+
+
 def replace(path: Path, old: str, new: str, *, count: int = -1) -> None:
     text = path.read_text(encoding="utf-8")
     assert old in text


### PR DESCRIPTION
## Summary
- pin both Claude command and review workflows to claude-code-action v1.0.204 commit 6bcfb826
- reject moving Claude action refs in the v1.45.3+ release gate
- prevent nested workflow basenames from spoofing canonical root verification

## Incident evidence
- failed claude-config PR 60 attempts resolved moving v1 to broken e5ad3c77 / Claude Code 2.1.243
- attempt 3 resolved v1 to upstream rollback 6bcfb826 / Claude Code 2.1.241 and succeeded

## Verification
- 981 passed, 48 subtests passed
- release verifier: 199 passed
- action pin tests: 5 passed, 2 subtests passed
- actionlint 1.7.12 passed
- independent review: CLEAN