### PR TITLE
chore(fleet): default rollouts to v1.47

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.46.2",
+  "automation_ref": "v1.47",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -33,7 +33,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.46.2"
+    assert config.automation_ref == "v1.47"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
## Summary

- advance the fleet rollout default from v1.46.2 to the immutable v1.47 release
- keep the catalog contract expectation aligned

## Release evidence

- annotated tag object: ba9168f3c61b91d374316ec9e30619df16e29822
- peeled secure commit: 3d92ddb5d66f8be2f69815719bb97102912ea96a
- credential-free full public clone verification: PASS

## Validation

- TDD RED: expected v1.47 while config returned v1.46.2
- catalog tests: 11 passed
- fleet config and rollout consumers: 263 passed
- full suite: 2727 passed, 48 subtests passed
- git diff --check: passed