### PR TITLE
chore(fleet): default rollouts to v1.46.2

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.46.1",
+  "automation_ref": "v1.46.2",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -33,7 +33,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.46.1"
+    assert config.automation_ref == "v1.46.2"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
## Summary

- advance the fleet rollout default from v1.46.1 to the immutable v1.46.2 release
- keep the catalog contract expectation aligned

## Release evidence

- annotated tag object: 1f0c9691a80a18c11a77830d755599509840b4db
- peeled secure commit: 79e87569272b865642c1d1493740135b567717ac
- credential-free full public clone verification: PASS

## Validation

- TDD RED: expected v1.46.2 while config returned v1.46.1
- catalog tests: 11 passed
- fleet config and rollout consumers: 324 passed
- full suite: 2467 passed, 48 subtests passed
- git diff --check: passed