### PR TITLE
fix(review): accept omitted reusable workflow ref

### DIFF
--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -1547,13 +1547,14 @@ def _run_provenances(
         if len(central) != 1:
             raise TransportError("provenance_mismatch")
         central = central[0]
+        central_ref = central.get("ref") if "ref" in central else central.get("sha")
         provenance = RunProvenance(
             repository=repository.get("full_name"), pr=request["pr"],
             head_sha=value.get("head_sha"),
             caller_workflow_path=value.get("path"),
             caller_event=value.get("event"),
             referenced_workflow_path=central.get("path"),
-            referenced_workflow_ref=central.get("ref"),
+            referenced_workflow_ref=central_ref,
             referenced_workflow_sha=central.get("sha"),
             run_id=value.get("id"), run_attempt=value.get("run_attempt"),
             status=value.get("status"), conclusion=value.get("conclusion"),

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -631,7 +631,7 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256 = (
     "42462dad335073794bd5c46e1993e02e4dc9824113d1b36fd5c6b89dc0583a9c"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256 = (
-    "9e7cae2b39f41f693122ff80206e0c9ad4ccd32ffa7fb21b344d5383a6421f59"
+    "e9dcfd404c8d427a6af3b35c248b5cdb5ee226b7b0080c9ee27b370128a947d9"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
     "claude": "92ec63f9b8a22703918d974e87e1eb3ab7f2f9ffaaca1a3c3f12e360f5839906",
@@ -4380,13 +4380,14 @@ def require_budget_helper_contract(source: str) -> None:
             "    if len(central) != 1:\n"
             "        raise TransportError('provenance_mismatch')\n"
             "    central = central[0]\n"
+            "    central_ref = central.get('ref') if 'ref' in central else central.get('sha')\n"
             "    provenance = RunProvenance("
             "repository=repository.get('full_name'), pr=request['pr'], "
             "head_sha=value.get('head_sha'), "
             "caller_workflow_path=value.get('path'), "
             "caller_event=value.get('event'), "
             "referenced_workflow_path=central.get('path'), "
-            "referenced_workflow_ref=central.get('ref'), "
+            "referenced_workflow_ref=central_ref, "
             "referenced_workflow_sha=central.get('sha'), "
             "run_id=value.get('id'), run_attempt=value.get('run_attempt'), "
             "status=value.get('status'), conclusion=value.get('conclusion'))\n"

--- a/tests/test_review_invocation_budget_action.py
+++ b/tests/test_review_invocation_budget_action.py
@@ -180,6 +180,8 @@ elif "/actions/runs/700/attempts/1" in endpoint:
         )
     elif config["scenario"] == "current-run-reference-malformed-ref":
         response["referenced_workflows"][0]["ref"] = "bad ref"
+    elif config["scenario"] == "current-run-reference-null-ref":
+        response["referenced_workflows"][0]["ref"] = None
     elif config["scenario"] == "current-run-reference-omits-ref":
         response["referenced_workflows"][0].pop("ref")
     elif config["scenario"] == "current-run-reference-wrong-sha":
@@ -518,6 +520,7 @@ def test_first_claim_uses_resolved_sha_when_github_omits_reusable_workflow_ref(f
         "current-run-reference-duplicate",
         "current-run-reference-wrong-path",
         "current-run-reference-malformed-ref",
+        "current-run-reference-null-ref",
         "current-run-reference-wrong-sha",
     ],
 )

--- a/tests/test_review_invocation_budget_action.py
+++ b/tests/test_review_invocation_budget_action.py
@@ -180,6 +180,8 @@ elif "/actions/runs/700/attempts/1" in endpoint:
         )
     elif config["scenario"] == "current-run-reference-malformed-ref":
         response["referenced_workflows"][0]["ref"] = "bad ref"
+    elif config["scenario"] == "current-run-reference-omits-ref":
+        response["referenced_workflows"][0].pop("ref")
     elif config["scenario"] == "current-run-reference-wrong-sha":
         response["referenced_workflows"][0]["sha"] = "not-a-sha"
 elif "/collaborators/" in endpoint and endpoint.endswith("/permission"):
@@ -244,7 +246,10 @@ class FakeGitHub:
         input_path.write_bytes(b"abcde")
 
         prior = _prior_comment()
-        if scenario in {"first-comment-create", "empty-cas-pages"}:
+        if scenario in {
+            "first-comment-create", "empty-cas-pages",
+            "current-run-reference-omits-ref",
+        }:
             comments = []
             head, full_hash = HEAD_A, HASH_1
         elif scenario == "finalize-trusted-comment":
@@ -493,6 +498,17 @@ def test_first_claim_authenticates_and_stores_reusable_workflow_provenance(fake_
     assert invocation["referenced_workflow_path"] == CENTRAL_PATH
     assert invocation["referenced_workflow_ref"] == CENTRAL_REF
     assert invocation["referenced_workflow_sha"] == CENTRAL_SHA
+
+
+def test_first_claim_uses_resolved_sha_when_github_omits_reusable_workflow_ref(fake_github):
+    result = fake_github.run_action(
+        mode="claim", scenario="current-run-reference-omits-ref",
+    )
+
+    assert result.outputs["decision"] == "claimed"
+    assert result.outputs["allow-invocation"] == "true"
+    invocation = result.checkpoint["ledger"]["invocations"][0]
+    assert invocation["referenced_workflow_ref"] == CENTRAL_SHA
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- treat an absent GitHub run API `referenced_workflows[].ref` as the already authenticated resolved workflow SHA
- keep malformed present refs, duplicate references, and path/SHA mismatches fail-closed
- add a regression fixture matching the live `wlan-package` PR #199 response

## Live failure evidence

On `wlan-package` PR #199, Claude, Gemini, and OpenCode each received a full diff but returned `state_invalid` / `provenance_mismatch` with `allow_invocation=false` because GitHub omitted only the optional `ref` field. The rollout remains stopped and PR #199 is not merged.

## Validation

- RED: omitted-ref regression returned `state_invalid`
- GREEN: targeted regression plus malformed provenance matrix: 6 passed
- full suite: 2728 passed, 48 subtests passed
- `git diff --check`: clean

After merge this requires a new immutable patch release; v1.47 will not be retagged.