### PR TITLE
fix(review): filter invalid OpenCode findings

### DIFF
--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -392,7 +392,7 @@ jobs:
           PREV_SUCCESSFUL_HEAD="$(printf '%s\n' "$PREV_RECORD" | jq -r '.state.successful_head // ""')"
           PREV_FULL_HASH="$(printf '%s\n' "$PREV_RECORD" | jq -r '.state.full_diff_sha256 // ""')"
           # Reserved workflow-owned text is never model input, even from a validated record.
-          PREV_REVIEW="$(printf '%s\n' "$PREV_REVIEW" | grep -vE '^(## OpenCode Review \(latest\)|<!-- automation:|<!-- automation-state:|- Status: |- Run: |- Reviewed: |- Last attempt: )' || true)"
+          PREV_REVIEW="$(printf '%s\n' "$PREV_REVIEW" | grep -vE '^(## OpenCode Review \(latest\)|<!-- automation:|<!-- automation-state:|- Status: |- Run: |- Reviewed: |- Validation: |- Last attempt: )' || true)"
           # A first failure has no checkpoint and must not become re-review context. A stale
           # failure is useful only when it retained a validated successful checkpoint/body.
           if ! [[ "$PREV_SUCCESSFUL_HEAD" =~ ^[0-9a-f]{40}$ ]] \
@@ -408,7 +408,7 @@ jobs:
             '[.[] | select((.user.type // "") != "Bot")] | .[-10:]
              | map("@" + (.user.login // "ghost") + " (" + (.created_at // "") + "):\n" + ((.body // "") | .[0:1500]))
              | join("\n\n---\n\n")' "$COMMENTS" \
-            | grep -vE '^(## OpenCode Review \(latest\)|<!-- automation:|<!-- automation-state:|- Status: |- Run: |- Reviewed: |- Last attempt: )' || true)"
+            | grep -vE '^(## OpenCode Review \(latest\)|<!-- automation:|<!-- automation-state:|- Status: |- Run: |- Reviewed: |- Validation: |- Last attempt: )' || true)"
 
           clip() {
             local text="$1"
@@ -3357,7 +3357,7 @@ jobs:
               }
               return true;
             };
-            const reserved = /^(## OpenCode Review \(latest\)|<!-- automation:|<!-- automation-candidate:|<!-- automation-state:|- Status: (success|failure|stale)$|- Run: https?:\/\/\S+$|- Attestation: [1-9][0-9]*$|- Reviewed: [0-9a-f]{40}$|- Last attempt: failure \(https?:\/\/\S+\)$|- Reason: [a-z_]+$)/;
+            const reserved = /^(## OpenCode Review \(latest\)|<!-- automation:|<!-- automation-candidate:|<!-- automation-state:|- Status: (success|failure|stale)$|- Run: https?:\/\/\S+$|- Attestation: [1-9][0-9]*$|- Reviewed: [0-9a-f]{40}$|- Validation: filtered_invalid_new_findings=[1-9][0-9]*; reasons=[a-z_,]+$|- Last attempt: failure \(https?:\/\/\S+\)$|- Reason: [a-z_]+$)/;
             const clean = (body) => {
               const rawLines = (body || '').split('\n');
               // OpenCode can include tool/thinking traces in the final text event. Only an exact
@@ -3646,13 +3646,12 @@ jobs:
               if (!sections) return null;
               const carryover = sections.filter((item) => item.name !== 'New findings');
               if (carryover.length && !priorSuccess) return null;
-              const anchors = [];
-              const removals = [];
+              const parsedBlocks = [];
               const currentHeadings = new Set();
-              for (const section of sections) {
-                const blocks = sectionBlocks(section);
-                if (blocks === null) return null;
-                for (const block of blocks) {
+              for (const [sectionIndex, section] of sections.entries()) {
+                const sectionFindingBlocks = sectionBlocks(section);
+                if (sectionFindingBlocks === null) return null;
+                for (const block of sectionFindingBlocks) {
                   if (currentHeadings.has(block.heading)) return null;
                   currentHeadings.add(block.heading);
                   const priorMatches = priorActiveHeadings.get(block.heading) || 0;
@@ -3669,8 +3668,10 @@ jobs:
                   const noRemovedPair = evidence.removedAnchors.length === 0
                     && evidence.removedLines.length === 0;
                   if (currentPair && noRemovedPair) {
-                    anchors.push({ ...evidence.changedAnchors[0],
-                      currentLine: evidence.currentLines[0] });
+                    const anchor = { ...evidence.changedAnchors[0],
+                      currentLine: evidence.currentLines[0] };
+                    parsedBlocks.push({ sectionIndex, section: section.name, block,
+                      evidence: { anchors: [anchor], removals: [] } });
                     continue;
                   }
                   if (section.name !== 'Resolved' || !removedPair || !noCurrentPair) return null;
@@ -3685,16 +3686,19 @@ jobs:
                   if (removedAnchor.path !== priorAnchor.path
                     || removedAnchor.line !== priorAnchor.line
                     || evidence.removedLines[0] !== previous[0].currentLines[0]) return null;
-                  removals.push({ ...removedAnchor,
-                    currentLine: evidence.removedLines[0] });
+                  const removal = { ...removedAnchor,
+                    currentLine: evidence.removedLines[0] };
+                  parsedBlocks.push({ sectionIndex, section: section.name, block,
+                    evidence: { anchors: [], removals: [removal] } });
                 }
               }
-              return { anchors, removals };
+              return { blocks: parsedBlocks, sections };
             };
 
-            const anchorsAreChanged = (evidence) => {
+            const changedPathValidation = new Map();
+            const validateAnchorEvidence = (evidence) => {
               if (!artifactsValid || !manifest || !evidence
-                || !Array.isArray(evidence.anchors) || !Array.isArray(evidence.removals)) return false;
+                || !Array.isArray(evidence.anchors) || !Array.isArray(evidence.removals)) return 'error';
               const locations = evidence.anchors;
               const files = new Map(manifest.files.map((file) => [file.filename, file]));
               const statusNames = new Map([
@@ -3840,18 +3844,23 @@ jobs:
               for (const location of locations) {
                 if (!location || typeof location.path !== 'string'
                   || !Number.isSafeInteger(location.line) || location.line <= 0
-                  || typeof location.currentLine !== 'string') return false;
+                  || typeof location.currentLine !== 'string') return 'error';
                 const file = files.get(location.path);
-                if (!file || file.status === 'removed') return false;
+                if (!file) return 'invalid';
                 anchors.push({ path: location.path, line: location.line,
                   currentLine: location.currentLine });
               }
               const rangesByPath = new Map();
               for (const path of new Set(anchors.map((anchor) => anchor.path))) {
+                const cached = changedPathValidation.get(path);
+                if (cached) {
+                  rangesByPath.set(path, cached);
+                  continue;
+                }
                 const file = files.get(path);
                 const renamedOrCopied = ['renamed', 'copied'].includes(file.status);
                 if (renamedOrCopied && (typeof file.previous_filename !== 'string'
-                  || file.previous_filename.length === 0)) return false;
+                  || file.previous_filename.length === 0)) return 'error';
                 const pathspecs = renamedOrCopied
                   ? [file.previous_filename, file.filename] : [file.filename];
                 const nameStatus = spawnSync('/usr/bin/git', [
@@ -3862,12 +3871,12 @@ jobs:
                 ], {
                   cwd: trustedWorkspace, env: gitEnv,
                 });
-                const records = nameStatus.error || nameStatus.status !== 0
-                  ? null : parseNameStatus(nameStatus.stdout);
+                if (nameStatus.error || nameStatus.status !== 0) return 'error';
+                const records = parseNameStatus(nameStatus.stdout);
                 if (!records || records.length !== 1 || records[0].status !== file.status
                   || records[0].filename !== file.filename
                   || (records[0].previous_filename || null) !== (file.previous_filename || null)) {
-                  return false;
+                  return 'error';
                 }
                 const result = spawnSync('/usr/bin/git', [
                   '--no-replace-objects', '--literal-pathspecs', '-c', 'diff.external=',
@@ -3878,9 +3887,11 @@ jobs:
                   encoding: 'utf8', cwd: trustedWorkspace,
                   env: gitEnv,
                 });
-                if (result.error || result.status !== 0 || typeof result.stdout !== 'string') return false;
+                if (result.error || result.status !== 0
+                  || typeof result.stdout !== 'string') return 'error';
                 const ranges = parseAddedRanges(result.stdout);
-                if (!ranges || !ranges.length || !(ranges.addedLines instanceof Map)) return false;
+                if (!ranges || !(ranges.addedLines instanceof Map)) return 'error';
+                changedPathValidation.set(path, ranges);
                 rangesByPath.set(path, ranges);
               }
               const currentEvidenceValid = anchors.every((anchor) => {
@@ -3888,25 +3899,25 @@ jobs:
                 return ranges.some(([start, end]) => anchor.line >= start && anchor.line <= end)
                   && ranges.addedLines.get(anchor.line) === anchor.currentLine;
               });
-              if (!currentEvidenceValid) return false;
+              if (!currentEvidenceValid) return 'invalid';
 
               const removals = evidence.removals;
-              if (!removals.length) return true;
+              if (!removals.length) return 'valid';
               const previousHead = priorSuccess ? existing.state.successful_head : '';
-              if (!/^[0-9a-f]{40}$/.test(previousHead)) return false;
+              if (!/^[0-9a-f]{40}$/.test(previousHead)) return 'error';
               const ancestor = spawnSync('/usr/bin/git', [
                 '--no-replace-objects', 'merge-base', '--is-ancestor', previousHead, attemptHead,
               ], { cwd: trustedWorkspace, env: gitEnv });
-              if (ancestor.error || ancestor.status !== 0) return false;
+              if (ancestor.error || ancestor.status !== 0) return 'error';
               const previousNameStatus = spawnSync('/usr/bin/git', [
                 '--no-replace-objects', '--literal-pathspecs', '-c', 'diff.external=',
                 'diff', '--no-ext-diff', '--no-textconv', '--name-status', '-z',
                 '--find-renames=50%', '--ignore-submodules=none',
                 `${previousHead}..${attemptHead}`,
               ], { cwd: trustedWorkspace, env: gitEnv });
-              const previousRecords = previousNameStatus.error || previousNameStatus.status !== 0
-                ? null : parseNameStatus(previousNameStatus.stdout);
-              if (!previousRecords) return false;
+              if (previousNameStatus.error || previousNameStatus.status !== 0) return 'error';
+              const previousRecords = parseNameStatus(previousNameStatus.stdout);
+              if (!previousRecords) return 'error';
               const previousContentDiff = spawnSync('/usr/bin/git', [
                 '--no-replace-objects', '--literal-pathspecs', '-c', 'diff.external=',
                 'diff', '--no-ext-diff', '--no-textconv', '--text', '--find-renames=50%',
@@ -3917,19 +3928,19 @@ jobs:
                 env: gitEnv,
               });
               if (previousContentDiff.error || previousContentDiff.status !== 0
-                || typeof previousContentDiff.stdout !== 'string') return false;
+                || typeof previousContentDiff.stdout !== 'string') return 'error';
               const globallyAddedLines = new Set(previousContentDiff.stdout.split('\n')
                 .filter((line) => line.startsWith('%')).map((line) => line.slice(1)));
 
               for (const removal of removals) {
                 if (!removal || typeof removal.path !== 'string'
                   || !Number.isSafeInteger(removal.line) || removal.line <= 0
-                  || typeof removal.currentLine !== 'string') return false;
+                  || typeof removal.currentLine !== 'string') return 'error';
                 const identityRecords = previousRecords.filter((record) =>
                   record.filename === removal.path || record.previous_filename === removal.path);
                 if (identityRecords.length !== 1
                   || identityRecords[0].filename !== removal.path
-                  || !['changed', 'modified', 'removed'].includes(identityRecords[0].status)) return false;
+                  || !['changed', 'modified', 'removed'].includes(identityRecords[0].status)) return 'invalid';
                 const result = spawnSync('/usr/bin/git', [
                   '--no-replace-objects', '--literal-pathspecs', '-c', 'diff.external=',
                   'diff', '--no-ext-diff', '--no-textconv', '--find-renames=50%',
@@ -3939,20 +3950,60 @@ jobs:
                   encoding: 'utf8', cwd: trustedWorkspace,
                   env: gitEnv,
                 });
-                if (result.error || result.status !== 0 || typeof result.stdout !== 'string') return false;
+                if (result.error || result.status !== 0
+                  || typeof result.stdout !== 'string') return 'error';
                 const ranges = parseAddedRanges(result.stdout);
                 if (!ranges || !(ranges.addedLines instanceof Map)
-                  || !(ranges.removedLines instanceof Map)
-                  || ranges.removedLines.get(removal.line) !== removal.currentLine
-                  || globallyAddedLines.has(removal.currentLine)) return false;
+                  || !(ranges.removedLines instanceof Map)) return 'error';
+                if (ranges.removedLines.get(removal.line) !== removal.currentLine
+                  || globallyAddedLines.has(removal.currentLine)) return 'invalid';
               }
-              return true;
+              return 'valid';
             };
 
             const candidate = candidateArtifactValid ? { body: candidateReview } : null;
             const review = candidate ? clean(candidate.body) : '';
             const parsedReview = review ? parseReview(review) : null;
-            const anchorsCovered = parsedReview !== null && anchorsAreChanged(parsedReview);
+            const filteredNewFindings = [];
+            let anchorValidationFailed = false;
+            if (parsedReview) {
+              const newFindings = parsedReview.blocks.filter((entry) =>
+                entry.section === 'New findings');
+              for (const entry of newFindings) {
+                const result = validateAnchorEvidence(entry.evidence);
+                if (result === 'valid') continue;
+                if (result === 'invalid') {
+                  filteredNewFindings.push({ entry, reason: 'anchor_out_of_scope' });
+                } else {
+                  anchorValidationFailed = true;
+                  break;
+                }
+              }
+              const carryover = parsedReview.blocks.filter((entry) =>
+                entry.section !== 'New findings');
+              if (!anchorValidationFailed && carryover.length > 0) {
+                const carryoverEvidence = {
+                  anchors: carryover.flatMap((entry) => entry.evidence.anchors),
+                  removals: carryover.flatMap((entry) => entry.evidence.removals),
+                };
+                if (validateAnchorEvidence(carryoverEvidence) !== 'valid') {
+                  anchorValidationFailed = true;
+                }
+              }
+            }
+            const filteredEntries = new Set(filteredNewFindings.map((item) => item.entry));
+            const canonicalReview = parsedReview && filteredEntries.size > 0
+              ? parsedReview.sections.map((section, sectionIndex) => {
+                  const retained = parsedReview.blocks.filter((entry) =>
+                    entry.sectionIndex === sectionIndex && !filteredEntries.has(entry));
+                  const sectionBody = section.name === 'New findings' && retained.length === 0
+                    ? 'None'
+                    : retained.map((entry) => [entry.block.heading, ...entry.block.lines]
+                      .join('\n').trim()).join('\n\n');
+                  return `### ${section.name}\n${sectionBody}`;
+                }).join('\n\n')
+              : review;
+            const anchorsCovered = parsedReview !== null && !anchorValidationFailed;
             const modelSucceeded = diffReady && ['full', 'delta'].includes(diffMode)
               && !unchangedSincePrevious && artifactsValid && modelOk
               && candidateArtifactValid && parsedReview !== null
@@ -3963,7 +4014,7 @@ jobs:
             const succeeded = modelSucceeded || unchangedSucceeded;
             const recordedMode = ['full', 'delta', 'unchanged', 'unavailable'].includes(diffMode)
               ? diffMode : 'unavailable';
-            const successBody = unchangedSucceeded ? previousBody : review;
+            const successBody = unchangedSucceeded ? previousBody : canonicalReview;
             const failureReason = !diffReady ? 'diff_unavailable'
               : !artifactsValid ? 'prepared_artifact_invalid'
               : !modelOk ? modelFailureReason
@@ -3988,7 +4039,12 @@ jobs:
                 };
             const status = succeeded ? 'success' : (priorSuccess ? 'stale' : 'failure');
             const displayBody = succeeded ? successBody : failureBody;
-            const bodyFor = (attestationId) => `${header}\n${marker}\n<!-- automation-state:${JSON.stringify(state)} -->\n${legacyMarker}\n\n- Status: ${status}\n- Run: ${process.env.RUN_URL}\n- Attestation: ${attestationId}${succeeded ? `\n- Reviewed: ${attemptHead}` : ''}${!succeeded ? `\n- Last attempt: failure (${process.env.RUN_URL})\n- Reason: ${failureReason}` : ''}\n\n${displayBody}`;
+            const filteredReasons = [...new Set(filteredNewFindings.map((item) => item.reason))]
+              .sort().join(',');
+            const validationSummary = modelSucceeded && filteredNewFindings.length > 0
+              ? `\n- Validation: filtered_invalid_new_findings=${filteredNewFindings.length}; reasons=${filteredReasons}`
+              : '';
+            const bodyFor = (attestationId) => `${header}\n${marker}\n<!-- automation-state:${JSON.stringify(state)} -->\n${legacyMarker}\n\n- Status: ${status}\n- Run: ${process.env.RUN_URL}\n- Attestation: ${attestationId}${succeeded ? `\n- Reviewed: ${attemptHead}` : ''}${validationSummary}${!succeeded ? `\n- Last attempt: failure (${process.env.RUN_URL})\n- Reason: ${failureReason}` : ''}\n\n${displayBody}`;
             if (Buffer.byteLength(bodyFor(Number.MAX_SAFE_INTEGER), 'utf8') > 65536) {
               throw new Error('canonical OpenCode comment exceeds 65,536-byte publication limit');
             }

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -327,6 +327,16 @@ parser then:
    truncated hunk bodies, counters, coordinates, and controls fail closed; diff prelude metadata is
    not treated as hunk-body evidence.
 
+After the document grammar and evidence fields validate, OpenCode checks each `New findings` block
+independently. A block whose path is absent or removed, whose line is not an actual added-side line,
+or whose quoted current line does not match is omitted without failing an otherwise valid review.
+Valid blocks—including `[HIGH]` blocks—remain unchanged. If every new block is omitted, the
+canonical section becomes exactly `### New findings` followed by `None`; the successful attested
+comment reports `filtered_invalid_new_findings=N` and `reasons=anchor_out_of_scope` on its visible
+validation line. Git invocation or parsing failures, sealed manifest inconsistencies, malformed
+document/evidence grammar, and invalid carryover or disposition evidence still fail the checkpoint
+without advancing `successful_head`.
+
 The sole zero-record case is an exact empty full review: the sealed manifest has `files: []`, the
 selected full diff is a zero-byte regular file, and local full-range name-status reconstruction is
 also empty. An empty delta, non-empty selected diff, or non-empty Git reconstruction remains

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -60,7 +60,7 @@ OPENCODE_REVIEW_RUN_SHA256 = (
     "9f1468128086b438cce0ce53fc20a9f0e02a14d581cd12b63f021c8c3a7620c6"
 )
 OPENCODE_AUTO_REVIEW_SHA256 = (
-    "af209bfc73798a0cdda8d2f024f8392004c26814069cc244b80c298dd46b8d0f"
+    "a38218bc27e672f7f7bde1873b9fa3de811057490f3fab7dc91c74d03d80ba97"
 )
 # These immutable annotated v1.45 patch releases predate format repair. Only their
 # exact peeled commits may retain the legacy generic command; no new commit may opt in.

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -3031,6 +3031,7 @@ def _run_upsert(
     run_jobs_by_attempt: dict[str, list[dict]] | None = None,
     current_workflow_run: dict | None = None,
     inject_comments_at_list_call: dict[int, list[dict]] | None = None,
+    node_preload: Path | None = None,
 ) -> list:
     workflow = _load(workflow_file)
     script = _step(workflow, job, step_name)["with"]["script"]
@@ -3080,11 +3081,16 @@ def _run_upsert(
         "runJobsByAttempt": run_jobs_by_attempt or {},
     }
     (tmp_path / "fixture.json").write_text(json.dumps(fixture), encoding="utf-8")
+    node_env = None
+    if node_preload is not None:
+        node_env = os.environ.copy()
+        node_env["NODE_OPTIONS"] = f"--require={node_preload}"
     result = subprocess.run(
         ["node", str(tmp_path / "harness.js"), str(tmp_path / "script.js"), str(tmp_path / "fixture.json")],
         check=False,
         capture_output=True,
         text=True,
+        env=node_env,
     )
     if expect_error:
         assert result.returncode != 0
@@ -11081,6 +11087,7 @@ def _run_opencode_canonicalize(
     candidate_artifact_case: str = "valid",
     candidate_review: str | None = None,
     failure_reason: str = "",
+    node_preload: Path | None = None,
 ) -> list:
     workflow = _load("opencode-auto-review.yml")
     script = _step(workflow, "opencode-canonicalize", "Canonicalize OpenCode review")["with"]["script"]
@@ -11357,6 +11364,7 @@ def _run_opencode_canonicalize(
         run_jobs_by_attempt=run_jobs_by_attempt,
         current_workflow_run=current_workflow_run,
         inject_comments_at_list_call=inject_comments_at_list_call,
+        node_preload=node_preload,
     )
 
 
@@ -12187,6 +12195,92 @@ def test_opencode_changed_anchor_scope_accepts_none_or_anchored_findings(tmp_pat
 
 
 @node_required
+def test_opencode_filters_out_of_scope_new_finding_but_keeps_valid_high(tmp_path):
+    valid_anchor = json.dumps(
+        {"path": OPENCODE_SCOPE_PATH, "line": 1},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    invalid_anchor = json.dumps(
+        {"path": ".github/workflows/gemini-auto-review.yml", "line": 74},
+        separators=(",", ":"),
+    )
+    review = (
+        f"{OPENCODE_MARKER}\n### New findings\n"
+        f"#### [HIGH] Real regression\n- Changed anchor: {valid_anchor}\n"
+        '- Current line: "added line 1"\nConcrete, blocking impact.\n\n'
+        f"#### [MEDIUM] Potential parameter duplication typo\n"
+        f"- Changed anchor: {invalid_anchor}\n"
+        '- Current line: "      publisher_app_id: ${{ vars.APP_ID }}"\n'
+        "This appears duplicated; verify whether it is intentional."
+    )
+    candidate = _bot("github-actions[bot]", review, 10, updated="u2")
+
+    calls = _run_opencode_canonicalize(tmp_path, [], [candidate])
+    body = _single_mutation_body(calls)
+    state = json.loads(
+        re.search(r"<!-- automation-state:(\{.*\}) -->", body).group(1)
+    )
+
+    assert state["attempt_status"] == "success"
+    assert "#### [HIGH] Real regression" in body
+    assert "Concrete, blocking impact." in body
+    assert "Potential parameter duplication typo" not in body
+    assert (
+        "- Validation: filtered_invalid_new_findings=1; "
+        "reasons=anchor_out_of_scope"
+    ) in body
+
+@node_required
+def test_opencode_all_out_of_scope_new_findings_becomes_clean_success(tmp_path):
+    invalid_anchor = json.dumps(
+        {"path": ".github/workflows/gemini-auto-review.yml", "line": 74},
+        separators=(",", ":"),
+    )
+    wrong_line_anchor = json.dumps(
+        {"path": OPENCODE_SCOPE_PATH, "line": 1},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    review = (
+        f"{OPENCODE_MARKER}\n### New findings\n"
+        f"#### [MEDIUM] Potential parameter duplication typo\n"
+        f"- Changed anchor: {invalid_anchor}\n"
+        '- Current line: "      publisher_app_id: ${{ vars.APP_ID }}"\n'
+        "This appears duplicated; verify whether it is intentional.\n\n"
+        f"#### [MEDIUM] Misquoted current source\n"
+        f"- Changed anchor: {wrong_line_anchor}\n"
+        '- Current line: "not the current added line"\n'
+        "The quoted source does not match the prepared diff."
+    )
+    candidate = _bot("github-actions[bot]", review, 10, updated="u2")
+
+    calls = _run_opencode_canonicalize(tmp_path, [], [candidate])
+    body = _single_mutation_body(calls)
+    state = json.loads(
+        re.search(r"<!-- automation-state:(\{.*\}) -->", body).group(1)
+    )
+
+    assert state["attempt_status"] == "success"
+    assert "### New findings\nNone" in body
+    assert "Potential parameter duplication typo" not in body
+    assert "Misquoted current source" not in body
+    assert (
+        "- Validation: filtered_invalid_new_findings=2; "
+        "reasons=anchor_out_of_scope"
+    ) in body
+
+    canonical, receipt = _opencode_published_from_calls(calls)
+    next_round = tmp_path / "next-round"
+    next_round.mkdir()
+    context = _run_opencode_ctx(
+        next_round, [canonical], check_runs=[receipt]
+    )
+    assert "### New findings\nNone" in context
+    assert "filtered_invalid_new_findings" not in context
+
+
+@node_required
 def test_opencode_canonicalization_quarantines_new_v2_forgery_and_uses_only_raw_candidate(tmp_path):
     old_head = "ab" * 20
     before = _bot(
@@ -12878,11 +12972,7 @@ def test_opencode_changed_anchor_scope_rejects_invalid_output_grammar(tmp_path, 
 
 
 @node_required
-@pytest.mark.parametrize(
-    "current_line",
-    [None, "wrong line"],
-)
-def test_opencode_finding_requires_exact_current_changed_line(tmp_path, current_line):
+def test_opencode_finding_requires_current_line_field(tmp_path):
     anchor = json.dumps(
         {"path": OPENCODE_SCOPE_PATH, "line": 1},
         ensure_ascii=False,
@@ -12893,14 +12983,43 @@ def test_opencode_finding_requires_exact_current_changed_line(tmp_path, current_
         "### New findings",
         "#### [MEDIUM] Grounded finding",
         f"- Changed anchor: {anchor}",
+        "Concrete impact.",
     ]
-    if current_line is not None:
-        lines.append(f"- Current line: {json.dumps(current_line)}")
-    lines.append("Concrete impact.")
     candidate = _bot("github-actions[bot]", "\n".join(lines), 10, updated="u2")
     body = _single_mutation_body(_run_opencode_canonicalize(tmp_path, [], [candidate]))
     state = json.loads(re.search(r"<!-- automation-state:(\{.*\}) -->", body).group(1))
     assert state["attempt_status"] == "failure"
+
+
+@node_required
+def test_opencode_finding_with_wrong_current_line_is_filtered(tmp_path):
+    anchor = json.dumps(
+        {"path": OPENCODE_SCOPE_PATH, "line": 1},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    candidate = _bot(
+        "github-actions[bot]",
+        (
+            f"{OPENCODE_MARKER}\n### New findings\n"
+            f"#### [MEDIUM] Wrong source line\n- Changed anchor: {anchor}\n"
+            '- Current line: "wrong line"\nConcrete impact.'
+        ),
+        10,
+        updated="u2",
+    )
+
+    body = _single_mutation_body(
+        _run_opencode_canonicalize(tmp_path, [], [candidate])
+    )
+    state = json.loads(
+        re.search(r"<!-- automation-state:(\{.*\}) -->", body).group(1)
+    )
+
+    assert state["attempt_status"] == "success"
+    assert "### New findings\nNone" in body
+    assert "Wrong source line" not in body
+    assert "filtered_invalid_new_findings=1" in body
 
 
 @node_required
@@ -12964,19 +13083,83 @@ def test_opencode_finding_allows_nonseparator_named_entity_prose(
 
 @node_required
 @pytest.mark.parametrize(
-    ("anchor", "manifest_files", "git_diff", "git_failure"),
+    (
+        "anchor_path",
+        "anchor_line",
+        "current_line",
+        "manifest_files",
+        "git_diff",
+        "git_failure",
+        "expected_status",
+    ),
     [
-        ("old-name.js:1", [{"status": "renamed", "filename": OPENCODE_SCOPE_PATH, "previous_filename": "old-name.js"}], "@@ -1,0 +1,1 @@\n+x\n", False),
-        ("deleted.js:1", [{"status": "removed", "filename": "deleted.js"}], "@@ -1 +0,0 @@\n-x\n", False),
-        ("absent.js:1", [{"status": "modified", "filename": OPENCODE_SCOPE_PATH}], "@@ -1,0 +1,1 @@\n+x\n", False),
-        (f"{OPENCODE_SCOPE_PATH}:2", [{"status": "modified", "filename": OPENCODE_SCOPE_PATH}], "@@ -1,0 +1,1 @@\n+x\n", False),
-        (f"{OPENCODE_SCOPE_PATH}:1", [{"status": "modified", "filename": OPENCODE_SCOPE_PATH}], "not a hunk\n", False),
-        (f"{OPENCODE_SCOPE_PATH}:1", [{"status": "modified", "filename": OPENCODE_SCOPE_PATH}], "@@ -1,0 +1,1 @@\n+x\n", True),
+        (
+            "old-name.js",
+            1,
+            "added line 1",
+            [{
+                "status": "renamed",
+                "filename": OPENCODE_SCOPE_PATH,
+                "previous_filename": "old-name.js",
+            }],
+            "@@ -1,0 +1,1 @@\n+x\n",
+            False,
+            "success",
+        ),
+        (
+            "deleted.js",
+            1,
+            "stable line 1",
+            [{"status": "removed", "filename": "deleted.js"}],
+            "@@ -1 +0,0 @@\n-x\n",
+            False,
+            "success",
+        ),
+        (
+            "absent.js",
+            1,
+            "added line 1",
+            [{"status": "modified", "filename": OPENCODE_SCOPE_PATH}],
+            "@@ -1,0 +1,1 @@\n+x\n",
+            False,
+            "success",
+        ),
+        (
+            OPENCODE_SCOPE_PATH,
+            2,
+            "stable line 1",
+            [{"status": "modified", "filename": OPENCODE_SCOPE_PATH}],
+            "@@ -1,0 +1,1 @@\n+x\n",
+            False,
+            "success",
+        ),
+        (
+            OPENCODE_SCOPE_PATH,
+            1,
+            "added line 1",
+            [{"status": "modified", "filename": OPENCODE_SCOPE_PATH}],
+            "@@ -1,0 +1,1 @@\n+x\n",
+            True,
+            "failure",
+        ),
     ],
-    ids=("previous-rename", "deleted", "out-of-scope", "unchanged-line", "malformed-hunk", "git-failure"),
+    ids=(
+        "previous-rename",
+        "deleted",
+        "out-of-scope",
+        "unchanged-line",
+        "git-failure",
+    ),
 )
-def test_opencode_changed_anchor_scope_rejects_non_added_locations(
-    tmp_path, anchor, manifest_files, git_diff, git_failure
+def test_opencode_new_finding_scope_filters_invalid_locations_but_keeps_validation_failures_hard(
+    tmp_path,
+    anchor_path,
+    anchor_line,
+    current_line,
+    manifest_files,
+    git_diff,
+    git_failure,
+    expected_status,
 ):
     manifest = {
         "schema": 1,
@@ -12986,19 +13169,147 @@ def test_opencode_changed_anchor_scope_rejects_non_added_locations(
         "head_sha": "cd" * 20,
         "files": manifest_files,
     }
+    anchor = json.dumps(
+        {"path": anchor_path, "line": anchor_line},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
     candidate = _bot(
         "github-actions[bot]",
-        f"{OPENCODE_MARKER}\n### New findings\n#### Finding\n- Changed anchor: `{anchor}`",
+        f"{OPENCODE_MARKER}\n### New findings\n#### Finding\n"
+        f"- Changed anchor: {anchor}\n"
+        f"- Current line: {json.dumps(current_line)}",
         10,
         updated="u2",
     )
     body = _single_mutation_body(
         _run_opencode_canonicalize(
-            tmp_path, [], [candidate], manifest=manifest, git_diff=git_diff, git_failure=git_failure
+            tmp_path,
+            [],
+            [candidate],
+            manifest=manifest,
+            git_diff=git_diff,
+            git_failure=git_failure,
         )
     )
-    state = json.loads(re.search(r"<!-- automation-state:(\{.*\}) -->", body).group(1))
+    state = json.loads(
+        re.search(r"<!-- automation-state:(\{.*\}) -->", body).group(1)
+    )
+    assert state["attempt_status"] == expected_status
+    if expected_status == "success":
+        assert "### New findings\nNone" in body
+        assert "filtered_invalid_new_findings=1" in body
+    else:
+        assert "Reason: anchor_out_of_scope" in body
+        assert "filtered_invalid_new_findings" not in body
+
+
+@node_required
+def test_opencode_removed_manifest_status_mismatch_remains_hard_failure(tmp_path):
+    repo = tmp_path / "repo"
+    _init_anchor_repo(repo)
+    path = "actually-modified.txt"
+    (repo / path).write_text("before\n", encoding="utf-8")
+    base = _commit_anchor_repo(repo, "base")
+    (repo / path).write_text("after\n", encoding="utf-8")
+    head = _commit_anchor_repo(repo, "modified head")
+    manifest = {
+        "schema": 1,
+        "repository": "example/repo",
+        "pr_number": 7,
+        "merge_base_sha": base,
+        "head_sha": head,
+        "files": [{"status": "removed", "filename": path}],
+    }
+
+    calls = _run_opencode_canonicalize(
+        tmp_path,
+        [],
+        [_anchor_candidate(path, 1, "Manifest status mismatch", "after")],
+        attempt_head=head,
+        current_head=head,
+        manifest=manifest,
+        trusted_workspace=repo,
+    )
+    body = _single_mutation_body(calls)
+    state = json.loads(
+        re.search(r"<!-- automation-state:(\{.*\}) -->", body).group(1)
+    )
+
     assert state["attempt_status"] == "failure"
+    assert "Reason: anchor_out_of_scope" in body
+    assert "filtered_invalid_new_findings" not in body
+
+
+@node_required
+def test_opencode_malformed_content_diff_remains_hard_failure(tmp_path):
+    repo = tmp_path / "repo"
+    _init_anchor_repo(repo)
+    path = "malformed-diff.txt"
+    (repo / path).write_text("before\n", encoding="utf-8")
+    base = _commit_anchor_repo(repo, "base")
+    (repo / path).write_text("after\n", encoding="utf-8")
+    head = _commit_anchor_repo(repo, "modified head")
+    manifest = {
+        "schema": 1,
+        "repository": "example/repo",
+        "pr_number": 7,
+        "merge_base_sha": base,
+        "head_sha": head,
+        "files": [{"status": "modified", "filename": path}],
+    }
+    git_log = tmp_path / "malformed-diff-calls.log"
+    preload = tmp_path / "malformed-diff-preload.js"
+    preload.write_text(
+        "const childProcess = require('child_process');\n"
+        "const fs = require('fs');\n"
+        f"const logPath = {json.dumps(str(git_log))};\n"
+        "const originalSpawnSync = childProcess.spawnSync;\n"
+        "childProcess.spawnSync = function(command, args, options) {\n"
+        "  if (command === '/usr/bin/git' && Array.isArray(args) "
+        "&& args.includes('-U0') && !args.includes('--output-indicator-new=%')) {\n"
+        "    fs.appendFileSync(logPath, 'content-diff\\n');\n"
+        "    return { status: 0, stdout: '@@ malformed\\n' };\n"
+        "  }\n"
+        "  return originalSpawnSync.apply(this, arguments);\n"
+        "};\n",
+        encoding="utf-8",
+    )
+    anchor = json.dumps(
+        {"path": path, "line": 1}, separators=(",", ":")
+    )
+    candidate = _bot(
+        "github-actions[bot]",
+        (
+            f"{OPENCODE_MARKER}\n### New findings\n"
+            f"#### Malformed content diff one\n- Changed anchor: {anchor}\n"
+            '- Current line: "after"\nFirst candidate.\n\n'
+            f"#### Malformed content diff two\n- Changed anchor: {anchor}\n"
+            '- Current line: "after"\nSecond candidate.'
+        ),
+        10,
+        updated="u2",
+    )
+
+    calls = _run_opencode_canonicalize(
+        tmp_path,
+        [],
+        [candidate],
+        attempt_head=head,
+        current_head=head,
+        manifest=manifest,
+        trusted_workspace=repo,
+        node_preload=preload,
+    )
+    body = _single_mutation_body(calls)
+    state = json.loads(
+        re.search(r"<!-- automation-state:(\{.*\}) -->", body).group(1)
+    )
+
+    assert state["attempt_status"] == "failure"
+    assert "Reason: anchor_out_of_scope" in body
+    assert "filtered_invalid_new_findings" not in body
+    assert git_log.read_text(encoding="utf-8").splitlines() == ["content-diff"]
 
 
 @node_required
@@ -13410,7 +13721,11 @@ def test_opencode_pure_rename_does_not_turn_unchanged_destination_lines_into_add
         trusted_workspace=repo,
     )
 
-    assert _published_opencode_state(calls)["attempt_status"] == "failure"
+    assert _published_opencode_state(calls)["attempt_status"] == "success"
+    body = _single_mutation_body(calls)
+    assert "### New findings\nNone" in body
+    assert "#### Pure rename" not in body
+    assert "filtered_invalid_new_findings=1" in body
 
 
 @node_required
@@ -13452,6 +13767,9 @@ def test_opencode_modified_rename_accepts_only_the_real_added_destination_line(t
     )
 
     assert _published_opencode_state(calls)["attempt_status"] == "success"
+    accepted_body = _single_mutation_body(calls)
+    assert "#### Modified rename" in accepted_body
+    assert "filtered_invalid_new_findings" not in accepted_body
 
     unchanged_dir = tmp_path / "unchanged-line"
     unchanged_dir.mkdir()
@@ -13464,7 +13782,11 @@ def test_opencode_modified_rename_accepts_only_the_real_added_destination_line(t
         manifest=manifest,
         trusted_workspace=repo,
     )
-    assert _published_opencode_state(unchanged_calls)["attempt_status"] == "failure"
+    assert _published_opencode_state(unchanged_calls)["attempt_status"] == "success"
+    filtered_body = _single_mutation_body(unchanged_calls)
+    assert "### New findings\nNone" in filtered_body
+    assert "#### Rename context" not in filtered_body
+    assert "filtered_invalid_new_findings=1" in filtered_body
 
 
 @node_required
@@ -13541,12 +13863,12 @@ def test_opencode_gitlink_anchor_ignores_hostile_submodule_ignore_configuration(
 
 @node_required
 @pytest.mark.parametrize(
-    ("line", "expected_status"),
-    ((1, "success"), (2, "failure"), (3, "success")),
+    ("line", "expected_retained"),
+    ((1, True), (2, False), (3, True)),
     ids=("first-change", "unchanged-bridge", "last-change-no-newline"),
 )
 def test_opencode_anchor_uses_only_added_lines_under_hostile_inter_hunk_context(
-    tmp_path, line, expected_status
+    tmp_path, line, expected_retained
 ):
     repo = tmp_path / "repo"
     _init_anchor_repo(repo)
@@ -13580,7 +13902,15 @@ def test_opencode_anchor_uses_only_added_lines_under_hostile_inter_hunk_context(
         trusted_workspace=repo,
     )
 
-    assert _published_opencode_state(calls)["attempt_status"] == expected_status
+    assert _published_opencode_state(calls)["attempt_status"] == "success"
+    body = _single_mutation_body(calls)
+    if expected_retained:
+        assert "#### Inter-hunk bridge" in body
+        assert "filtered_invalid_new_findings" not in body
+    else:
+        assert "### New findings\nNone" in body
+        assert "#### Inter-hunk bridge" not in body
+        assert "filtered_invalid_new_findings=1" in body
 
 
 @node_required


### PR DESCRIPTION
## Summary

- validate each syntactically valid OpenCode New findings block independently
- filter only deterministic path, added-line, and Current line scope mismatches while preserving valid findings including HIGH
- keep malformed evidence, Git or parser errors, manifest inconsistencies, and invalid carryover as hard failures
- publish an attested filtered count and convert an all-filtered New findings section to None
- update the authenticated workflow release digest

## Validation

- pytest -q: 2467 passed
- OpenCode workflow logic: 1178 passed
- release integrity regressions: 6 passed
- actionlint with CI flags: passed
- git diff --check: passed
- independent review: no Critical, Important, or Minor findings

Fixes #49