### PR TITLE
chore(workflows): default rollout to v1.49

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.48",
+  "automation_ref": "v1.49",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -33,7 +33,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.48"
+    assert config.automation_ref == "v1.49"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
## Summary

- advance the fleet default from immutable v1.48 to verified v1.49
- update the closed catalog expectation only

## Release evidence

- v1.49 annotated tag resolves to a394b653db79d153d56eb8eb7d7620595cc12ef7
- local and remote workflow release verification passed
- rollout/catalog/release tests: 250 passed
- git diff --check: passed

Follow-up rollout for #58.