### PR TITLE
chore(fleet): default rollouts to v1.46.1

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.44",
+  "automation_ref": "v1.46.1",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -33,7 +33,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.44"
+    assert config.automation_ref == "v1.46.1"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
## Summary
- advance the fleet default from v1.44 to the verified immutable v1.46.1 release
- keep the catalog contract expectation aligned

## Verification
- TDD red: expected v1.46.1 while config still returned v1.44
- focused catalog: 11 passed
- fleet config consumers: 290 passed
- git diff --check