### PR TITLE
feat(review): add bounded force-review path

### DIFF
--- a/.github/actions/prepare-review-diff/action.yml
+++ b/.github/actions/prepare-review-diff/action.yml
@@ -11,6 +11,9 @@ inputs:
   previous-full-hash:
     required: false
     default: ''
+  force-full:
+    required: false
+    default: 'false'
   context-lines:
     required: false
     default: '3'
@@ -37,16 +40,26 @@ runs:
         PR_NUMBER: ${{ inputs.pr-number }}
         PREVIOUS_SHA: ${{ inputs.previous-sha }}
         PREVIOUS_FULL_HASH: ${{ inputs.previous-full-hash }}
+        FORCE_FULL: ${{ inputs.force-full }}
         CONTEXT_LINES: ${{ inputs.context-lines }}
         OUTPUT_DIRECTORY: ${{ inputs.output-directory }}
-      run: >-
-        python3 "$GITHUB_ACTION_PATH/prepare_review_diff.py"
-        --repository "$GITHUB_REPOSITORY"
-        --pr-number "$PR_NUMBER"
-        --previous-sha "$PREVIOUS_SHA"
-        --previous-full-hash "$PREVIOUS_FULL_HASH"
-        --context-lines "$CONTEXT_LINES"
-        --full-output "$OUTPUT_DIRECTORY/review-full.diff"
-        --delta-output "$OUTPUT_DIRECTORY/review-delta.diff"
-        --manifest-output "$OUTPUT_DIRECTORY/review-scope.json"
-        --github-output "$GITHUB_OUTPUT"
+      run: |
+        set -euo pipefail
+        force_args=()
+        if [[ "$FORCE_FULL" == 'true' ]]; then
+          force_args+=(--force-full)
+        elif [[ "$FORCE_FULL" != 'false' ]]; then
+          echo 'force-full must be true or false' >&2
+          exit 2
+        fi
+        python3 "$GITHUB_ACTION_PATH/prepare_review_diff.py" \
+          --repository "$GITHUB_REPOSITORY" \
+          --pr-number "$PR_NUMBER" \
+          --previous-sha "$PREVIOUS_SHA" \
+          --previous-full-hash "$PREVIOUS_FULL_HASH" \
+          --context-lines "$CONTEXT_LINES" \
+          --full-output "$OUTPUT_DIRECTORY/review-full.diff" \
+          --delta-output "$OUTPUT_DIRECTORY/review-delta.diff" \
+          --manifest-output "$OUTPUT_DIRECTORY/review-scope.json" \
+          --github-output "$GITHUB_OUTPUT" \
+          "${force_args[@]}"

--- a/.github/actions/prepare-review-diff/prepare_review_diff.py
+++ b/.github/actions/prepare-review-diff/prepare_review_diff.py
@@ -59,6 +59,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--pr-number", required=True, type=int)
     parser.add_argument("--previous-sha", required=True)
     parser.add_argument("--previous-full-hash", required=True)
+    parser.add_argument("--force-full", action="store_true")
     parser.add_argument("--context-lines", required=True, type=int)
     parser.add_argument("--full-output", required=True)
     parser.add_argument("--delta-output", required=True)
@@ -358,9 +359,13 @@ def prepare(args: argparse.Namespace, cwd: Path) -> PreparedReviewDiff:
         full_hash = hashlib.sha256(full_diff).hexdigest()
         mode: Literal["full", "delta", "unchanged"] = "full"
         delta_diff: bytes | None = None
-        if args.previous_full_hash and full_hash.lower() == args.previous_full_hash.lower():
+        if (
+            not args.force_full
+            and args.previous_full_hash
+            and full_hash.lower() == args.previous_full_hash.lower()
+        ):
             mode = "unchanged"
-        elif args.previous_sha:
+        elif not args.force_full and args.previous_sha:
             try:
                 ensure_commit(args.previous_sha, cwd)
                 ancestor = run(

--- a/.github/actions/review-invocation-budget/action.yml
+++ b/.github/actions/review-invocation-budget/action.yml
@@ -15,6 +15,9 @@ inputs:
     required: true
   diff-mode:
     required: true
+  force-review:
+    required: false
+    default: 'false'
   input-files-json:
     required: true
   authenticated-review-json:
@@ -66,6 +69,7 @@ runs:
         EXPECTED_HEAD_SHA: ${{ inputs.expected-head-sha }}
         FULL_DIFF_SHA256: ${{ inputs.full-diff-sha256 }}
         DIFF_MODE: ${{ inputs.diff-mode }}
+        FORCE_REVIEW: ${{ inputs.force-review }}
         INPUT_FILES_JSON: ${{ inputs.input-files-json }}
         AUTHENTICATED_REVIEW_JSON: ${{ inputs.authenticated-review-json }}
         MODEL_ROUTE_JSON: ${{ inputs.model-route-json }}
@@ -128,6 +132,7 @@ runs:
           "$BUDGET_MODE" "$GITHUB_REPOSITORY" "$PR_NUMBER" "$REVIEWER" \
           "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" "$EXPECTED_HEAD_SHA" \
           "$FULL_DIFF_SHA256" "$DIFF_MODE" "$INPUT_FILES_JSON" \
+          "$FORCE_REVIEW" \
           "$AUTHENTICATED_REVIEW_JSON" "$MODEL_ROUTE_JSON" "$EFFORT" \
           "$ACTUAL_CALL_COUNT" "$ELAPSED_SECONDS" "$REVIEW_OUTCOME" \
           "$STOP_REASON" "$REMAINING_FINDING_IDS_JSON" "$CHECKPOINT_FILE" \
@@ -139,6 +144,7 @@ runs:
         names = (
             "operation", "repository", "pr", "reviewer", "run_id", "run_attempt",
             "head_sha", "full_diff_sha256", "diff_mode", "input_files_json",
+            "force_review",
             "authenticated_review_json", "model_route_json", "effort", "actual_call_count",
             "elapsed_seconds", "outcome", "stop_reason", "remaining_finding_ids_json",
             "checkpoint_file", "github_workspace", "server_url",

--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -467,6 +467,7 @@ class ClaimRequest:
     model_route: tuple[str, ...]
     effort: str
     call_unit: str
+    force_review: bool = False
 
 
 @dataclass(frozen=True)
@@ -532,20 +533,37 @@ def _validate_state_shape(state: LedgerState) -> None:
     run_keys = {(item.run_id, item.run_attempt) for item in state.invocations}
     if len(run_keys) != len(state.invocations):
         raise BudgetStateError("duplicate_run_identity")
-    if len({item.head_sha for item in state.invocations}) != len(state.invocations):
-        raise BudgetStateError("duplicate_head")
-    if len({item.full_diff_sha256 for item in state.invocations}) != len(state.invocations):
-        raise BudgetStateError("duplicate_effective_diff")
     automatic = [item for item in state.invocations if item.override_event_id is None]
     overrides = [item for item in state.invocations if item.override_event_id is not None]
+    forced_override = next(
+        (item for item in overrides if item.caller_event == "workflow_dispatch"), None
+    )
+    for attribute, reason in (
+        ("head_sha", "duplicate_head"),
+        ("full_diff_sha256", "duplicate_effective_diff"),
+    ):
+        values = [getattr(item, attribute) for item in state.invocations]
+        duplicates = {value for value in values if values.count(value) > 1}
+        if duplicates and (
+            forced_override is None
+            or any(values.count(value) != 2 for value in duplicates)
+            or any(getattr(forced_override, attribute) != value for value in duplicates)
+            or all(getattr(item, attribute) not in duplicates for item in automatic)
+        ):
+            raise BudgetStateError(reason)
     if len(automatic) > state.budgets.max_rounds or len(overrides) > state.budgets.max_override_rounds:
         raise BudgetStateError("rounds_invalid")
     if [item.round_number for item in automatic] != list(range(1, len(automatic) + 1)):
         raise BudgetStateError("rounds_invalid")
     if overrides:
         item = overrides[0]
-        if (len(automatic) != state.budgets.max_rounds or state.invocations[-1] != item or
-                item.round_number != state.budgets.max_rounds + 1 or
+        expected_automatic_rounds = (
+            range(0, state.budgets.max_rounds + 1)
+            if item.caller_event == "workflow_dispatch"
+            else (state.budgets.max_rounds,)
+        )
+        if (len(automatic) not in expected_automatic_rounds or state.invocations[-1] != item or
+                item.round_number != len(automatic) + 1 or
                 item.override_event_id not in state.consumed_override_event_ids):
             raise BudgetStateError("override_invalid")
     if len(state.consumed_override_event_ids) != len(overrides):
@@ -643,6 +661,10 @@ def _validate_request(request: ClaimRequest) -> None:
     _hash(request.full_diff_sha256, _HASH, "full_diff_sha256")
     if request.diff_mode not in {"changed", "unchanged"}:
         raise BudgetStateError("diff_mode_invalid")
+    if not isinstance(request.force_review, bool):
+        raise BudgetStateError("force_review_invalid")
+    if request.force_review and request.diff_mode != "changed":
+        raise BudgetStateError("force_review_diff_invalid")
     if not isinstance(request.authenticated_review, AuthenticatedReview):
         raise BudgetStateError("authenticated_review_invalid")
     review = request.authenticated_review
@@ -678,7 +700,7 @@ def _expected_referenced_workflow_path(reviewer: Reviewer, sha: str) -> str:
 def _validate_provenance_identity(
         provenance: RunProvenance, reviewer: Reviewer) -> None:
     if (
-        provenance.caller_event != "pull_request" or
+        provenance.caller_event not in {"pull_request", "workflow_dispatch"} or
         not isinstance(provenance.caller_workflow_path, str) or
         _CALLER_WORKFLOW.fullmatch(provenance.caller_workflow_path) is None or
         ".." in Path(provenance.caller_workflow_path).parts or
@@ -724,10 +746,20 @@ def _validate_one_provenance(
     expected_run_attempt = (
         request.run_attempt if invocation is None else invocation.run_attempt
     )
+    expected_event = (
+        invocation.caller_event
+        if invocation is not None
+        else (
+            "workflow_dispatch"
+            if isinstance(request, ClaimRequest) and request.force_review
+            else "pull_request"
+        )
+    )
     if (
         provenance.repository != state.repository or
         provenance.pr != state.pr or
         provenance.head_sha != expected_head or
+        provenance.caller_event != expected_event or
         provenance.run_id != expected_run_id or
         provenance.run_attempt != expected_run_attempt or
         (not current and provenance.status != "completed") or
@@ -912,14 +944,25 @@ def claim(state: LedgerState | None, request: ClaimRequest,
         if not request.authenticated_review.covers_hash(request.full_diff_sha256):
             return _invalid_transition(validated, request, "unchanged_without_authenticated_review")
         return refuse(validated, request, "authenticated_reuse")
-    if any(item.head_sha == request.head_sha for item in validated.invocations):
+    if not request.force_review and any(
+        item.head_sha == request.head_sha for item in validated.invocations
+    ):
         return refuse(validated, request, "duplicate_head")
-    if any(item.full_diff_sha256 == request.full_diff_sha256 for item in validated.invocations):
+    if not request.force_review and any(
+        item.full_diff_sha256 == request.full_diff_sha256
+        for item in validated.invocations
+    ):
         return refuse(validated, request, "duplicate_effective_diff")
     if request.estimated_input_tokens > validated.budgets.max_estimated_tokens_per_round:
         return refuse(validated, request, "input_budget_exhausted")
     override = None
-    if automatic_rounds(validated) >= validated.budgets.max_rounds:
+    if any(item.override_event_id is not None for item in validated.invocations):
+        return refuse(validated, request, "round_budget_exhausted")
+    if request.force_review:
+        override = choose_override(validated, request.override_events)
+        if override is None:
+            return refuse(validated, request, "round_budget_exhausted")
+    elif automatic_rounds(validated) >= validated.budgets.max_rounds:
         override = choose_override(validated, request.override_events)
         if override is None:
             return refuse(validated, request, "round_budget_exhausted")
@@ -1207,6 +1250,7 @@ def _transport_request(path: Path) -> dict[str, object]:
         "authenticated_review_json", "model_route_json", "effort", "actual_call_count",
         "elapsed_seconds", "outcome", "stop_reason", "remaining_finding_ids_json",
         "checkpoint_file", "github_workspace", "server_url",
+        "force_review",
     }
     value = dict(_exact_keys(value, keys, "request"))
     repository = _string(value["repository"], "repository")
@@ -1240,6 +1284,10 @@ def _transport_request(path: Path) -> dict[str, object]:
     value["diff_mode"] = diff_mode
     value["head_sha"] = head_sha
     value["full_diff_sha256"] = full_diff_sha256
+    force_review = _string(value["force_review"], "force_review")
+    if force_review not in {"true", "false"}:
+        raise TransportError("force_review_invalid")
+    value["force_review"] = force_review == "true"
     for name in (
         "input_files_json", "authenticated_review_json", "model_route_json", "effort",
         "outcome", "stop_reason", "remaining_finding_ids_json", "checkpoint_file",
@@ -1299,6 +1347,7 @@ def _base_claim_request(
         authenticated_review=_authenticated_review(request), override_events=override_events,
         model_route=_model_route(request), effort=request["effort"],
         call_unit=_CALL_UNITS[request["reviewer"]],
+        force_review=request["force_review"],
     )
 
 
@@ -1520,6 +1569,9 @@ def _run_provenances(
         state: LedgerState | None, request: Mapping[str, object], output_directory: Path,
     ) -> dict[tuple[int, int], RunProvenance]:
     result: dict[tuple[int, int], RunProvenance] = {}
+    stored_by_identity = {} if state is None else {
+        (item.run_id, item.run_attempt): item for item in state.invocations
+    }
     identities = {(request["run_id"], request["run_attempt"])}
     if state is not None:
         identities.update(
@@ -1553,9 +1605,22 @@ def _run_provenances(
             raise TransportError("provenance_mismatch")
         central = central[0]
         central_ref = central.get("ref") if "ref" in central else central.get("sha")
+        stored = stored_by_identity.get((run_id, run_attempt))
+        is_force_dispatch = (
+            stored is not None and stored.caller_event == "workflow_dispatch"
+        ) or (
+            stored is None
+            and request["operation"] == "claim"
+            and request["force_review"]
+            and (run_id, run_attempt) == (request["run_id"], request["run_attempt"])
+        )
+        reviewed_head = stored.head_sha if stored is not None else request["head_sha"]
         provenance = RunProvenance(
             repository=repository.get("full_name"), pr=request["pr"],
-            head_sha=value.get("head_sha"),
+            # workflow_dispatch runs are rooted at the caller's default branch, not
+            # the reviewed PR. The independently fetched PR payload binds the target
+            # head; the Actions payload still binds run/attempt/caller/reusable ref.
+            head_sha=reviewed_head if is_force_dispatch else value.get("head_sha"),
             caller_workflow_path=value.get("path"),
             caller_event=value.get("event"),
             referenced_workflow_path=central.get("path"),
@@ -1564,7 +1629,10 @@ def _run_provenances(
             run_id=value.get("id"), run_attempt=value.get("run_attempt"),
             status=value.get("status"), conclusion=value.get("conclusion"),
         )
-        if request["pr"] not in pull_numbers:
+        if is_force_dispatch:
+            if value.get("event") != "workflow_dispatch":
+                raise TransportError("provenance_mismatch")
+        elif request["pr"] not in pull_numbers:
             raise TransportError("provenance_mismatch")
         _validate_provenance_identity(provenance, request["reviewer"])
         result[(run_id, run_attempt)] = provenance

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,11 @@ on:
         type: boolean
         required: false
         default: false
+      force_review:
+        description: 'Perform one explicitly authorized review even when HEAD is unchanged'
+        type: boolean
+        required: false
+        default: false
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -43,12 +48,12 @@ jobs:
         uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
         with:
           workflow-name: claude-code-review
-          force-run: ${{ inputs.force_run && 'true' || 'false' }}
+          force-run: ${{ (inputs.force_run || inputs.force_review) && 'true' || 'false' }}
 
       - name: Check auto review mode
         id: auto_mode
         env:
-          FORCE_RUN: ${{ inputs.force_run && 'true' || 'false' }}
+          FORCE_RUN: ${{ (inputs.force_run || inputs.force_review) && 'true' || 'false' }}
         run: |-
           CONFIG_FILE=".github/workflow-config.yml"
           if [[ "$FORCE_RUN" == 'true' ]]; then
@@ -172,6 +177,8 @@ jobs:
                 type == "string" and (. == "success" or . == "failure");
               def diff_mode:
                 type == "string" and (. == "full" or . == "delta" or . == "unchanged" or . == "unavailable");
+              def review_execution:
+                . == null or . == "performed" or . == "reused" or . == "not_performed";
               def successful_pair:
                 if .successful_head == null then .full_diff_sha256 == null
                 else (.successful_head | sha1) and (.full_diff_sha256 | sha256)
@@ -180,12 +187,19 @@ jobs:
                 if .attempt_status == "success" then
                   .successful_head != null and .successful_head == .attempt_head and successful_pair
                   and (.diff_mode == "full" or .diff_mode == "delta" or .diff_mode == "unchanged")
+                  and (if .diff_mode == "unchanged" then
+                    (.review_execution == null or .review_execution == "reused")
+                  else
+                    (.review_execution == null or .review_execution == "performed")
+                  end)
                   and (.accepted_count | nonnegative_integer)
                   and (.filtered_count | nonnegative_integer)
                   and (.normalized_count | nonnegative_integer)
                   and (.filtered_max_severity | max_severity)
                 elif .attempt_status == "failure" then
                   successful_pair
+                  and (.review_execution == null or .review_execution == "performed"
+                    or .review_execution == "not_performed")
                   and (if .successful_head == null then
                     .accepted_count == null and .filtered_count == null
                     and .normalized_count == null and .filtered_max_severity == null
@@ -203,7 +217,8 @@ jobs:
                 | select($lines[0] == $header and $lines[1] == $marker)
                 | (($lines[2]? // "") | (capture("^<!-- automation-state:(?<json>\\{.*\\}) -->$")? | .json? | fromjson?)) as $s
                 | select(($s | type) == "object")
-                | select(($s | keys | sort) == ["accepted_count", "attempt_head", "attempt_status", "diff_mode", "filtered_count", "filtered_max_severity", "full_diff_sha256", "normalized_count", "pr", "quality_schema", "reviewer", "run_attempt", "run_id", "schema", "successful_head"])
+                | select((($s | keys | sort) == ["accepted_count", "attempt_head", "attempt_status", "diff_mode", "filtered_count", "filtered_max_severity", "full_diff_sha256", "normalized_count", "pr", "quality_schema", "reviewer", "run_attempt", "run_id", "schema", "successful_head"])
+                  or (($s | keys | sort) == ["accepted_count", "attempt_head", "attempt_status", "diff_mode", "filtered_count", "filtered_max_severity", "full_diff_sha256", "normalized_count", "pr", "quality_schema", "review_execution", "reviewer", "run_attempt", "run_id", "schema", "successful_head"]))
                 | select(($s.schema | type) == "number" and $s.schema == 3)
                 | select(($s.quality_schema | type) == "number" and $s.quality_schema == 1)
                 | select(($s.reviewer | type) == "string" and $s.reviewer == $reviewer)
@@ -212,12 +227,15 @@ jobs:
                 | select($s.run_attempt | positive_integer)
                 | select($s.attempt_head | sha1)
                 | select($s.attempt_status | attempt_status)
+                | select($s.review_execution | review_execution)
                 | select($s | state_semantics)
                 | select($s.diff_mode | diff_mode)
                 | ("- Run: " + $server + "/" + $repo + "/actions/runs/" + ($s.run_id | tostring)) as $run
                 | (if $s.attempt_status == "success" then "success"
                    elif $s.successful_head == null then "failure" else "stale" end) as $status
-                | (["- Status: " + $status, $run]
+                | (["- Status: " + $status]
+                  + (if $s.review_execution == null then [] else ["- Execution: " + $s.review_execution] end)
+                  + [$run]
                   + (if $s.successful_head == null then [] else ["- Reviewed: " + $s.successful_head] end)
                   + (if $s.accepted_count == null then [] else [
                       "- Validation: accepted=" + ($s.accepted_count | tostring)
@@ -280,9 +298,10 @@ jobs:
                 .id == $run_id and .run_attempt == $run_attempt
                 and .status == "completed"
                 and (.conclusion == "success" or .conclusion == "failure")
-                and .event == "pull_request" and .head_sha == $head
+                and ((.event == "pull_request" and .head_sha == $head
+                  and ([.pull_requests[]? | select(.number == $pr)] | length == 1))
+                  or .event == "workflow_dispatch")
                 and .repository.full_name == $repo
-                and ([.pull_requests[]? | select(.number == $pr)] | length == 1)
                 and ([.referenced_workflows[]? | select(
                   (.path | startswith($workflow_prefix))
                   and (.sha | test("^[0-9a-f]{40}$"))
@@ -300,7 +319,7 @@ jobs:
           # Every context-input lane uses this same sanitizer. It removes only reserved
           # workflow-owned lines, leaving normal reviewer findings and human rebuttals.
           strip_reserved() {
-            grep -vE '^(- Status: |- Run: |- Reviewed: |- Last attempt: |- Validation: |<!-- automation:|<!-- automation-state:|## Claude Code Review \(latest\))'
+            grep -vE '^(- Status: |- Execution: |- Run: |- Reviewed: |- Last attempt: |- Validation: |<!-- automation:|<!-- automation-state:|## Claude Code Review \(latest\))'
           }
           # 코멘트별 1,500자 선클립 후 join — 한 개의 초장문 코멘트가 나머지 최신 반박들을
           # 섹션 상한 밖으로 밀어내지 못하게 한다.
@@ -383,6 +402,7 @@ jobs:
           pr-number: ${{ inputs.pr_number || github.event.pull_request.number }}
           previous-sha: ${{ steps.prepare-review-input.outputs.previous_sha }}
           previous-full-hash: ${{ steps.prepare-review-input.outputs.previous_full_hash }}
+          force-full: ${{ inputs.force_review && 'true' || 'false' }}
           context-lines: '3'
           output-directory: ${{ runner.temp }}
 
@@ -447,6 +467,7 @@ jobs:
           expected-head-sha: ${{ steps.stage-claude-budget-input.outputs.expected_head_sha }}
           full-diff-sha256: ${{ steps.stage-claude-budget-input.outputs.full_diff_sha256 }}
           diff-mode: ${{ steps.prepare-diff.outputs.diff-mode || 'unavailable' }}
+          force-review: ${{ inputs.force_review && 'true' || 'false' }}
           input-files-json: ${{ steps.stage-claude-budget-input.outputs.input_files_json }}
           authenticated-review-json: ${{ steps.prepare-review-input.outputs.authenticated_review_json }}
           model-route-json: ${{ steps.claude-budget-config.outputs.model_route_json }}
@@ -497,6 +518,12 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
           overwrite: false
+
+      - name: Enforce force-review claim
+        if: ${{ always() && !cancelled() && inputs.force_review && steps.review-budget-claim.outputs.allow-invocation != 'true' }}
+        run: |
+          echo '::error::force-review was not authorized by the bounded review budget'
+          exit 1
 
       - name: Checkout prepared review head
         if: ${{ steps.prepare-diff.outputs.diff-ready == 'true' && steps.prepare-diff.outputs.diff-mode != 'unchanged' && steps.review-budget-claim.outputs.allow-invocation == 'true' }}
@@ -724,7 +751,9 @@ jobs:
             const serverUrl = process.env.SERVER_URL || '';
             const repository = process.env.REPOSITORY || '';
             const botLogin = process.env.BOT_LOGIN || '';
-            const ok = (process.env.REVIEW_OUTCOME || '').toLowerCase() === 'success';
+            const reviewOutcome = (process.env.REVIEW_OUTCOME || '').toLowerCase();
+            const ok = reviewOutcome === 'success';
+            const modelStepEntered = ['success', 'failure'].includes(reviewOutcome);
             const diffReady = process.env.DIFF_READY === 'true';
             const canonicalOutcome = (process.env.CANONICAL_OUTCOME || '').toLowerCase();
             const documentValid = process.env.DOCUMENT_VALID === 'true';
@@ -784,9 +813,11 @@ jobs:
               && Number.isSafeInteger(state.filtered_count) && state.filtered_count >= 0
               && Number.isSafeInteger(state.normalized_count) && state.normalized_count >= 0
               && maxSeverity(state.filtered_max_severity);
-            const expectedStateKeys = ['accepted_count', 'attempt_head', 'attempt_status', 'diff_mode', 'filtered_count', 'filtered_max_severity', 'full_diff_sha256', 'normalized_count', 'pr', 'quality_schema', 'reviewer', 'run_attempt', 'run_id', 'schema', 'successful_head'];
+            const legacyStateKeys = ['accepted_count', 'attempt_head', 'attempt_status', 'diff_mode', 'filtered_count', 'filtered_max_severity', 'full_diff_sha256', 'normalized_count', 'pr', 'quality_schema', 'reviewer', 'run_attempt', 'run_id', 'schema', 'successful_head'];
+            const expectedStateKeys = [...legacyStateKeys, 'review_execution'].sort();
             const validState = (state) => state && typeof state === 'object' && !Array.isArray(state)
-              && JSON.stringify(Object.keys(state).sort()) === JSON.stringify(expectedStateKeys)
+              && [legacyStateKeys, expectedStateKeys].some((keys) =>
+                JSON.stringify(Object.keys(state).sort()) === JSON.stringify(keys))
               && state.schema === 3 && state.quality_schema === 1
               && state.reviewer === 'claude' && state.pr === issueNumber
               && Number.isSafeInteger(state.run_id) && state.run_id > 0
@@ -796,6 +827,10 @@ jobs:
                 ? state.successful_head === state.attempt_head && state.successful_head !== null
                   && sha1(state.successful_head) && sha256(state.full_diff_sha256)
                   && ['full', 'delta', 'unchanged'].includes(state.diff_mode)
+                  && (state.review_execution === undefined
+                    || (state.diff_mode === 'unchanged'
+                      ? state.review_execution === 'reused'
+                      : state.review_execution === 'performed'))
                   && validQuality(state)
                 : state.attempt_status === 'failure' && (state.successful_head === null
                 ? state.full_diff_sha256 === null && state.accepted_count === null
@@ -803,13 +838,19 @@ jobs:
                   && state.filtered_max_severity === null
                 : sha1(state.successful_head) && sha256(state.full_diff_sha256)
                   && validQuality(state)))
-              && ['full', 'delta', 'unchanged', 'unavailable'].includes(state.diff_mode);
+              && ['full', 'delta', 'unchanged', 'unavailable'].includes(state.diff_mode)
+              && (state.review_execution === undefined
+                || ['performed', 'reused', 'not_performed'].includes(state.review_execution))
+              && (state.attempt_status !== 'failure'
+                || state.review_execution === undefined
+                || ['performed', 'not_performed'].includes(state.review_execution));
             const metadata = (state) => {
               const trustedRun = `${serverUrl}/${repository}/actions/runs/${state.run_id}`;
               const status = state.attempt_status === 'success' ? 'success'
                 : (state.successful_head === null ? 'failure' : 'stale');
               return [
                 `- Status: ${status}`,
+                state.review_execution === undefined ? null : `- Execution: ${state.review_execution}`,
                 `- Run: ${trustedRun}`,
                 state.successful_head === null ? null : `- Reviewed: ${state.successful_head}`,
                 state.accepted_count === null ? null
@@ -843,11 +884,12 @@ jobs:
               && run?.run_attempt === record.state.run_attempt
               && run?.status === 'completed'
               && ['success', 'failure'].includes(run?.conclusion)
-              && run?.event === 'pull_request' && run?.head_sha === record.state.attempt_head
+              && ((run?.event === 'pull_request' && run?.head_sha === record.state.attempt_head
+                && (run?.pull_requests || []).filter((pr) =>
+                  pr?.number === issueNumber
+                ).length === 1)
+                || run?.event === 'workflow_dispatch')
               && run?.repository?.full_name === repository
-              && (run?.pull_requests || []).filter((pr) =>
-                pr?.number === issueNumber
-              ).length === 1
               && (run?.referenced_workflows || []).filter((item) =>
                 (item?.path || '').startsWith(workflowPrefix) && sha1(item?.sha)
               ).length === 1;
@@ -938,6 +980,9 @@ jobs:
               successful_head: failed ? (preserveSuccess ? existing.state.successful_head : null) : attemptHead,
               attempt_status: failed ? 'failure' : 'success',
               diff_mode: stateDiffMode,
+              review_execution: unchangedInputIsValid
+                ? 'reused'
+                : (modelStepEntered ? 'performed' : 'not_performed'),
               full_diff_sha256: failed
                 ? (preserveSuccess ? existing.state.full_diff_sha256 : null)
                 : fullDiffSha256,

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -26,6 +26,11 @@ on:
         type: boolean
         required: false
         default: false
+      force_review:
+        description: 'Perform one explicitly authorized review even when HEAD is unchanged'
+        type: boolean
+        required: false
+        default: false
 
     secrets:
       APP_PRIVATE_KEY:
@@ -55,12 +60,12 @@ jobs:
         uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
         with:
           workflow-name: gemini-auto-review
-          force-run: ${{ inputs.force_run && 'true' || 'false' }}
+          force-run: ${{ (inputs.force_run || inputs.force_review) && 'true' || 'false' }}
 
       - name: Check auto review mode
         id: auto_mode
         env:
-          FORCE_RUN: ${{ inputs.force_run && 'true' || 'false' }}
+          FORCE_RUN: ${{ (inputs.force_run || inputs.force_review) && 'true' || 'false' }}
         run: |-
           CONFIG_FILE=".github/workflow-config.yml"
           if [[ "$FORCE_RUN" == 'true' ]]; then
@@ -221,6 +226,8 @@ jobs:
                 type == "string" and (. == "success" or . == "failure");
               def diff_mode:
                 type == "string" and (. == "full" or . == "delta" or . == "unchanged" or . == "unavailable");
+              def review_execution:
+                . == null or . == "performed" or . == "reused" or . == "not_performed";
               def successful_pair:
                 if .successful_head == null then .full_diff_sha256 == null
                 else (.successful_head | sha1) and (.full_diff_sha256 | sha256)
@@ -229,12 +236,19 @@ jobs:
                 if .attempt_status == "success" then
                   .successful_head != null and .successful_head == .attempt_head and successful_pair
                   and (.diff_mode == "full" or .diff_mode == "delta" or .diff_mode == "unchanged")
+                  and (if .diff_mode == "unchanged" then
+                    (.review_execution == null or .review_execution == "reused")
+                  else
+                    (.review_execution == null or .review_execution == "performed")
+                  end)
                   and (.accepted_count | nonnegative_integer)
                   and (.filtered_count | nonnegative_integer)
                   and (.normalized_count | nonnegative_integer)
                   and (.filtered_max_severity | max_severity)
                 elif .attempt_status == "failure" then
                   successful_pair
+                  and (.review_execution == null or .review_execution == "performed"
+                    or .review_execution == "not_performed")
                   and (if .successful_head == null then
                     .accepted_count == null and .filtered_count == null
                     and .normalized_count == null and .filtered_max_severity == null
@@ -269,7 +283,8 @@ jobs:
                 | select($lines[0] == $header and $lines[1] == $marker)
                 | (($lines[2]? // "") | (capture("^<!-- automation-state:(?<json>\\{.*\\}) -->$")? | .json? | fromjson?)) as $s
                 | select(($s | type) == "object")
-                | select(($s | keys | sort) == ["accepted_count", "attempt_head", "attempt_status", "diff_mode", "filtered_count", "filtered_max_severity", "full_diff_sha256", "normalized_count", "pr", "quality_schema", "reviewer", "run_attempt", "run_id", "schema", "successful_head"])
+                | select((($s | keys | sort) == ["accepted_count", "attempt_head", "attempt_status", "diff_mode", "filtered_count", "filtered_max_severity", "full_diff_sha256", "normalized_count", "pr", "quality_schema", "reviewer", "run_attempt", "run_id", "schema", "successful_head"])
+                  or (($s | keys | sort) == ["accepted_count", "attempt_head", "attempt_status", "diff_mode", "filtered_count", "filtered_max_severity", "full_diff_sha256", "normalized_count", "pr", "quality_schema", "review_execution", "reviewer", "run_attempt", "run_id", "schema", "successful_head"]))
                 | select(($s.schema | type) == "number" and $s.schema == 3)
                 | select(($s.quality_schema | type) == "number" and $s.quality_schema == 1)
                 | select(($s.reviewer | type) == "string" and $s.reviewer == $reviewer)
@@ -278,12 +293,15 @@ jobs:
                 | select($s.run_attempt | positive_integer)
                 | select($s.attempt_head | sha1)
                 | select($s.attempt_status | attempt_status)
+                | select($s.review_execution | review_execution)
                 | select($s | state_semantics)
                 | select($s.diff_mode | diff_mode)
                 | ("- Run: " + $server + "/" + $repo + "/actions/runs/" + ($s.run_id | tostring)) as $run
                 | (if $s.attempt_status == "success" then "success"
                    elif $s.successful_head == null then "failure" else "stale" end) as $status
-                | (["- Status: " + $status, $run]
+                | (["- Status: " + $status]
+                  + (if $s.review_execution == null then [] else ["- Execution: " + $s.review_execution] end)
+                  + [$run]
                   + (if $s.successful_head == null then [] else ["- Reviewed: " + $s.successful_head] end)
                   + (if $s.accepted_count == null then [] else [
                       "- Validation: accepted=" + ($s.accepted_count | tostring)
@@ -346,9 +364,10 @@ jobs:
                 .id == $run_id and .run_attempt == $run_attempt
                 and .status == "completed"
                 and (.conclusion == "success" or .conclusion == "failure")
-                and .event == "pull_request" and .head_sha == $head
+                and ((.event == "pull_request" and .head_sha == $head
+                  and ([.pull_requests[]? | select(.number == $pr)] | length == 1))
+                  or .event == "workflow_dispatch")
                 and .repository.full_name == $repo
-                and ([.pull_requests[]? | select(.number == $pr)] | length == 1)
                 and ([.referenced_workflows[]? | select(
                   (.path | startswith($workflow_prefix))
                   and (.sha | test("^[0-9a-f]{40}$"))
@@ -364,7 +383,7 @@ jobs:
           PREV_FULL_HASH="$(printf '%s\n' "$PREV_STATE" | jq -r '(.full_diff_sha256 // "") | if test("^[0-9a-f]{64}$") then . else "" end')"
           PREV_BODY_B64="$(printf '%s\n' "$PREV_RECORD" | jq -r '(.canonical_body // "") | @base64')"
           strip_reserved() {
-            grep -vE '^(- Status: |- Run: |- Reviewed: |- Last attempt: |- Validation: |<!-- automation:|<!-- automation-state:|## 🔎 Gemini Code Review$|REPO: |PR NUMBER: |Reviewer: Gemini|\*Reviewed by Gemini\*)'
+            grep -vE '^(- Status: |- Execution: |- Run: |- Reviewed: |- Last attempt: |- Validation: |<!-- automation:|<!-- automation-state:|## 🔎 Gemini Code Review$|REPO: |PR NUMBER: |Reviewer: Gemini|\*Reviewed by Gemini\*)'
           }
           # A first failure or historical v2 display has no authenticated successful pair.
           # Decode the canonical body directly so the shared action receives exact UTF-8 bytes.
@@ -427,6 +446,7 @@ jobs:
           pr-number: ${{ inputs.pr_number || github.event.pull_request.number }}
           previous-sha: ${{ steps.pr-details.outputs.previous_sha }}
           previous-full-hash: ${{ steps.pr-details.outputs.previous_full_hash }}
+          force-full: ${{ inputs.force_review && 'true' || 'false' }}
           context-lines: '20'
           output-directory: ${{ runner.temp }}
 
@@ -497,6 +517,7 @@ jobs:
           expected-head-sha: ${{ steps.stage-gemini-budget-input.outputs.expected_head_sha }}
           full-diff-sha256: ${{ steps.stage-gemini-budget-input.outputs.full_diff_sha256 }}
           diff-mode: ${{ steps.prepare-diff.outputs.diff-mode || 'unavailable' }}
+          force-review: ${{ inputs.force_review && 'true' || 'false' }}
           input-files-json: ${{ steps.stage-gemini-budget-input.outputs.input_files_json }}
           authenticated-review-json: ${{ steps.pr-details.outputs.authenticated_review_json }}
           model-route-json: ${{ steps.gemini-budget-config.outputs.model_route_json }}
@@ -547,6 +568,12 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
           overwrite: false
+
+      - name: Enforce force-review claim
+        if: ${{ always() && !cancelled() && inputs.force_review && steps.review-budget-claim.outputs.allow-invocation != 'true' }}
+        run: |
+          echo '::error::force-review was not authorized by the bounded review budget'
+          exit 1
 
       - name: Checkout prepared review head
         if: ${{ steps.prepare-diff.outputs.diff-ready == 'true' && steps.prepare-diff.outputs.diff-mode != 'unchanged' && steps.review-budget-claim.outputs.allow-invocation == 'true' }}
@@ -1416,7 +1443,9 @@ jobs:
                 || (authMode === 'github_app' && appPublisherMatches(comment, '15368'))
                 || (authMode === 'github_token' && publisherAppIdIsValid
                   && publisherAppId !== '' && appPublisherMatches(comment, publisherAppId)));
-            const ok = (process.env.REVIEW_OUTCOME || '').toLowerCase() === 'success';
+            const reviewOutcome = (process.env.REVIEW_OUTCOME || '').toLowerCase();
+            const ok = reviewOutcome === 'success';
+            const modelStepEntered = ['success', 'failure'].includes(reviewOutcome);
             const diffReady = process.env.DIFF_READY === 'true';
             const diffTruncated = process.env.DIFF_TRUNCATED === 'true';
             const canonicalOutcome = (process.env.CANONICAL_OUTCOME || '').toLowerCase();
@@ -1488,9 +1517,11 @@ jobs:
               && Number.isSafeInteger(state.filtered_count) && state.filtered_count >= 0
               && Number.isSafeInteger(state.normalized_count) && state.normalized_count >= 0
               && maxSeverity(state.filtered_max_severity);
-            const expectedStateKeys = ['accepted_count', 'attempt_head', 'attempt_status', 'diff_mode', 'filtered_count', 'filtered_max_severity', 'full_diff_sha256', 'normalized_count', 'pr', 'quality_schema', 'reviewer', 'run_attempt', 'run_id', 'schema', 'successful_head'];
+            const legacyStateKeys = ['accepted_count', 'attempt_head', 'attempt_status', 'diff_mode', 'filtered_count', 'filtered_max_severity', 'full_diff_sha256', 'normalized_count', 'pr', 'quality_schema', 'reviewer', 'run_attempt', 'run_id', 'schema', 'successful_head'];
+            const expectedStateKeys = [...legacyStateKeys, 'review_execution'].sort();
             const validState = (state) => state && typeof state === 'object' && !Array.isArray(state)
-              && JSON.stringify(Object.keys(state).sort()) === JSON.stringify(expectedStateKeys)
+              && [legacyStateKeys, expectedStateKeys].some((keys) =>
+                JSON.stringify(Object.keys(state).sort()) === JSON.stringify(keys))
               && state.schema === 3 && state.quality_schema === 1
               && state.reviewer === 'gemini' && state.pr === issueNumber
               && Number.isSafeInteger(state.run_id) && state.run_id > 0
@@ -1500,6 +1531,10 @@ jobs:
                 ? state.successful_head === state.attempt_head && state.successful_head !== null
                   && sha1(state.successful_head) && sha256(state.full_diff_sha256)
                   && ['full', 'delta', 'unchanged'].includes(state.diff_mode)
+                  && (state.review_execution === undefined
+                    || (state.diff_mode === 'unchanged'
+                      ? state.review_execution === 'reused'
+                      : state.review_execution === 'performed'))
                   && validQuality(state)
                 : state.attempt_status === 'failure' && (state.successful_head === null
                 ? state.full_diff_sha256 === null && state.accepted_count === null
@@ -1507,13 +1542,19 @@ jobs:
                   && state.filtered_max_severity === null
                 : sha1(state.successful_head) && sha256(state.full_diff_sha256)
                   && validQuality(state)))
-              && ['full', 'delta', 'unchanged', 'unavailable'].includes(state.diff_mode);
+              && ['full', 'delta', 'unchanged', 'unavailable'].includes(state.diff_mode)
+              && (state.review_execution === undefined
+                || ['performed', 'reused', 'not_performed'].includes(state.review_execution))
+              && (state.attempt_status !== 'failure'
+                || state.review_execution === undefined
+                || ['performed', 'not_performed'].includes(state.review_execution));
             const metadata = (state) => {
               const trustedRun = `${serverUrl}/${repository}/actions/runs/${state.run_id}`;
               const status = state.attempt_status === 'success' ? 'success'
                 : (state.successful_head === null ? 'failure' : 'stale');
               return [
                 `- Status: ${status}`,
+                state.review_execution === undefined ? null : `- Execution: ${state.review_execution}`,
                 `- Run: ${trustedRun}`,
                 state.successful_head === null ? null : `- Reviewed: ${state.successful_head}`,
                 state.accepted_count === null ? null
@@ -1571,11 +1612,12 @@ jobs:
               && run?.run_attempt === record.state.run_attempt
               && run?.status === 'completed'
               && ['success', 'failure'].includes(run?.conclusion)
-              && run?.event === 'pull_request' && run?.head_sha === record.state.attempt_head
+              && ((run?.event === 'pull_request' && run?.head_sha === record.state.attempt_head
+                && (run?.pull_requests || []).filter((pr) =>
+                  pr?.number === issueNumber
+                ).length === 1)
+                || run?.event === 'workflow_dispatch')
               && run?.repository?.full_name === repository
-              && (run?.pull_requests || []).filter((pr) =>
-                pr?.number === issueNumber
-              ).length === 1
               && (run?.referenced_workflows || []).filter((item) =>
                 (item?.path || '').startsWith(workflowPrefix) && sha1(item?.sha)
               ).length === 1;
@@ -1665,6 +1707,9 @@ jobs:
               successful_head: failed ? (preserveSuccess ? existing.state.successful_head : null) : attemptHead,
               attempt_status: failed ? 'failure' : 'success',
               diff_mode: stateDiffMode,
+              review_execution: unchangedInputIsValid
+                ? 'reused'
+                : (modelStepEntered ? 'performed' : 'not_performed'),
               full_diff_sha256: failed
                 ? (preserveSuccess ? existing.state.full_diff_sha256 : null)
                 : fullDiffSha256,

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -90,6 +90,7 @@ jobs:
       request: '${{ steps.extract_command.outputs.request }}'
       additional_context: '${{ steps.extract_command.outputs.additional_context }}'
       target_commit: '${{ steps.extract_command.outputs.target_commit }}'
+      reviewed_sha: '${{ steps.resolve_review_target.outputs.reviewed_sha }}'
       scope: '${{ steps.extract_command.outputs.scope }}'
       target_url: '${{ steps.extract_command.outputs.target_url }}'
       patch: '${{ steps.extract_command.outputs.patch }}'
@@ -215,7 +216,7 @@ jobs:
             core.setOutput('command', command);
 
             // Command parsing (commit=<sha>, scope=line|thread, from=<url>)
-            const commitMatch = request.match(/commit=([a-f0-9]+)/);
+            const commitMatch = request.match(/(?:^|\s)commit=([^\s]+)/);
             if (commitMatch) core.setOutput('target_commit', commitMatch[1]);
 
             const scopeMatch = request.match(/scope=(line|thread)/);
@@ -280,6 +281,54 @@ jobs:
 
             core.setOutput('additional_context', additionalContext);
 
+      - name: Resolve review target
+        id: resolve_review_target
+        if: steps.extract_command.outputs.command == 'review'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # ratchet:actions/github-script@v7
+        env:
+          ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
+          TARGET_COMMIT: '${{ steps.extract_command.outputs.target_commit }}'
+        with:
+          github-token: '${{ steps.auth.outputs.token }}'
+          script: |
+            const { owner, repo } = context.repo;
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const requested = (process.env.TARGET_COMMIT || '').trim().toLowerCase();
+            if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+              throw new Error('review target requires a pull request number');
+            }
+            if (requested && !/^[0-9a-f]{7,40}$/.test(requested)) {
+              throw new Error('commit must be a 7-40 character hexadecimal SHA');
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: issueNumber,
+            });
+            const currentHead = pull?.head?.sha;
+            if (!/^[0-9a-f]{40}$/.test(currentHead || '')) {
+              throw new Error('pull request head is unavailable');
+            }
+
+            let reviewedSha = currentHead;
+            if (requested) {
+              const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner,
+                repo,
+                pull_number: issueNumber,
+                per_page: 100,
+              });
+              const matches = commits
+                .map((item) => item?.sha)
+                .filter((sha) => /^[0-9a-f]{40}$/.test(sha || '') && sha.startsWith(requested));
+              if (matches.length !== 1) {
+                throw new Error('commit does not identify exactly one commit in this pull request');
+              }
+              reviewedSha = matches[0];
+            }
+            core.setOutput('reviewed_sha', reviewedSha);
+
       - name: 'Acknowledge request'
         if: steps.extract_command.outputs.command != 'noop' && steps.extract_command.outputs.command != 'unauthorized'
         env:
@@ -307,6 +356,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: '${{ needs.dispatch.outputs.reviewed_sha }}'
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate repository-write auth
         shell: bash
@@ -355,6 +408,7 @@ jobs:
           ADDITIONAL_CONTEXT: '${{ needs.dispatch.outputs.additional_context }}'
           PATCH: '${{ needs.dispatch.outputs.patch }}'
           INCREMENTAL: '${{ needs.dispatch.outputs.incremental }}'
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_cli_version: '${{ vars.GEMINI_CLI_VERSION }}'
@@ -383,6 +437,7 @@ jobs:
 
             **Repository:** ${{ github.repository }}
             **PR/Issue:** #${{ github.event.pull_request.number || github.event.issue.number }}
+            **Reviewed SHA:** ${{ needs.dispatch.outputs.reviewed_sha }}
 
             You are performing a deep, professional review that goes BEYOND the current diff.
             Focus on missing improvements, latent risks, and hardening opportunities in areas touched by this PR.
@@ -435,6 +490,7 @@ jobs:
           ADDITIONAL_CONTEXT: '${{ needs.dispatch.outputs.additional_context }}'
           PATCH: '${{ needs.dispatch.outputs.patch }}'
           INCREMENTAL: '${{ needs.dispatch.outputs.incremental }}'
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_cli_version: '${{ vars.GEMINI_CLI_VERSION }}'
@@ -464,6 +520,7 @@ jobs:
             **Repository:** ${{ github.repository }}
             **PR/Issue:** #${{ github.event.pull_request.number || github.event.issue.number }}
             **Model:** ${{ vars.GEMINI_FALLBACK_MODEL }}
+            **Reviewed SHA:** ${{ needs.dispatch.outputs.reviewed_sha }}
 
             You are performing a deep, professional review that goes BEYOND the current diff.
             Focus on missing improvements, latent risks, and hardening opportunities in areas touched by this PR.
@@ -540,6 +597,7 @@ jobs:
           OUTCOME: '${{ steps.final_review.outputs.outcome }}'
           RESPONSE: '${{ steps.final_review.outputs.response }}'
           ERRORS: '${{ steps.final_review.outputs.errors }}'
+          REVIEWED_SHA: '${{ needs.dispatch.outputs.reviewed_sha }}'
         with:
           github-token: '${{ steps.auth.outputs.token }}'
           script: |
@@ -552,6 +610,10 @@ jobs:
             const runUrl = process.env.RUN_URL;
             const modelUsed = process.env.MODEL_USED || '';
             const outcome = (process.env.OUTCOME || '').toLowerCase();
+            const reviewedSha = (process.env.REVIEWED_SHA || '').toLowerCase();
+            if (!/^[0-9a-f]{40}$/.test(reviewedSha)) {
+              throw new Error('reviewed SHA is invalid');
+            }
 
             const maxLen = 60000;
             const trim = (s) => {
@@ -605,13 +667,16 @@ jobs:
             // gemini-review 워크플로가 남긴 JSON 마커({..., last_success_sha})가 있으면 그대로
             // 승계한다 — 닫힌 마커로 덮어쓰면 incremental 리뷰의 기준 SHA가 소실된다.
             const jsonMarker = existing ? (existing.body || '').match(/<!-- automation:gemini-review \{.*\} -->/) : null;
-            const markerLine = jsonMarker ? jsonMarker[0] : marker;
+            const markerLine = ok
+              ? `<!-- automation:gemini-review ${JSON.stringify({ last_success_sha: reviewedSha })} -->`
+              : (jsonMarker ? jsonMarker[0] : marker);
 
             const header = `## Gemini Review (latest)\n${markerLine}`;
             const meta = [
               `- Status: ${ok ? 'success' : 'failure'}`,
               modelUsed ? `- Model: ${modelUsed}` : null,
               `- Run: ${runUrl}`,
+              `- Reviewed: ${reviewedSha}`,
             ].filter(Boolean).join('\n');
 
             const content = ok

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -213,6 +213,9 @@ manifest has schema `1`, repository, PR number, merge-base SHA, head SHA, and fi
 `status`, `filename`, and optional `previous_filename`.
 The file list may be empty only for a tree-equivalent head whose authenticated full diff and local
 full-range name-status reconstruction are both empty.
+`force-full=true` is reserved for the authenticated force-review entrypoint. It ignores only the
+previous SHA/hash optimization and therefore produces the same immutable full PR diff and manifest;
+it does not relax PR-head, scope, or output validation.
 
 `prepare-review-diff` requires an explicit `output-directory`; Claude and Gemini bind it to
 `${{ runner.temp }}`. Their prior canonical body and context files use the same runner-temporary
@@ -478,8 +481,13 @@ hash; otherwise both are `null`. Status is `success` or `failure`; mode is `full
 pair with `successful_head == attempt_head`; failure may carry either a null pair or a valid pair
 retained from an earlier success.
 
-Claude/Gemini schema 3 adds exactly `quality_schema`, `accepted_count`, `filtered_count`,
-`normalized_count`, and `filtered_max_severity`. `quality_schema` is always `1`. On full or delta
+Claude/Gemini schema 3 additionally emits `review_execution` and the quality fields
+`quality_schema`, `accepted_count`, `filtered_count`, `normalized_count`, and
+`filtered_max_severity`. `review_execution` is `performed` when this attempt entered the model
+step, `reused` only for authenticated unchanged reuse, and `not_performed` when the attempt failed
+before a model call. Existing schema-3 records without this additive field remain readable.
+The same value appears in the trusted `- Execution:` metadata line, so a reused success cannot be
+presented as a new model review. `quality_schema` is always `1`. On full or delta
 success the counts are non-negative safe integers and the maximum is `none`, `MEDIUM`, `HIGH`, or
 `CRITICAL`. A first schema-3 failure has all four count/severity values `null`. A stale failure that
 preserves a prior schema-3 success also preserves that success's four values with its body, head,
@@ -780,9 +788,10 @@ one compact `<!-- automation-budget-state:{...} -->` JSON marker:
 Only a comment authored by exactly `github-actions[bot]` is eligible, and exactly one
 comment may match a reviewer marker. Invalid, duplicate, or provenance-unverifiable
 state fails closed. The effective-diff identity is the SHA-256 of the immutable
-`review-full.diff`, including when a provider consumes a delta. A prior invocation by
+`review-full.diff`, including when a provider consumes a delta. A normal invocation by
 the same reviewer with the same head SHA or full-diff hash is an absolute zero-call
-gate and cannot be overridden.
+gate. Only the explicit force-review contract below may consume the one override round
+to review that input again.
 
 A round is one distinct effective diff claimed by one reviewer. Each reviewer has two
 automatic rounds. One `review-budget-override` label timeline-event ID can authorize
@@ -794,9 +803,34 @@ action session, three Gemini `generate_content` requests across primary, retries
 configured same-reviewer fallback, and two OpenCode `opencode run` sessions including
 format repair.
 
+Claude and Gemini baseline callers expose a `workflow_dispatch` input pair:
+`pr_number` (required) and `force_review` (boolean, default `false`). A force claim is accepted only
+when the run event is `workflow_dispatch` and the PR timeline contains an unconsumed
+`review-budget-override` label event created by an actor with write, maintain, or admin permission.
+It prepares the current full PR diff, binds publication and budget state to the fetched current
+head plus the exact run ID/attempt, consumes the override immediately, and is terminal for that
+reviewer budget. A label alone never bypasses the normal same-head zero-call gate.
+
+`/jhw:ship` or an operator uses the stable sequence below, substituting the repository, PR, and
+caller filename. The Gemini caller uses `gemini-auto-review.yml` with the same inputs.
+
+```bash
+gh pr edit 26 --repo OWNER/REPO --add-label review-budget-override
+gh workflow run claude-code-review.yml --repo OWNER/REPO \
+  -f pr_number=26 -f force_review=true
+```
+
+The caller job is skipped when `force_review` is omitted or false. A missing, unauthorized,
+already-consumed, or otherwise unavailable override returns `round_budget_exhausted` and performs
+no model call. A non-dispatch force request or a run/PR/head/ref mismatch returns `state_invalid`;
+diff preparation and provider/canonicalization failures retain their existing fail-closed outcomes.
+Neither a failed force run nor budget exhaustion is merge approval, and orchestration must require
+`review_execution=performed` on a current-head successful state before treating the force request
+as satisfied.
+
 Claim decisions are applied in this order: invalid state/provenance/head/diff;
-authenticated unchanged reuse; duplicate head; duplicate effective diff; per-round
-input exhaustion; automatic-round exhaustion and eligible override consumption;
+authenticated unchanged reuse; normal duplicate head; normal duplicate effective diff; per-round
+input exhaustion; force authorization or automatic-round exhaustion and eligible override consumption;
 aggregate usage exhaustion; then `claimed` with `allow-invocation=true`. The claim is
 persisted before provider execution. Cancelled, timed-out, provider-failed,
 quality-filtered, and unfinalized claims remain consumed. Immediately before ledger

--- a/examples/baseline-workflows/.github/workflows/claude-code-review.yml
+++ b/examples/baseline-workflows/.github/workflows/claude-code-review.yml
@@ -3,10 +3,25 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        type: number
+        required: true
+      force_review:
+        description: Perform one authorized same-HEAD review
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   claude-review:
-    if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: >-
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'workflow_dispatch' && inputs.force_review)
     permissions:
       actions: read
       contents: read
@@ -15,6 +30,7 @@ jobs:
       pull-requests: write
     uses: jhw7500/automation/.github/workflows/claude-code-review.yml@__AUTOMATION_COMMIT__
     with:
-      pr_number: ${{ github.event.pull_request.number }}
+      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
+      force_review: ${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/examples/baseline-workflows/.github/workflows/gemini-auto-review.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-auto-review.yml
@@ -3,10 +3,25 @@ name: Gemini Auto PR Review
 on:
   pull_request:
     types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        type: number
+        required: true
+      force_review:
+        description: Perform one authorized same-HEAD review
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   gemini-review:
-    if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: >-
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'workflow_dispatch' && inputs.force_review)
     permissions:
       actions: read
       contents: read
@@ -14,7 +29,8 @@ jobs:
       pull-requests: write
     uses: jhw7500/automation/.github/workflows/gemini-auto-review.yml@__AUTOMATION_COMMIT__
     with:
-      pr_number: ${{ github.event.pull_request.number }}
+      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
+      force_review: ${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}
       repo_write_auth: github_app
       app_id: ${{ vars.APP_ID }}
       publisher_app_id: ${{ vars.APP_ID }}

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -316,6 +316,7 @@ EXPECTED_PREPARE_REVIEW_DIFF_ACTION = {
         "pr-number": {"required": "true"},
         "previous-sha": {"required": "false", "default": ""},
         "previous-full-hash": {"required": "false", "default": ""},
+        "force-full": {"required": "false", "default": "false"},
         "context-lines": {"required": "false", "default": "3"},
         "output-directory": {"required": "true"},
     },
@@ -341,20 +342,30 @@ EXPECTED_PREPARE_REVIEW_DIFF_ACTION = {
                     "PR_NUMBER": "${{ inputs.pr-number }}",
                     "PREVIOUS_SHA": "${{ inputs.previous-sha }}",
                     "PREVIOUS_FULL_HASH": "${{ inputs.previous-full-hash }}",
+                    "FORCE_FULL": "${{ inputs.force-full }}",
                     "CONTEXT_LINES": "${{ inputs.context-lines }}",
                     "OUTPUT_DIRECTORY": "${{ inputs.output-directory }}",
                 },
                 "run": (
-                    'python3 "$GITHUB_ACTION_PATH/prepare_review_diff.py" '
-                    '--repository "$GITHUB_REPOSITORY" '
-                    '--pr-number "$PR_NUMBER" '
-                    '--previous-sha "$PREVIOUS_SHA" '
-                    '--previous-full-hash "$PREVIOUS_FULL_HASH" '
-                    '--context-lines "$CONTEXT_LINES" '
-                    '--full-output "$OUTPUT_DIRECTORY/review-full.diff" '
-                    '--delta-output "$OUTPUT_DIRECTORY/review-delta.diff" '
-                    '--manifest-output "$OUTPUT_DIRECTORY/review-scope.json" '
-                    '--github-output "$GITHUB_OUTPUT"'
+                    "set -euo pipefail\n"
+                    "force_args=()\n"
+                    "if [[ \"$FORCE_FULL\" == 'true' ]]; then\n"
+                    "  force_args+=(--force-full)\n"
+                    "elif [[ \"$FORCE_FULL\" != 'false' ]]; then\n"
+                    "  echo 'force-full must be true or false' >&2\n"
+                    "  exit 2\n"
+                    "fi\n"
+                    'python3 "$GITHUB_ACTION_PATH/prepare_review_diff.py" \\\n'
+                    '  --repository "$GITHUB_REPOSITORY" \\\n'
+                    '  --pr-number "$PR_NUMBER" \\\n'
+                    '  --previous-sha "$PREVIOUS_SHA" \\\n'
+                    '  --previous-full-hash "$PREVIOUS_FULL_HASH" \\\n'
+                    '  --context-lines "$CONTEXT_LINES" \\\n'
+                    '  --full-output "$OUTPUT_DIRECTORY/review-full.diff" \\\n'
+                    '  --delta-output "$OUTPUT_DIRECTORY/review-delta.diff" \\\n'
+                    '  --manifest-output "$OUTPUT_DIRECTORY/review-scope.json" \\\n'
+                    '  --github-output "$GITHUB_OUTPUT" \\\n'
+                    '  "${force_args[@]}"\n'
                 ),
             }
         ],
@@ -364,8 +375,10 @@ EXPECTED_PREPARE_REVIEW_DIFF_ACTION = {
 # required output-directory input so the final checkout cannot replace them.
 EXPECTED_PREPARE_REVIEW_DIFF_ACTION_V145 = deepcopy(EXPECTED_PREPARE_REVIEW_DIFF_ACTION)
 del EXPECTED_PREPARE_REVIEW_DIFF_ACTION_V145["inputs"]["output-directory"]
+del EXPECTED_PREPARE_REVIEW_DIFF_ACTION_V145["inputs"]["force-full"]
 _legacy_prepare_step = EXPECTED_PREPARE_REVIEW_DIFF_ACTION_V145["runs"]["steps"][0]
 del _legacy_prepare_step["env"]["OUTPUT_DIRECTORY"]
+del _legacy_prepare_step["env"]["FORCE_FULL"]
 _legacy_prepare_step["run"] = (
     'python3 "$GITHUB_ACTION_PATH/prepare_review_diff.py" '
     '--repository "$GITHUB_REPOSITORY" '
@@ -628,14 +641,14 @@ REVIEWER_WORKFLOWS = {
     "opencode": "opencode-auto-review.yml",
 }
 EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256 = (
-    "42462dad335073794bd5c46e1993e02e4dc9824113d1b36fd5c6b89dc0583a9c"
+    "70b50ce482ff0e54df9fff88d5126cd8e760ed8bdabfefcc2f2ccdc639cb693b"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256 = (
-    "b58044cadbded4e91b2b021e4902e56b4ca267cc47e75f3984037f61b662ee48"
+    "a2ccb7dcfa131186ed302836172f03502d71ec191bf58780477b2e447a42c594"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
-    "claude": "2fa6fdb6fbad2e874c5dfab7e059d53c8d2f610731f3d3dcf918cd531c585876",
-    "gemini": "a8b048f7862c3eed467482a750da57abad8d6ef04ed61964a35e4f90b4afeeda",
+    "claude": "d34dfc388a393a6679bfd6a38ac281cc2c14a843063a010e9f1303c68df58cc7",
+    "gemini": "6837358dbbdcc2f3f5ebf6aca3956b646f89b35fed7c9a201bbde2d6af7519dd",
     "opencode": "28791fa77f05454775043cb5b582f849aef7fe81c109c65161bcf860a6d6531a",
 }
 EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION = yaml.load(
@@ -656,6 +669,9 @@ inputs:
     required: true
   diff-mode:
     required: true
+  force-review:
+    required: false
+    default: 'false'
   input-files-json:
     required: true
   authenticated-review-json:
@@ -707,6 +723,7 @@ runs:
         EXPECTED_HEAD_SHA: ${{ inputs.expected-head-sha }}
         FULL_DIFF_SHA256: ${{ inputs.full-diff-sha256 }}
         DIFF_MODE: ${{ inputs.diff-mode }}
+        FORCE_REVIEW: ${{ inputs.force-review }}
         INPUT_FILES_JSON: ${{ inputs.input-files-json }}
         AUTHENTICATED_REVIEW_JSON: ${{ inputs.authenticated-review-json }}
         MODEL_ROUTE_JSON: ${{ inputs.model-route-json }}
@@ -769,6 +786,7 @@ runs:
           "$BUDGET_MODE" "$GITHUB_REPOSITORY" "$PR_NUMBER" "$REVIEWER" \
           "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" "$EXPECTED_HEAD_SHA" \
           "$FULL_DIFF_SHA256" "$DIFF_MODE" "$INPUT_FILES_JSON" \
+          "$FORCE_REVIEW" \
           "$AUTHENTICATED_REVIEW_JSON" "$MODEL_ROUTE_JSON" "$EFFORT" \
           "$ACTUAL_CALL_COUNT" "$ELAPSED_SECONDS" "$REVIEW_OUTCOME" \
           "$STOP_REASON" "$REMAINING_FINDING_IDS_JSON" "$CHECKPOINT_FILE" \
@@ -780,6 +798,7 @@ runs:
         names = (
             "operation", "repository", "pr", "reviewer", "run_id", "run_attempt",
             "head_sha", "full_diff_sha256", "diff_mode", "input_files_json",
+            "force_review",
             "authenticated_review_json", "model_route_json", "effort", "actual_call_count",
             "elapsed_seconds", "outcome", "stop_reason", "remaining_finding_ids_json",
             "checkpoint_file", "github_workspace", "server_url",
@@ -969,11 +988,15 @@ QUALITY_STATE_KEYS = (
     "normalized_count",
     "pr",
     "quality_schema",
+    "review_execution",
     "reviewer",
     "run_attempt",
     "run_id",
     "schema",
     "successful_head",
+)
+LEGACY_QUALITY_STATE_KEYS = tuple(
+    key for key in QUALITY_STATE_KEYS if key != "review_execution"
 )
 REVIEW_PUBLICATION_CONTRACTS = {
     "claude-code-review.yml": {
@@ -994,7 +1017,7 @@ REVIEW_PUBLICATION_CONTRACTS = {
             "d2f1d2eab1e974bf05f184406e854cfe0861ab4b863520a4189d987ceccf27cc"
         ),
         "upsert_sha256_v147": (
-            "250893bab0d29e25706b7512a9cddb5f7aca687292a9c66de27cf9a1cc323842"
+            "bc79b2db414640a7a707f9c5dfe6e13fd05a726aaad74ad163c6d46f71caf766"
         ),
         "bot_login": "github-actions[bot]",
         "workflow_prefix": (
@@ -1026,7 +1049,7 @@ REVIEW_PUBLICATION_CONTRACTS = {
             "cc81b9e370c357366a384a059c9d6e1fe02065f085985f30532b92410c49c43d"
         ),
         "upsert_sha256_v147": (
-            "1eb58f53bd3af4dc3db2e580e02078df961b9ecb52c9b75af233db2475e45635"
+            "b924753e8c9eda60ac3047dfc2c085ec4c56d62b2d6ad81a3ec979a3ff85e5f0"
         ),
         "bot_login": "${{ steps.auth.outputs.bot-login }}",
         "auth_mode": "${{ inputs.repo_write_auth }}",
@@ -3849,6 +3872,23 @@ def require_budget_helper_contract(source: str) -> None:
                 ("stop_reason", "str", None),
                 ("remaining_finding_ids", "tuple[str, ...]", None),
             ),
+            "ClaimRequest": (
+                ("repository", "str", None),
+                ("pr", "int", None),
+                ("reviewer", "Reviewer", None),
+                ("run_id", "int", None),
+                ("run_attempt", "int", None),
+                ("head_sha", "str", None),
+                ("full_diff_sha256", "str", None),
+                ("estimated_input_tokens", "int", None),
+                ("diff_mode", "str", None),
+                ("authenticated_review", "AuthenticatedReview", None),
+                ("override_events", "tuple[OverrideEvent, ...]", None),
+                ("model_route", "tuple[str, ...]", None),
+                ("effort", "str", None),
+                ("call_unit", "str", None),
+                ("force_review", "bool", "False"),
+            ),
             "DecisionRecord": (
                 ("decision", "str | None", "None"),
                 ("stop_reason", "str | None", "None"),
@@ -3979,6 +4019,20 @@ def require_budget_helper_contract(source: str) -> None:
             _direct_guard(
                 function.body, expression, "BudgetStateError", reason
             )
+        claim_request_validation = _function_node(module, "_validate_request")
+        for expression, reason in (
+            ("not isinstance(request.force_review, bool)", "force_review_invalid"),
+            (
+                "request.force_review and request.diff_mode != 'changed'",
+                "force_review_diff_invalid",
+            ),
+        ):
+            _direct_guard(
+                claim_request_validation.body,
+                expression,
+                "BudgetStateError",
+                reason,
+            )
         reviewer_policy = _function_node(policy, "for_reviewer")
         if (
             len(reviewer_policy.body) != 2
@@ -4054,118 +4108,64 @@ def require_budget_helper_contract(source: str) -> None:
         ):
             raise ValueError("public helper function differs")
         claim_function = _function_node(module, "claim")
-        claim_body = claim_function.body
-        claim_tests = {
-            2: (
-                "same_run and any((item.head_sha, item.full_diff_sha256) != "
-                "(request.head_sha, request.full_diff_sha256) "
-                "for item in same_run)"
-            ),
-            3: "request.diff_mode == 'unchanged'",
-            4: (
-                "any(item.head_sha == request.head_sha "
-                "for item in validated.invocations)"
-            ),
-            5: (
-                "any(item.full_diff_sha256 == request.full_diff_sha256 "
-                "for item in validated.invocations)"
-            ),
-            6: (
-                "request.estimated_input_tokens > "
-                "validated.budgets.max_estimated_tokens_per_round"
-            ),
-            8: (
-                "automatic_rounds(validated) >= "
-                "validated.budgets.max_rounds"
-            ),
-            10: (
-                "estimated_total(validated) + request.estimated_input_tokens "
-                "> total_limit"
-            ),
-        }
-        if (
-            len(claim_body) != 12
-            or not all(
-                isinstance(claim_body[index], ast.If)
-                and _ast_expression_matches(claim_body[index].test, expression)
-                for index, expression in claim_tests.items()
-            )
-            or not _ast_statement_matches(
-                claim_body[1],
-                "same_run = [item for item in validated.invocations "
-                "if (item.run_id, item.run_attempt) == "
-                "(request.run_id, request.run_attempt)]",
-            )
-            or not _ast_statement_matches(claim_body[7], "override = None")
-            or not _ast_statement_matches(
-                claim_body[9],
-                "total_limit = 600_000 if override is not None else 400_000",
-            )
-            or not _ast_statement_matches(
-                claim_body[11],
-                "return append_claim(validated, request, override, "
-                "provenances[(request.run_id, request.run_attempt)])",
-            )
+        expected_claim = ast.parse(
+            "def expected(state, request, provenances):\n"
+            "    try:\n"
+            "        validated = validate_or_initialize(state, request, provenances)\n"
+            "    except BudgetStateError as exc:\n"
+            "        return _invalid_transition(state, request, str(exc))\n"
+            "    same_run = [item for item in validated.invocations "
+            "if (item.run_id, item.run_attempt) == "
+            "(request.run_id, request.run_attempt)]\n"
+            "    if same_run and any((item.head_sha, item.full_diff_sha256) != "
+            "(request.head_sha, request.full_diff_sha256) "
+            "for item in same_run):\n"
+            "        return _invalid_transition(validated, request, "
+            "'duplicate_run_identity')\n"
+            "    if request.diff_mode == 'unchanged':\n"
+            "        if not request.authenticated_review.covers_hash("
+            "request.full_diff_sha256):\n"
+            "            return _invalid_transition(validated, request, "
+            "'unchanged_without_authenticated_review')\n"
+            "        return refuse(validated, request, 'authenticated_reuse')\n"
+            "    if not request.force_review and any("
+            "item.head_sha == request.head_sha for item in validated.invocations):\n"
+            "        return refuse(validated, request, 'duplicate_head')\n"
+            "    if not request.force_review and any("
+            "item.full_diff_sha256 == request.full_diff_sha256 "
+            "for item in validated.invocations):\n"
+            "        return refuse(validated, request, 'duplicate_effective_diff')\n"
+            "    if request.estimated_input_tokens > "
+            "validated.budgets.max_estimated_tokens_per_round:\n"
+            "        return refuse(validated, request, 'input_budget_exhausted')\n"
+            "    override = None\n"
+            "    if any(item.override_event_id is not None "
+            "for item in validated.invocations):\n"
+            "        return refuse(validated, request, 'round_budget_exhausted')\n"
+            "    if request.force_review:\n"
+            "        override = choose_override(validated, request.override_events)\n"
+            "        if override is None:\n"
+            "            return refuse(validated, request, 'round_budget_exhausted')\n"
+            "    elif automatic_rounds(validated) >= validated.budgets.max_rounds:\n"
+            "        override = choose_override(validated, request.override_events)\n"
+            "        if override is None:\n"
+            "            return refuse(validated, request, 'round_budget_exhausted')\n"
+            "    total_limit = 600_000 if override is not None else 400_000\n"
+            "    if estimated_total(validated) + request.estimated_input_tokens "
+            "> total_limit:\n"
+            "        return refuse(validated, request, "
+            "'total_usage_budget_exhausted')\n"
+            "    return append_claim(validated, request, override, "
+            "provenances[(request.run_id, request.run_attempt)])\n"
+        ).body[0]
+        if ast.dump(
+            ast.Module(body=claim_function.body, type_ignores=[]),
+            include_attributes=False,
+        ) != ast.dump(
+            ast.Module(body=expected_claim.body, type_ignores=[]),
+            include_attributes=False,
         ):
-            raise ValueError("claim live control flow differs")
-        if (
-            len(claim_body[2].body) != 1
-            or not _ast_statement_matches(
-                claim_body[2].body[0],
-                'return _invalid_transition(validated, request, '
-                '"duplicate_run_identity")',
-            )
-            or len(claim_body[3].body) != 2
-            or not isinstance(claim_body[3].body[0], ast.If)
-            or not _ast_expression_matches(
-                claim_body[3].body[0].test,
-                "not request.authenticated_review.covers_hash("
-                "request.full_diff_sha256)",
-            )
-            or len(claim_body[3].body[0].body) != 1
-            or not _ast_statement_matches(
-                claim_body[3].body[0].body[0],
-                'return _invalid_transition(validated, request, '
-                '"unchanged_without_authenticated_review")',
-            )
-            or not _refusal_return(
-                claim_body[3].body[1], "validated", "authenticated_reuse"
-            )
-            or len(claim_body[4].body) != 1
-            or not _refusal_return(
-                claim_body[4].body[0], "validated", "duplicate_head"
-            )
-            or len(claim_body[5].body) != 1
-            or not _refusal_return(
-                claim_body[5].body[0], "validated", "duplicate_effective_diff"
-            )
-            or len(claim_body[6].body) != 1
-            or not _refusal_return(
-                claim_body[6].body[0], "validated", "input_budget_exhausted"
-            )
-            or len(claim_body[8].body) != 2
-            or not _ast_statement_matches(
-                claim_body[8].body[0],
-                "override = choose_override(validated, request.override_events)",
-            )
-            or not isinstance(claim_body[8].body[1], ast.If)
-            or not _ast_expression_matches(
-                claim_body[8].body[1].test, "override is None"
-            )
-            or len(claim_body[8].body[1].body) != 1
-            or not _refusal_return(
-                claim_body[8].body[1].body[0],
-                "validated",
-                "round_budget_exhausted",
-            )
-            or len(claim_body[10].body) != 1
-            or not _refusal_return(
-                claim_body[10].body[0],
-                "validated",
-                "total_usage_budget_exhausted",
-            )
-        ):
-            raise ValueError("claim gate relationship differs")
+            raise ValueError("claim policy differs")
 
         finalize_function = _function_node(module, "finalize")
         if (
@@ -4220,17 +4220,54 @@ def require_budget_helper_contract(source: str) -> None:
             != ast.dump(expected_invocation_loop, include_attributes=False)
         ):
             raise ValueError("stored cap policy differs")
+        expected_duplicate_policy = ast.parse(
+            "automatic = [item for item in state.invocations "
+            "if item.override_event_id is None]\n"
+            "overrides = [item for item in state.invocations "
+            "if item.override_event_id is not None]\n"
+            "forced_override = next((item for item in overrides "
+            "if item.caller_event == 'workflow_dispatch'), None)\n"
+            "for attribute, reason in (('head_sha', 'duplicate_head'), "
+            "('full_diff_sha256', 'duplicate_effective_diff')):\n"
+            "    values = [getattr(item, attribute) for item in state.invocations]\n"
+            "    duplicates = {value for value in values "
+            "if values.count(value) > 1}\n"
+            "    if duplicates and (forced_override is None or "
+            "any(values.count(value) != 2 for value in duplicates) or "
+            "any(getattr(forced_override, attribute) != value "
+            "for value in duplicates) or "
+            "all(getattr(item, attribute) not in duplicates "
+            "for item in automatic)):\n"
+            "        raise BudgetStateError(reason)\n"
+            "if len(automatic) > state.budgets.max_rounds or "
+            "len(overrides) > state.budgets.max_override_rounds:\n"
+            "    raise BudgetStateError('rounds_invalid')\n"
+            "if [item.round_number for item in automatic] != "
+            "list(range(1, len(automatic) + 1)):\n"
+            "    raise BudgetStateError('rounds_invalid')\n"
+            "if overrides:\n"
+            "    item = overrides[0]\n"
+            "    expected_automatic_rounds = ("
+            "range(0, state.budgets.max_rounds + 1) "
+            "if item.caller_event == 'workflow_dispatch' "
+            "else (state.budgets.max_rounds,))\n"
+            "    if (len(automatic) not in expected_automatic_rounds or "
+            "state.invocations[-1] != item or "
+            "item.round_number != len(automatic) + 1 or "
+            "item.override_event_id not in state.consumed_override_event_ids):\n"
+            "        raise BudgetStateError('override_invalid')\n"
+            "if len(state.consumed_override_event_ids) != len(overrides):\n"
+            "    raise BudgetStateError('override_invalid')\n"
+        ).body
+        if ast.dump(
+            ast.Module(body=state_shape.body[9:17], type_ignores=[]),
+            include_attributes=False,
+        ) != ast.dump(
+            ast.Module(body=expected_duplicate_policy, type_ignores=[]),
+            include_attributes=False,
+        ):
+            raise ValueError("forced duplicate policy differs")
         for expression, reason in (
-            (
-                "len({item.head_sha for item in state.invocations}) "
-                "!= len(state.invocations)",
-                "duplicate_head",
-            ),
-            (
-                "len({item.full_diff_sha256 for item in state.invocations}) "
-                "!= len(state.invocations)",
-                "duplicate_effective_diff",
-            ),
             (
                 "len(automatic) > state.budgets.max_rounds or "
                 "len(overrides) > state.budgets.max_override_rounds",
@@ -4255,7 +4292,7 @@ def require_budget_helper_contract(source: str) -> None:
         )
         _direct_guard(
             provenance_identity.body,
-            "provenance.caller_event != 'pull_request' or "
+            "provenance.caller_event not in {'pull_request', 'workflow_dispatch'} or "
             "not isinstance(provenance.caller_workflow_path, str) or "
             "_CALLER_WORKFLOW.fullmatch(provenance.caller_workflow_path) is None or "
             "'..' in Path(provenance.caller_workflow_path).parts or "
@@ -4301,8 +4338,12 @@ def require_budget_helper_contract(source: str) -> None:
             "    expected_head = request.head_sha if invocation is None else invocation.head_sha\n"
             "    expected_run_id = request.run_id if invocation is None else invocation.run_id\n"
             "    expected_run_attempt = (request.run_attempt if invocation is None else invocation.run_attempt)\n"
+            "    expected_event = (invocation.caller_event if invocation is not None "
+            "else ('workflow_dispatch' if isinstance(request, ClaimRequest) "
+            "and request.force_review else 'pull_request'))\n"
             "    if (provenance.repository != state.repository or "
             "provenance.pr != state.pr or provenance.head_sha != expected_head or "
+            "provenance.caller_event != expected_event or "
             "provenance.run_id != expected_run_id or "
             "provenance.run_attempt != expected_run_attempt or "
             "(not current and provenance.status != 'completed') or "
@@ -4384,9 +4425,17 @@ def require_budget_helper_contract(source: str) -> None:
             "        raise TransportError('provenance_mismatch')\n"
             "    central = central[0]\n"
             "    central_ref = central.get('ref') if 'ref' in central else central.get('sha')\n"
+            "    stored = stored_by_identity.get((run_id, run_attempt))\n"
+            "    is_force_dispatch = (stored is not None and "
+            "stored.caller_event == 'workflow_dispatch') or ("
+            "stored is None and request['operation'] == 'claim' and "
+            "request['force_review'] and (run_id, run_attempt) == "
+            "(request['run_id'], request['run_attempt']))\n"
+            "    reviewed_head = stored.head_sha if stored is not None "
+            "else request['head_sha']\n"
             "    provenance = RunProvenance("
             "repository=repository.get('full_name'), pr=request['pr'], "
-            "head_sha=value.get('head_sha'), "
+            "head_sha=reviewed_head if is_force_dispatch else value.get('head_sha'), "
             "caller_workflow_path=value.get('path'), "
             "caller_event=value.get('event'), "
             "referenced_workflow_path=central.get('path'), "
@@ -4394,7 +4443,10 @@ def require_budget_helper_contract(source: str) -> None:
             "referenced_workflow_sha=central.get('sha'), "
             "run_id=value.get('id'), run_attempt=value.get('run_attempt'), "
             "status=value.get('status'), conclusion=value.get('conclusion'))\n"
-            "    if request['pr'] not in pull_numbers:\n"
+            "    if is_force_dispatch:\n"
+            "        if value.get('event') != 'workflow_dispatch':\n"
+            "            raise TransportError('provenance_mismatch')\n"
+            "    elif request['pr'] not in pull_numbers:\n"
             "        raise TransportError('provenance_mismatch')\n"
             "    _validate_provenance_identity(provenance, request['reviewer'])\n"
             "    result[(run_id, run_attempt)] = provenance\n"
@@ -4407,6 +4459,13 @@ def require_budget_helper_contract(source: str) -> None:
             raise ValueError("provenance transport differs")
         if not _ast_statement_matches(
             run_provenances.body[1],
+            "stored_by_identity = {} if state is None else {"
+            "(item.run_id, item.run_attempt): item "
+            "for item in state.invocations}",
+        ):
+            raise ValueError("stored provenance lookup differs")
+        if not _ast_statement_matches(
+            run_provenances.body[2],
             "identities = {(request['run_id'], request['run_attempt'])}",
         ):
             raise ValueError("current provenance lookup differs")
@@ -5332,7 +5391,10 @@ def _verify_review_publication_contracts(
 ) -> None:
     budget = release_supports_review_invocation_budget(ref)
     jq_state_keys = json.dumps(list(QUALITY_STATE_KEYS))
-    js_state_keys = ", ".join(repr(key) for key in QUALITY_STATE_KEYS)
+    legacy_jq_state_keys = json.dumps(list(LEGACY_QUALITY_STATE_KEYS))
+    legacy_js_state_keys = ", ".join(
+        repr(key) for key in LEGACY_QUALITY_STATE_KEYS
+    )
     expected_output_env = {
         "CANONICAL_OUTCOME": "${{ steps.canonicalize-review.outcome }}",
         "DOCUMENT_VALID": "${{ steps.canonicalize-review.outputs.document-valid }}",
@@ -5416,12 +5478,21 @@ def _verify_review_publication_contracts(
                 and "app_publisher($publisher_app_id)" in collector_script
                 and "select(publisher_matches(" in collector_script
             )
+            collector_state_keys_contract = (
+                f"== {legacy_jq_state_keys}" in collector_script
+                and (not budget or f"== {jq_state_keys}" in collector_script)
+            )
+            collector_run_event_contract = (
+                '.event == "pull_request" and .head_sha == $head'
+                in collector_script
+                and (not budget or '.event == "workflow_dispatch"' in collector_script)
+            )
             collector_contract = (
                 collector_marker
                 and collector_token_contract
                 and collector_publisher_contract
                 and collector.get("id") == contract["collector_id"]
-                and f"== {jq_state_keys}" in collector_script
+                and collector_state_keys_contract
                 and "$s.schema == 3" in collector_script
                 and "$s.quality_schema == 1" in collector_script
                 and "canonical_body" in collector_script
@@ -5444,8 +5515,7 @@ def _verify_review_publication_contracts(
                 and "proceeding without re-review context" not in collector_script
                 and ("actions/runs/${candidate_run_id}/attempts/${candidate_attempt}")
                 in collector_script
-                and '.event == "pull_request" and .head_sha == $head'
-                in collector_script
+                and collector_run_event_contract
                 and ".repository.full_name == $repo" in collector_script
                 and ".number == $pr" in collector_script
                 and ".head.sha == $head" not in collector_script
@@ -5532,11 +5602,35 @@ def _verify_review_publication_contracts(
                 and "if (!publisherMatches(comment)) return null;" in upsert_script
                 and "if (!publisherMatches(comment)) return false;" in upsert_script
             )
+            upsert_state_keys_contract = (
+                (
+                    f"const legacyStateKeys = [{legacy_js_state_keys}];"
+                    in upsert_script
+                    and "const expectedStateKeys = "
+                    "[...legacyStateKeys, 'review_execution'].sort();"
+                    in upsert_script
+                    and "review_execution: unchangedInputIsValid" in upsert_script
+                    and "const modelStepEntered = ['success', 'failure'].includes(reviewOutcome);"
+                    in upsert_script
+                    and ": (modelStepEntered ? 'performed' : 'not_performed'),"
+                    in upsert_script
+                    and "`- Execution: ${state.review_execution}`" in upsert_script
+                )
+                if budget
+                else (
+                    f"const expectedStateKeys = [{legacy_js_state_keys}];"
+                    in upsert_script
+                )
+            )
+            upsert_run_event_contract = (
+                "run?.event === 'pull_request'" in upsert_script
+                and (not budget or "run?.event === 'workflow_dispatch'" in upsert_script)
+            )
             upsert_contract = (
                 f"const marker = '{marker}';" in upsert_script
                 and f"const v2Marker = '{contract['v2_marker']}';" in upsert_script
                 and ":v1 -->" not in upsert_script
-                and f"const expectedStateKeys = [{js_state_keys}];" in upsert_script
+                and upsert_state_keys_contract
                 and "state.schema === 3" in upsert_script
                 and "state.quality_schema === 1" in upsert_script
                 and "schema: 3" in upsert_script
@@ -5552,7 +5646,7 @@ def _verify_review_publication_contracts(
                 and upsert_publisher_contract
                 and upsert_run_lookup_contract
                 and contract["workflow_prefix"] in upsert_script
-                and "run?.event === 'pull_request'" in upsert_script
+                and upsert_run_event_contract
                 and "run?.head_sha === record.state.attempt_head" in upsert_script
                 and "run?.repository?.full_name === repository" in upsert_script
                 and "pr?.number === issueNumber" in upsert_script

--- a/scripts/workflow-catalog.json
+++ b/scripts/workflow-catalog.json
@@ -54,6 +54,21 @@
             "opened",
             "synchronize"
           ]
+        },
+        "workflow_dispatch": {
+          "inputs": {
+            "pr_number": {
+              "description": "Pull request number",
+              "type": "number",
+              "required": "true"
+            },
+            "force_review": {
+              "description": "Perform one authorized same-HEAD review",
+              "type": "boolean",
+              "required": "false",
+              "default": "false"
+            }
+          }
         }
       },
       "caller_jobs": [
@@ -67,6 +82,7 @@
             "pull-requests": "write"
           },
           "with": [
+            "force_review",
             "pr_number"
           ],
           "secrets": [
@@ -87,6 +103,21 @@
             "opened",
             "synchronize"
           ]
+        },
+        "workflow_dispatch": {
+          "inputs": {
+            "pr_number": {
+              "description": "Pull request number",
+              "type": "number",
+              "required": "true"
+            },
+            "force_review": {
+              "description": "Perform one authorized same-HEAD review",
+              "type": "boolean",
+              "required": "false",
+              "default": "false"
+            }
+          }
         }
       },
       "caller_jobs": [
@@ -100,6 +131,7 @@
           },
           "with": [
             "app_id",
+            "force_review",
             "pr_number",
             "publisher_app_id",
             "repo_write_auth"

--- a/tests/release_fixture_helpers.py
+++ b/tests/release_fixture_helpers.py
@@ -34,9 +34,86 @@ V145_PREPARE_DIFF_FIXTURE = (
 )
 
 
+def restore_pre_force_review_callers(repo: Path) -> None:
+    """Remove the force-review caller surface from historical fixtures."""
+
+    baseline_root = repo / "examples/baseline-workflows/.github/workflows"
+    for filename in ("claude-code-review.yml", "gemini-auto-review.yml"):
+        path = baseline_root / filename
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        dispatch = (
+            "  workflow_dispatch:\n"
+            "    inputs:\n"
+            "      pr_number:\n"
+            "        description: Pull request number\n"
+            "        type: number\n"
+            "        required: true\n"
+            "      force_review:\n"
+            "        description: Perform one authorized same-HEAD review\n"
+            "        type: boolean\n"
+            "        required: false\n"
+            "        default: false\n"
+        )
+        forced_if = (
+            "    if: >-\n"
+            "      (github.event_name == 'pull_request' &&\n"
+            "      github.event.pull_request.head.repo.fork == false &&\n"
+            "      github.event.pull_request.head.repo.full_name == github.repository) ||\n"
+            "      (github.event_name == 'workflow_dispatch' && inputs.force_review)\n"
+        )
+        assert text.count(dispatch) == 1
+        assert text.count(forced_if) == 1
+        assert text.count("      force_review: ${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}\n") == 1
+        text = text.replace(dispatch, "", 1).replace(
+            forced_if,
+            "    if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.head.repo.full_name == github.repository }}\n",
+            1,
+        ).replace(
+            "      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}\n",
+            "      pr_number: ${{ github.event.pull_request.number }}\n",
+            1,
+        ).replace(
+            "      force_review: ${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}\n",
+            "",
+            1,
+        )
+        path.write_text(text, encoding="utf-8")
+
+    catalog = repo / "scripts/workflow-catalog.json"
+    if catalog.exists():
+        text = catalog.read_text(encoding="utf-8")
+        dispatch = (
+            '        },\n'
+            '        "workflow_dispatch": {\n'
+            '          "inputs": {\n'
+            '            "pr_number": {\n'
+            '              "description": "Pull request number",\n'
+            '              "type": "number",\n'
+            '              "required": "true"\n'
+            '            },\n'
+            '            "force_review": {\n'
+            '              "description": "Perform one authorized same-HEAD review",\n'
+            '              "type": "boolean",\n'
+            '              "required": "false",\n'
+            '              "default": "false"\n'
+            '            }\n'
+            '          }\n'
+            '        }\n'
+        )
+        assert text.count(dispatch) == 2
+        assert text.count('            "force_review",\n') == 2
+        text = text.replace(dispatch, "        }\n", 2).replace(
+            '            "force_review",\n', "", 2
+        )
+        catalog.write_text(text, encoding="utf-8")
+
+
 def restore_pre_v146_review_contracts(repo: Path) -> None:
     """Restore shared auth identity and Claude/Gemini caller ceilings."""
 
+    restore_pre_force_review_callers(repo)
     setup = repo / ".github/actions/setup-gemini-auth/action.yml"
     setup.parent.mkdir(parents=True, exist_ok=True)
     setup.write_bytes(PRE_V146_SETUP_AUTH_FIXTURE.read_bytes())

--- a/tests/test_canonical_workflow_tree.py
+++ b/tests/test_canonical_workflow_tree.py
@@ -61,10 +61,40 @@ EXPECTED_TRIGGERS: dict[str, object] = {
         "issues": {"types": ["opened", "assigned"]},
     },
     "claude-code-review.yml": {
-        "pull_request": {"types": ["opened", "synchronize"]}
+        "pull_request": {"types": ["opened", "synchronize"]},
+        "workflow_dispatch": {
+            "inputs": {
+                "pr_number": {
+                    "description": "Pull request number",
+                    "type": "number",
+                    "required": "true",
+                },
+                "force_review": {
+                    "description": "Perform one authorized same-HEAD review",
+                    "type": "boolean",
+                    "required": "false",
+                    "default": "false",
+                },
+            }
+        },
     },
     "gemini-auto-review.yml": {
-        "pull_request": {"types": ["opened", "synchronize"]}
+        "pull_request": {"types": ["opened", "synchronize"]},
+        "workflow_dispatch": {
+            "inputs": {
+                "pr_number": {
+                    "description": "Pull request number",
+                    "type": "number",
+                    "required": "true",
+                },
+                "force_review": {
+                    "description": "Perform one authorized same-HEAD review",
+                    "type": "boolean",
+                    "required": "false",
+                    "default": "false",
+                },
+            }
+        },
     },
     "gemini-chat.yml": {
         "issue_comment": {"types": ["created"]},

--- a/tests/test_prepare_review_diff.py
+++ b/tests/test_prepare_review_diff.py
@@ -506,6 +506,35 @@ def test_matching_full_hash_reports_unchanged_and_removes_delta(
     assert not delta.exists()
 
 
+def test_force_full_reviews_same_head_instead_of_reusing_matching_hash(
+    history: RepositoryHistory, gh_fixture: GhFixture, tmp_path: Path
+) -> None:
+    configure_gh(gh_fixture, base=history.base, head=history.head)
+    full, delta, manifest = outputs(tmp_path)
+    baseline = run_prepare(history.repo, gh_fixture, *prepare_args(full, delta, manifest))
+    baseline_hash = json.loads(baseline.stdout)["full_diff_sha256"]
+    configure_gh(gh_fixture, base=history.base, head=history.head)
+
+    result = run_prepare(
+        history.repo,
+        gh_fixture,
+        *prepare_args(
+            full,
+            delta,
+            manifest,
+            "--previous-full-hash",
+            baseline_hash,
+            "--force-full",
+        ),
+    )
+
+    assert result.returncode == 0, result.stderr
+    state = json.loads(result.stdout)
+    assert state["diff_mode"] == "full"
+    assert state["unchanged_since_previous"] is False
+    assert state["full_diff_sha256"] == baseline_hash
+
+
 def test_invalid_invocation_is_nonzero_and_does_not_call_gh(
     history: RepositoryHistory, gh_fixture: GhFixture, tmp_path: Path
 ) -> None:

--- a/tests/test_review_invocation_budget.py
+++ b/tests/test_review_invocation_budget.py
@@ -389,6 +389,83 @@ def test_quality_filtered_is_terminal_and_duplicate_input_stays_blocked():
     assert not again.allow_invocation
 
 
+def test_force_review_claims_same_head_once_with_dispatch_and_authorized_override():
+    existing = budget.LedgerState.initial(
+        REPOSITORY,
+        PR,
+        "claude",
+        invocations=(invocation(),),
+    )
+    force_request = replace(
+        request(run_id=700),
+        force_review=True,
+        override_events=(
+            budget.OverrideEvent(9001, "labeled", "review-budget-override", "write"),
+        ),
+    )
+    provenances = valid_provenances(existing)
+    provenances[(700, 1)] = replace(
+        reusable_provenance(run_id=700), caller_event="workflow_dispatch"
+    )
+
+    result = budget.claim(existing, force_request, provenances)
+
+    assert result.allow_invocation
+    assert result.decision == "claimed"
+    assert result.round_number == 2
+    assert result.state.consumed_override_event_ids == (9001,)
+    assert result.state.invocations[-1].head_sha == HEAD_A
+    assert result.state.invocations[-1].full_diff_sha256 == HASH_1
+    assert result.state.invocations[-1].caller_event == "workflow_dispatch"
+
+
+def test_force_review_fails_closed_without_dispatch_or_authorized_override():
+    existing = budget.LedgerState.initial(
+        REPOSITORY,
+        PR,
+        "claude",
+        invocations=(invocation(),),
+    )
+    force_request = replace(request(run_id=700), force_review=True)
+    pull_request_provenances = claim_provenances(existing, force_request)
+
+    wrong_event = budget.claim(existing, force_request, pull_request_provenances)
+    assert not wrong_event.allow_invocation
+    assert wrong_event.decision == "state_invalid"
+    assert wrong_event.stop_reason == "provenance_mismatch"
+
+    dispatch_provenances = dict(pull_request_provenances)
+    dispatch_provenances[(700, 1)] = replace(
+        dispatch_provenances[(700, 1)], caller_event="workflow_dispatch"
+    )
+    no_override = budget.claim(existing, force_request, dispatch_provenances)
+    assert not no_override.allow_invocation
+    assert no_override.decision == "round_budget_exhausted"
+
+
+def test_normal_same_head_remains_zero_call_when_override_label_exists():
+    existing = budget.LedgerState.initial(
+        REPOSITORY,
+        PR,
+        "claude",
+        invocations=(invocation(),),
+    )
+    normal_request = replace(
+        request(run_id=700),
+        override_events=(
+            budget.OverrideEvent(9001, "labeled", "review-budget-override", "write"),
+        ),
+    )
+
+    result = budget.claim(
+        existing, normal_request, claim_provenances(existing, normal_request)
+    )
+
+    assert not result.allow_invocation
+    assert result.decision == "duplicate_head"
+    assert result.state.consumed_override_event_ids == ()
+
+
 def test_finalization_matches_one_claim_and_rejects_identity_or_status_drift():
     state = claimed_state()
     finalized = budget.finalize(state, finalize_request(), current_provenances(state))

--- a/tests/test_review_invocation_budget_action.py
+++ b/tests/test_review_invocation_budget_action.py
@@ -281,6 +281,7 @@ class FakeGitHub:
             "EXPECTED_HEAD_SHA": head,
             "FULL_DIFF_SHA256": full_hash,
             "DIFF_MODE": diff_mode,
+            "FORCE_REVIEW": "false",
             "INPUT_FILES_JSON": json.dumps([str(input_path)]),
             "AUTHENTICATED_REVIEW_JSON": json.dumps({
                 "success": False,
@@ -338,6 +339,7 @@ def test_action_metadata_has_one_inert_environment_bridge():
     assert set(document["inputs"]) == {
         "github-token", "mode", "reviewer", "pr-number", "expected-head-sha",
         "full-diff-sha256", "diff-mode", "input-files-json", "authenticated-review-json",
+        "force-review",
         "model-route-json", "effort", "checkpoint-file", "actual-call-count",
         "elapsed-seconds", "outcome", "stop-reason", "remaining-finding-ids-json",
     }
@@ -348,6 +350,7 @@ def test_action_metadata_has_one_inert_environment_bridge():
     }
     assert {name: value["default"] for name, value in document["inputs"].items() if "default" in value} == {
         "actual-call-count": "0",
+        "force-review": "false",
         "elapsed-seconds": "0",
         "outcome": "checkpoint_failure",
         "stop-reason": "",

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -131,6 +131,10 @@ def _v3_state(
         "normalized_count": 3,
         "filtered_max_severity": "HIGH",
     }
+    if "review_execution" not in changes:
+        state["review_execution"] = (
+            "reused" if changes.get("diff_mode") == "unchanged" else "performed"
+        )
     state.update(changes)
     return state
 
@@ -146,7 +150,10 @@ def _v3_body(
         "stale" if state.get("successful_head") is not None else "failure"
     )
     run_url = f"https://github.com/example/repo/actions/runs/{state.get('run_id')}"
-    meta = [f"- Status: {status}", f"- Run: {run_url}"]
+    meta = [f"- Status: {status}"]
+    if state.get("review_execution") is not None:
+        meta.append(f"- Execution: {state.get('review_execution')}")
+    meta.append(f"- Run: {run_url}")
     if state.get("successful_head") is not None:
         meta.append(f"- Reviewed: {state.get('successful_head')}")
     if state.get("accepted_count") is not None:
@@ -190,6 +197,9 @@ def _upgrade_claude_v2_fixture(comment: dict) -> dict:
     for key, value in old.items():
         if key != "schema":
             state[key] = value
+    state["review_execution"] = (
+        "reused" if state.get("diff_mode") == "unchanged" else "performed"
+    )
     state["schema"] = 3 if old.get("schema") == 2 else old.get("schema")
     for required in (
         "reviewer", "pr", "run_id", "run_attempt", "attempt_head", "successful_head",
@@ -242,6 +252,9 @@ def _upgrade_gemini_v2_fixture(comment: dict) -> dict:
     for key, value in old.items():
         if key != "schema":
             state[key] = value
+    state["review_execution"] = (
+        "reused" if state.get("diff_mode") == "unchanged" else "performed"
+    )
     state["schema"] = 3 if old.get("schema") == 2 else old.get("schema")
     for required in (
         "reviewer", "pr", "run_id", "run_attempt", "attempt_head", "successful_head",
@@ -1318,7 +1331,8 @@ def test_claude_budget_claim_is_durable_before_provider_and_every_model_path_is_
         "full-diff-sha256": (
             "${{ steps.stage-claude-budget-input.outputs.full_diff_sha256 }}"
         ),
-        "diff-mode": "${{ steps.prepare-diff.outputs.diff-mode || 'unavailable' }}",
+            "diff-mode": "${{ steps.prepare-diff.outputs.diff-mode || 'unavailable' }}",
+            "force-review": "${{ inputs.force_review && 'true' || 'false' }}",
         "input-files-json": (
             "${{ steps.stage-claude-budget-input.outputs.input_files_json }}"
         ),
@@ -1854,7 +1868,8 @@ def test_gemini_budget_claim_precedes_provider_and_guards_every_new_diff_path():
         "full-diff-sha256": (
             "${{ steps.stage-gemini-budget-input.outputs.full_diff_sha256 }}"
         ),
-        "diff-mode": "${{ steps.prepare-diff.outputs.diff-mode || 'unavailable' }}",
+            "diff-mode": "${{ steps.prepare-diff.outputs.diff-mode || 'unavailable' }}",
+            "force-review": "${{ inputs.force_review && 'true' || 'false' }}",
         "input-files-json": (
             "${{ steps.stage-gemini-budget-input.outputs.input_files_json }}"
         ),
@@ -2743,6 +2758,7 @@ def test_shared_diff_wiring_is_exact_and_scope_safe():
             "pr-number": pr_number,
             "previous-sha": f"${{{{ steps.{_step_id(job, collector_name)}.outputs.previous_sha }}}}",
             "previous-full-hash": f"${{{{ steps.{_step_id(job, collector_name)}.outputs.previous_full_hash }}}}",
+            "force-full": "${{ inputs.force_review && 'true' || 'false' }}",
             "context-lines": context_lines,
             "output-directory": "${{ runner.temp }}",
         }
@@ -2968,6 +2984,56 @@ def test_shared_diff_models_use_one_selected_artifact_and_scope_prompt():
     assert _step(gemini, "gemini-review", "Get PR details")["env"]["PR_NUMBER"] == (
         "${{ inputs.pr_number || github.event.pull_request.number }}"
     )
+
+
+def test_force_review_is_opt_in_and_forces_a_full_diff_for_both_reviewers():
+    for workflow_name, job_name, prepare_name, claim_name in (
+        (
+            "claude-code-review.yml",
+            "claude-review",
+            "Prepare review diff",
+            "Claim Claude review budget",
+        ),
+        (
+            "gemini-auto-review.yml",
+            "gemini-review",
+            "Prepare review diff",
+            "Claim Gemini review budget",
+        ),
+    ):
+        workflow = _load(workflow_name)
+        force_input = workflow["on"]["workflow_call"]["inputs"]["force_review"]
+        assert force_input["type"] == "boolean"
+        assert force_input["default"] == "false"
+        assert _step(workflow, job_name, prepare_name)["with"]["force-full"] == (
+            "${{ inputs.force_review && 'true' || 'false' }}"
+        )
+        assert _step(workflow, job_name, claim_name)["with"]["force-review"] == (
+            "${{ inputs.force_review && 'true' || 'false' }}"
+        )
+        enforce = _step(workflow, job_name, "Enforce force-review claim")
+        assert "inputs.force_review" in enforce["if"]
+        assert "allow-invocation != 'true'" in enforce["if"]
+        assert "exit 1" in enforce["run"]
+
+    for workflow_name, job_name in (
+        ("claude-code-review.yml", "claude-review"),
+        ("gemini-auto-review.yml", "gemini-review"),
+    ):
+        caller = yaml.load(
+            (
+                ROOT
+                / "examples/baseline-workflows/.github/workflows"
+                / workflow_name
+            ).read_text(encoding="utf-8"),
+            Loader=yaml.BaseLoader,
+        )
+        dispatch_inputs = caller["on"]["workflow_dispatch"]["inputs"]
+        assert dispatch_inputs["force_review"]["default"] == "false"
+        assert dispatch_inputs["pr_number"]["required"] == "true"
+        assert caller["jobs"][job_name]["with"]["force_review"] == (
+            "${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}"
+        )
 
 
 def test_collect_strips_sticky_meta_from_injected_context(tmp_path):
@@ -3359,6 +3425,26 @@ def _run_reviewer_collector(
         comments_fail=comments_fail,
     )
     return previous
+
+
+@pytest.mark.parametrize("reviewer", ["claude", "gemini"])
+def test_reviewer_collector_authenticates_force_dispatch_state(tmp_path, reviewer):
+    forced = _collector_comment(
+        reviewer,
+        run_id=20,
+        text="FORCED REVIEW RESULT",
+        comment_id=20,
+        head="bb" * 20,
+    )
+    run = _review_run_fixtures([forced], reviewer)[0]
+    run.update({"event": "workflow_dispatch", "head_sha": "aa" * 20, "pull_requests": []})
+
+    previous = _run_reviewer_collector(
+        tmp_path, reviewer, [forced], workflow_runs=[run]
+    )
+
+    assert previous is not None
+    assert "FORCED REVIEW RESULT" in previous
 
 
 @pytest.mark.parametrize("reviewer", ["claude", "gemini"])
@@ -3991,6 +4077,7 @@ const github = {
   paginate: async (method) => {
     if (method === github.rest.checks.listForRef) return checkRuns;
     if (method === github.rest.actions.listJobsForWorkflowRunAttempt) return fx.runJobs || [];
+    if (method === github.rest.pulls.listCommits) return fx.pullCommits || [];
     listCommentCalls += 1;
     for (const item of (fx.injectCommentsAtListCall || {})[String(listCommentCalls)] || []) {
       if (!comments.some((comment) => comment.id === item.id)) comments.push(JSON.parse(JSON.stringify(item)));
@@ -4022,7 +4109,8 @@ const github = {
         },
     },
     pulls: {
-      get: async () => ({ data: { head: { sha: fx.currentHead } } }),
+      get: async () => ({ data: fx.pullRequest || { head: { sha: fx.currentHead } } }),
+      listCommits: 'LIST_COMMITS',
     },
     checks: {
       listForRef: async (a) => {
@@ -4170,6 +4258,8 @@ def _run_upsert(
     current_workflow_run: dict | None = None,
     inject_comments_at_list_call: dict[int, list[dict]] | None = None,
     node_preload: Path | None = None,
+    pull_request: dict | None = None,
+    pull_commits: list[dict] | None = None,
 ) -> list:
     workflow = _load(workflow_file)
     script = _step(workflow, job, step_name)["with"]["script"]
@@ -4215,6 +4305,8 @@ def _run_upsert(
         "workflowRunListResponses": workflow_run_list_responses,
         "checkRunListResponses": check_run_list_responses,
         "currentWorkflowRun": current_workflow_run,
+        "pullRequest": pull_request,
+        "pullCommits": pull_commits or [],
         "runJobs": [{"name": "OpenCode Auto PR Review / opencode-canonicalize", "conclusion": "success"}],
         "runJobsByAttempt": run_jobs_by_attempt or {},
     }
@@ -4432,6 +4524,8 @@ def test_claude_unchanged_v3_success_advances_head_and_preserves_body_hash_quali
     assert state["attempt_head"] == current_head
     assert state["successful_head"] == current_head
     assert state["full_diff_sha256"] == "12" * 32
+    assert state["review_execution"] == "reused"
+    assert "- Execution: reused" in body
     assert [state[key] for key in (
         "accepted_count", "filtered_count", "normalized_count", "filtered_max_severity"
     )] == [1, 2, 3, "HIGH"]
@@ -4485,7 +4579,8 @@ def test_claude_oversize_success_becomes_candidate_oversize_without_truncation(t
 
 @node_required
 def test_claude_oversize_stale_envelope_leaves_prior_success_untouched(tmp_path):
-    prior = _v3_body(_v3_state(run_id=1), "X" * 64810)
+    empty = _v3_body(_v3_state(run_id=1), "")
+    prior = empty + ("X" * (65_533 - len(empty.encode("utf-8"))))
     assert len(prior.encode("utf-8")) == 65533
     existing = _bot("github-actions[bot]", prior, 11)
 
@@ -4615,6 +4710,33 @@ def _single_mutation_body(calls: list) -> str:
         return canonical[-1][1]["body"]
     assert len(mutations) == 1
     return mutations[0][1]["body"]
+
+
+@node_required
+@pytest.mark.parametrize("reviewer", ["claude", "gemini"])
+@pytest.mark.parametrize(
+    ("outcome", "expected_execution"),
+    [("skipped", "not_performed"), ("failure", "performed")],
+)
+def test_provider_step_outcome_controls_execution_state(
+    tmp_path, reviewer, outcome, expected_execution
+):
+    upsert = _claude_upsert if reviewer == "claude" else _gemini_upsert
+    calls = upsert(
+        tmp_path,
+        outcome,
+        [],
+        with_review=False,
+        canonical_outcome="skipped",
+        document_valid="false",
+        budget_allow_invocation="true",
+    )
+
+    body = _single_mutation_body(calls)
+    state = _posted_state(body)
+    assert state["attempt_status"] == "failure"
+    assert state["review_execution"] == expected_execution
+    assert f"- Execution: {expected_execution}" in body
 
 
 def _updated_comment_body(calls: list, comment_id: int) -> str:
@@ -4951,7 +5073,7 @@ def test_upsert_prefers_newest_comment_for_duplicate_authenticated_generation(
         ("gemini", GEMINI_HEADER, GEMINI_V3_MARKER, _gemini_upsert),
     ],
 )
-@pytest.mark.parametrize("mismatch", ("repository", "head", "pr", "workflow", "event"))
+@pytest.mark.parametrize("mismatch", ("repository", "head", "pr", "workflow"))
 def test_upsert_rejects_mismatched_state_run_provenance(
     tmp_path, reviewer, header, marker, upsert, mismatch
 ):
@@ -4986,9 +5108,6 @@ def test_upsert_rejects_mismatched_state_run_provenance(
         forged_run["referenced_workflows"][0]["path"] = (
             "jhw7500/automation/.github/workflows/opencode-auto-review.yml@refs/tags/v1.46"
         )
-    else:
-        forged_run["event"] = "workflow_dispatch"
-
     calls = upsert(
         tmp_path,
         "success",
@@ -5687,6 +5806,8 @@ def test_gemini_unchanged_v3_success_advances_head_and_preserves_body_hash_quali
     assert state["attempt_status"] == "success"
     assert state["successful_head"] == current_head
     assert state["full_diff_sha256"] == "12" * 32
+    assert state["review_execution"] == "reused"
+    assert "- Execution: reused" in body
     assert [state[key] for key in (
         "accepted_count", "filtered_count", "normalized_count", "filtered_max_severity"
     )] == [4, 5, 6, "CRITICAL"]
@@ -6284,6 +6405,7 @@ def test_dispatch_upsert_carries_json_marker_forward(tmp_path):
     env = {
         "ISSUE_NUMBER": "7", "RUN_URL": "run-url", "MODEL_USED": "m",
         "OUTCOME": "success", "RESPONSE": "new dispatch review", "ERRORS": "",
+        "REVIEWED_SHA": "ab" * 20,
     }
     calls = _run_upsert(
         tmp_path, "gemini-dispatch.yml", "review", "Upsert PR comment (Gemini Review)",
@@ -6292,6 +6414,7 @@ def test_dispatch_upsert_carries_json_marker_forward(tmp_path):
     updates = [c for c in calls if c[0] == "update"]
     assert [c[1]["comment_id"] for c in updates] == [21]
     assert "last_success_sha" in updates[0][1]["body"]
+    assert f"- Reviewed: {'ab' * 20}" in updates[0][1]["body"]
 
 
 @node_required
@@ -6305,6 +6428,7 @@ def test_dispatch_upsert_failure_preserves_sticky_and_stamps_attempt(tmp_path):
     env = {
         "ISSUE_NUMBER": "7", "RUN_URL": "run-url", "MODEL_USED": "m",
         "OUTCOME": "failure", "RESPONSE": "", "ERRORS": "boom",
+        "REVIEWED_SHA": "ab" * 20,
     }
     calls = _run_upsert(
         tmp_path, "gemini-dispatch.yml", "review", "Upsert PR comment (Gemini Review)",
@@ -6400,6 +6524,83 @@ def test_dispatch_extract_ignores_forged_human_json_marker(tmp_path):
     )
     outputs = _dispatch_extract_outputs(tmp_path, [forged])
     assert "last_success_sha" not in outputs
+
+
+@node_required
+def test_dispatch_resolves_current_pr_head_and_validates_requested_commit_membership(
+    tmp_path,
+):
+    default_head = "ef" * 20
+    current_head = "ab" * 20
+    older_commit = "cd" * 20
+    fixture_files = {default_head: "default-only", current_head: "pr-head-only"}
+    pull_request = {"number": 7, "head": {"sha": current_head}}
+    pull_commits = [{"sha": older_commit}, {"sha": current_head}]
+    for name in ("current", "commit", "foreign"):
+        (tmp_path / name).mkdir()
+
+    current_calls = _run_upsert(
+        tmp_path / "current",
+        "gemini-dispatch.yml",
+        "dispatch",
+        "Resolve review target",
+        {"ISSUE_NUMBER": "7", "TARGET_COMMIT": ""},
+        [],
+        context=DISPATCH_CONTEXT,
+        pull_request=pull_request,
+        pull_commits=pull_commits,
+    )
+    reviewed = [call for call in current_calls if call[:2] == ["output", "reviewed_sha"]]
+    assert reviewed == [
+        ["output", "reviewed_sha", current_head]
+    ]
+    assert current_head != default_head
+    assert fixture_files[reviewed[0][2]] == "pr-head-only"
+
+    commit_calls = _run_upsert(
+        tmp_path / "commit",
+        "gemini-dispatch.yml",
+        "dispatch",
+        "Resolve review target",
+        {"ISSUE_NUMBER": "7", "TARGET_COMMIT": older_commit[:12]},
+        [],
+        context=DISPATCH_CONTEXT,
+        pull_request=pull_request,
+        pull_commits=pull_commits,
+    )
+    assert [call for call in commit_calls if call[:2] == ["output", "reviewed_sha"]] == [
+        ["output", "reviewed_sha", older_commit]
+    ]
+
+    _run_upsert(
+        tmp_path / "foreign",
+        "gemini-dispatch.yml",
+        "dispatch",
+        "Resolve review target",
+        {"ISSUE_NUMBER": "7", "TARGET_COMMIT": "ef" * 20},
+        [],
+        context=DISPATCH_CONTEXT,
+        pull_request=pull_request,
+        pull_commits=pull_commits,
+        expect_error=True,
+    )
+
+
+def test_dispatch_checks_out_resolved_head_trusts_ci_workspace_and_records_sha():
+    workflow = _load("gemini-dispatch.yml")
+    checkout = _step(workflow, "review", "Checkout repository")
+    assert checkout["with"]["ref"] == "${{ needs.dispatch.outputs.reviewed_sha }}"
+    assert checkout["with"]["fetch-depth"] == "0"
+
+    for step_name in (
+        "Run Gemini pull request review (primary)",
+        "Run Gemini pull request review (fallback)",
+    ):
+        model = _step(workflow, "review", step_name)
+        assert model["env"]["GEMINI_CLI_TRUST_WORKSPACE"] == "true"
+
+    upsert = _step(workflow, "review", "Upsert PR comment (Gemini Review)")
+    assert upsert["env"]["REVIEWED_SHA"] == "${{ needs.dispatch.outputs.reviewed_sha }}"
 
 
 def _extract_gemini_python() -> str:

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -25,6 +25,7 @@ from release_fixture_helpers import (
     HISTORICAL_REVIEW_WORKFLOWS,
     V145_REVIEW_FIXTURE_ROOT,
     restore_historical_review_workflows,
+    restore_pre_force_review_callers,
     restore_v145_review_workflows,
 )
 
@@ -214,6 +215,7 @@ def current_release_repo(tmp_path: Path) -> tuple[Path, str]:
 def restore_v1462_workflow_fixtures(repo: Path) -> None:
     """Restore authenticated v1.46.2 workflow bytes without consulting the worktree."""
 
+    restore_pre_force_review_callers(repo)
     tree = release_verifier.VerifiedCommitTree.open(
         ROOT, V1462_WORKFLOW_FIXTURE_COMMIT
     )
@@ -1828,8 +1830,10 @@ def test_v147_budget_helper_semantics_bind_live_ast_relationships(
         )
     elif mutation == "claim-gate-dead-body":
         substitute(
-            "    if any(item.head_sha == request.head_sha "
-            "for item in validated.invocations):\n"
+            "    if not request.force_review and any(\n"
+            "        item.head_sha == request.head_sha "
+            "for item in validated.invocations\n"
+            "    ):\n"
             "        return refuse(validated, request, \"duplicate_head\")\n",
             "    if False:\n"
             "        return refuse(validated, request, \"duplicate_head\")\n",
@@ -1868,13 +1872,14 @@ def test_v147_budget_helper_semantics_bind_live_ast_relationships(
         )
     elif mutation == "caller-event-dead-decoy":
         substitute(
-            'provenance.caller_event != "pull_request"',
-            'provenance.caller_event != "workflow_call"',
+            'provenance.caller_event not in {"pull_request", "workflow_dispatch"}',
+            'provenance.caller_event not in {"pull_request"}',
         )
         source += (
             "\n\ndef _dead_caller_event_decoy(provenance):\n"
             "    if False:\n"
-            '        return provenance.caller_event != "pull_request"\n'
+            '        return provenance.caller_event not in '
+            '{"pull_request", "workflow_dispatch"}\n'
         )
     elif mutation == "referenced-workflow-cardinality-dead-decoy":
         substitute("        if len(central) != 1:\n", "        if not central:\n")

--- a/tests/test_workflow_release_bundle.py
+++ b/tests/test_workflow_release_bundle.py
@@ -202,6 +202,7 @@ def test_prepare_review_diff_composite_action_has_exact_safe_shell_contract() ->
             "pr-number": {"required": "true"},
             "previous-sha": {"required": "false", "default": ""},
             "previous-full-hash": {"required": "false", "default": ""},
+            "force-full": {"required": "false", "default": "false"},
             "context-lines": {"required": "false", "default": "3"},
             "output-directory": {"required": "true"},
         },
@@ -227,20 +228,30 @@ def test_prepare_review_diff_composite_action_has_exact_safe_shell_contract() ->
                         "PR_NUMBER": "${{ inputs.pr-number }}",
                         "PREVIOUS_SHA": "${{ inputs.previous-sha }}",
                         "PREVIOUS_FULL_HASH": "${{ inputs.previous-full-hash }}",
+                        "FORCE_FULL": "${{ inputs.force-full }}",
                         "CONTEXT_LINES": "${{ inputs.context-lines }}",
                         "OUTPUT_DIRECTORY": "${{ inputs.output-directory }}",
                     },
                     "run": (
-                        'python3 "$GITHUB_ACTION_PATH/prepare_review_diff.py" '
-                        '--repository "$GITHUB_REPOSITORY" '
-                        '--pr-number "$PR_NUMBER" '
-                        '--previous-sha "$PREVIOUS_SHA" '
-                        '--previous-full-hash "$PREVIOUS_FULL_HASH" '
-                        '--context-lines "$CONTEXT_LINES" '
-                        '--full-output "$OUTPUT_DIRECTORY/review-full.diff" '
-                        '--delta-output "$OUTPUT_DIRECTORY/review-delta.diff" '
-                        '--manifest-output "$OUTPUT_DIRECTORY/review-scope.json" '
-                        '--github-output "$GITHUB_OUTPUT"'
+                        "set -euo pipefail\n"
+                        "force_args=()\n"
+                        "if [[ \"$FORCE_FULL\" == 'true' ]]; then\n"
+                        "  force_args+=(--force-full)\n"
+                        "elif [[ \"$FORCE_FULL\" != 'false' ]]; then\n"
+                        "  echo 'force-full must be true or false' >&2\n"
+                        "  exit 2\n"
+                        "fi\n"
+                        'python3 "$GITHUB_ACTION_PATH/prepare_review_diff.py" \\\n'
+                        '  --repository "$GITHUB_REPOSITORY" \\\n'
+                        '  --pr-number "$PR_NUMBER" \\\n'
+                        '  --previous-sha "$PREVIOUS_SHA" \\\n'
+                        '  --previous-full-hash "$PREVIOUS_FULL_HASH" \\\n'
+                        '  --context-lines "$CONTEXT_LINES" \\\n'
+                        '  --full-output "$OUTPUT_DIRECTORY/review-full.diff" \\\n'
+                        '  --delta-output "$OUTPUT_DIRECTORY/review-delta.diff" \\\n'
+                        '  --manifest-output "$OUTPUT_DIRECTORY/review-scope.json" \\\n'
+                        '  --github-output "$GITHUB_OUTPUT" \\\n'
+                        '  "${force_args[@]}"\n'
                     ),
                 }
             ],
@@ -282,6 +293,7 @@ def test_prepare_review_diff_action_run_passes_quoted_environment_values_to_help
         "PR_NUMBER": pr_number,
         "PREVIOUS_SHA": "a" * 40,
         "PREVIOUS_FULL_HASH": "b" * 64,
+        "FORCE_FULL": "false",
         "CONTEXT_LINES": "20",
         "OUTPUT_DIRECTORY": str(runner_temp),
     }
@@ -382,7 +394,7 @@ def test_review_invocation_budget_action_has_exact_safe_contract() -> None:
     document = yaml.load(payload, Loader=yaml.BaseLoader)
 
     assert hashlib.sha256(payload).hexdigest() == (
-        "42462dad335073794bd5c46e1993e02e4dc9824113d1b36fd5c6b89dc0583a9c"
+        "70b50ce482ff0e54df9fff88d5126cd8e760ed8bdabfefcc2f2ccdc639cb693b"
     )
     assert document == release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION
 


### PR DESCRIPTION
## Summary

- add an opt-in force_review input for Claude/Gemini manual reruns while preserving the zero-call same-HEAD default
- bind forced execution and published state to the requested PR HEAD plus exact run/attempt provenance
- validate Gemini dispatch commit membership, check out the reviewed SHA explicitly, and enable trusted workspace execution
- extend release verification, canonical callers, documentation, and regression coverage for performed/reused/not_performed states

## Safety contract

- force_review defaults to false
- only workflow_dispatch plus one authorized, unconsumed review-budget-override event can claim the bounded override
- skipped provider steps are recorded as not_performed; provider success/failure records performed
- issue #52 is not changed by this PR

## Validation

- python3 -m pytest -q --tb=short: 2742 passed, 48 subtests passed
- tests/test_review_workflow_logic.py: 1556 passed
- tests/test_verify_workflow_release.py: 537 passed
- related release/budget/diff/canonical suite: 202 passed
- actionlint 1.7.12 (YAML/expression validation), py_compile, git diff --check: passed
- independent re-review: no Critical/Important findings

Closes #58