### PR TITLE
fix(review): allow Claude timeout headroom

### DIFF
--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -88,7 +88,12 @@ class BudgetPolicy:
     def for_reviewer(cls, reviewer: Reviewer) -> "BudgetPolicy":
         if reviewer not in MARKERS:
             raise BudgetStateError("reviewer_invalid")
-        return cls(max_calls_per_round={"claude": 1, "gemini": 3, "opencode": 2}[reviewer])
+        return cls(
+            max_calls_per_round={"claude": 1, "gemini": 3, "opencode": 2}[reviewer],
+            max_wall_seconds_per_round={
+                "claude": 1080, "gemini": 600, "opencode": 600,
+            }[reviewer],
+        )
 
     def to_dict(self) -> dict[str, int]:
         return {

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -101,7 +101,7 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       actions: read
       contents: read
@@ -1012,7 +1012,7 @@ jobs:
 
           if [[ ! "$ELAPSED_SECONDS" =~ ^[0-9]+$ ]]; then
             :
-          elif (( ELAPSED_SECONDS > 600 )); then
+          elif (( ELAPSED_SECONDS > 1080 )); then
             outcome='wall_time_exhausted'
             stop_reason='wall_time_exhausted'
           elif [[ "$PROVIDER_OUTCOME" == 'failure' ]]; then

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -631,10 +631,10 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256 = (
     "42462dad335073794bd5c46e1993e02e4dc9824113d1b36fd5c6b89dc0583a9c"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256 = (
-    "e9dcfd404c8d427a6af3b35c248b5cdb5ee226b7b0080c9ee27b370128a947d9"
+    "b58044cadbded4e91b2b021e4902e56b4ca267cc47e75f3984037f61b662ee48"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
-    "claude": "92ec63f9b8a22703918d974e87e1eb3ab7f2f9ffaaca1a3c3f12e360f5839906",
+    "claude": "2fa6fdb6fbad2e874c5dfab7e059d53c8d2f610731f3d3dcf918cd531c585876",
     "gemini": "a8b048f7862c3eed467482a750da57abad8d6ef04ed61964a35e4f90b4afeeda",
     "opencode": "28791fa77f05454775043cb5b582f849aef7fe81c109c65161bcf860a6d6531a",
 }
@@ -3994,11 +3994,14 @@ def require_budget_helper_contract(source: str) -> None:
             )
             or not _ast_statement_matches(
                 reviewer_policy.body[1],
-                "return cls(max_calls_per_round={"
-                "'claude': 1, 'gemini': 3, 'opencode': 2}[reviewer])",
+                "return cls("
+                "max_calls_per_round={'claude': 1, 'gemini': 3, "
+                "'opencode': 2}[reviewer], "
+                "max_wall_seconds_per_round={'claude': 1080, "
+                "'gemini': 600, 'opencode': 600}[reviewer])",
             )
         ):
-            raise ValueError("reviewer call caps differ")
+            raise ValueError("reviewer execution caps differ")
         finding_bindings = [
             item.value
             for item in module.body
@@ -4663,7 +4666,8 @@ def require_budget_workflow_contract(
         }
         if provider.get("if") != expected_provider_guards[reviewer]:
             raise ValueError("provider allow predicate differs")
-        if provider_job.get("timeout-minutes") != "10":
+        expected_timeouts = {"claude": "20", "gemini": "10", "opencode": "10"}
+        if provider_job.get("timeout-minutes") != expected_timeouts[reviewer]:
             raise ValueError("review timeout differs")
 
         claim_names = {

--- a/tests/fixtures/review-invocation-budget/cases.json
+++ b/tests/fixtures/review-invocation-budget/cases.json
@@ -11,8 +11,8 @@
   {"kind":"finalize","name":"gemini-call-over-cap","reviewer":"gemini","calls":4,"expected_outcome":"checkpoint_failure"},
   {"kind":"finalize","name":"opencode-call-at-cap","reviewer":"opencode","calls":2,"expected_outcome":"success"},
   {"kind":"finalize","name":"opencode-call-over-cap","reviewer":"opencode","calls":3,"expected_outcome":"checkpoint_failure"},
-  {"kind":"finalize","name":"wall-at-cap","reviewer":"claude","elapsed":600,"expected_outcome":"success"},
-  {"kind":"finalize","name":"wall-over-cap","reviewer":"claude","elapsed":601,"expected_outcome":"wall_time_exhausted"},
+  {"kind":"finalize","name":"wall-at-cap","reviewer":"claude","elapsed":1080,"expected_outcome":"success"},
+  {"kind":"finalize","name":"wall-over-cap","reviewer":"claude","elapsed":1081,"expected_outcome":"wall_time_exhausted"},
   {"kind":"finalize","name":"quality-filtered","reviewer":"claude","outcome":"quality_filtered","expected_outcome":"quality_filtered"},
   {"kind":"finalize","name":"provider-failure","reviewer":"claude","outcome":"provider_failure","expected_outcome":"provider_failure"},
   {"kind":"finalize","name":"remaining-finding-ids","reviewer":"claude","remaining":["RVW-111111111111","RVW-222222222222"],"expected_outcome":"success"}

--- a/tests/test_review_invocation_budget.py
+++ b/tests/test_review_invocation_budget.py
@@ -828,15 +828,25 @@ def test_stored_call_count_enforces_each_reviewer_boundary(reviewer, max_calls):
     )
 
 
-def test_stored_elapsed_seconds_enforces_round_boundary():
+@pytest.mark.parametrize(
+    ("reviewer", "max_elapsed"),
+    (("claude", 1080), ("gemini", 600), ("opencode", 600)),
+)
+def test_stored_elapsed_seconds_enforces_each_reviewer_round_boundary(
+    reviewer, max_elapsed,
+):
     at_limit = budget.LedgerState.initial(
-        REPOSITORY, PR, "claude", invocations=(invocation(elapsed_seconds=600),),
+        REPOSITORY, PR, reviewer,
+        invocations=(invocation(reviewer=reviewer, elapsed_seconds=max_elapsed),),
     )
     assert budget.parse_ledger(
-        ledger_body(at_limit), repository=REPOSITORY, pr=PR, reviewer="claude",
+        ledger_body(at_limit), repository=REPOSITORY, pr=PR, reviewer=reviewer,
     ) == at_limit
     above_limit = replace(
-        at_limit, invocations=(replace(at_limit.invocations[0], elapsed_seconds=601),),
+        at_limit,
+        invocations=(replace(
+            at_limit.invocations[0], elapsed_seconds=max_elapsed + 1,
+        ),),
     )
     assert_stored_state_rejected(above_limit, "wall_time_exhausted")
 
@@ -849,7 +859,8 @@ def test_stored_elapsed_seconds_enforces_round_boundary():
         ),),
     )
     assert budget.parse_ledger(
-        ledger_body(normalized_failure), repository=REPOSITORY, pr=PR, reviewer="claude",
+        ledger_body(normalized_failure),
+        repository=REPOSITORY, pr=PR, reviewer=reviewer,
     ) == normalized_failure
     assert_stored_state_rejected(
         replace(normalized_failure, invocations=(replace(

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -1294,7 +1294,7 @@ def test_claude_budget_claim_is_durable_before_provider_and_every_model_path_is_
     assert allow in _step(workflow, "claude-review", "Start Claude review metrics")["if"]
     assert allow in _step(workflow, "claude-review", "Run Claude Code Review")["if"]
     assert allow in _step(workflow, "claude-review", "Canonicalize Claude review")["if"]
-    assert job["timeout-minutes"] == "10"
+    assert job["timeout-minutes"] == "20"
     assert job["permissions"] == {
         "actions": "read",
         "contents": "read",
@@ -1707,7 +1707,7 @@ def test_claude_budget_outcome_is_deterministic_and_has_no_provider_fallback():
         ("success", "success", "true", "0", "2", "true", "5", "quality_filtered", []),
         ("failure", "failure", "false", "", "", "false", "5", "provider_failure", ["RVW-aaaaaaaaaaaa"]),
         ("success", "success", "true", "1", "0", "false", "5", "checkpoint_failure", ["RVW-aaaaaaaaaaaa"]),
-        ("success", "success", "true", "1", "0", "true", "601", "wall_time_exhausted", ["RVW-aaaaaaaaaaaa"]),
+        ("success", "success", "true", "1", "0", "true", "1081", "wall_time_exhausted", ["RVW-aaaaaaaaaaaa"]),
     ),
 )
 def test_claude_budget_outcome_mapping_and_remaining_ids_are_reproducible(

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -1942,7 +1942,7 @@ def test_v147_rejects_budget_workflow_safety_gate_mutations(
             )
             provider["if"] = "${{ steps.prepare-diff.outputs.diff-ready == 'true' }}"
         elif mutation == "raise-timeout":
-            target_job["timeout-minutes"] = "11"
+            target_job["timeout-minutes"] = "21"
         elif mutation == "omit-finalize":
             steps.remove(
                 next(item for item in steps if item.get("name") == "Finalize Gemini review budget")


### PR DESCRIPTION
## Summary
- raise only the Claude review job timeout from 10 to 20 minutes
- allow Claude provider execution up to 1080 seconds, leaving 2 minutes for canonicalization and publication
- keep Gemini and OpenCode at 10 minutes / 600 seconds
- update authenticated release contracts and per-reviewer boundary tests

## Evidence
- redmine PR #26 Claude provider step: 12m45s; job: 13m00s; workflow: 13m12s
- full local suite: 2731 passed, 48 subtests passed
- actionlint with the CI flags: passed
- independent Critical/Important review: no findings

## Scope
This does not implement force-review from issue #58.