### PR TITLE
fix(review): preserve rejected candidate diagnostics

### DIFF
--- a/.github/actions/canonicalize-review/canonicalize_review.py
+++ b/.github/actions/canonicalize-review/canonicalize_review.py
@@ -109,6 +109,26 @@ class CandidateReason:
 
 
 @dataclass(frozen=True)
+class CandidateValidation:
+    attempt: Literal["initial"]
+    sha256: str
+    valid: Literal[False]
+    rule: str
+    line: int
+    column: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "attempt": self.attempt,
+            "sha256": self.sha256,
+            "valid": self.valid,
+            "rule": self.rule,
+            "line": self.line,
+            "column": self.column,
+        }
+
+
+@dataclass(frozen=True)
 class CanonicalizationResult:
     document_valid: bool
     accepted_count: int
@@ -117,10 +137,11 @@ class CanonicalizationResult:
     filtered_max_severity: Literal["none", "MEDIUM", "HIGH", "CRITICAL"]
     failure_reason: str
     candidate_reasons: tuple[CandidateReason, ...]
+    candidate_validations: tuple[CandidateValidation, ...]
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "schema": 1,
+            "schema": 2,
             "document_valid": self.document_valid,
             "accepted_count": self.accepted_count,
             "filtered_count": self.filtered_count,
@@ -128,6 +149,9 @@ class CanonicalizationResult:
             "filtered_max_severity": self.filtered_max_severity,
             "failure_reason": self.failure_reason,
             "candidate_reasons": [reason.to_dict() for reason in self.candidate_reasons],
+            "candidate_validations": [
+                validation.to_dict() for validation in self.candidate_validations
+            ],
         }
 
 
@@ -140,6 +164,14 @@ class _Block:
     low_severity: bool
     title: str
     lines: tuple[str, ...]
+
+
+class _CandidateSyntaxError(ValueError):
+    def __init__(self, rule: str, line: int, column: int = 1):
+        super().__init__(rule)
+        self.rule = rule
+        self.line = line
+        self.column = column
 
 
 @dataclass(frozen=True)
@@ -188,8 +220,13 @@ def stable_finding_id(reviewer: str, anchor: SourceAnchor, severity: str, title:
     return "RVW-" + hashlib.sha256(identity.encode("utf-8")).hexdigest()[:12]
 
 
-def _hard(reason: str) -> CanonicalizationResult:
-    return CanonicalizationResult(False, 0, 0, 0, "none", reason, ())
+def _hard(
+    reason: str,
+    candidate_validations: tuple[CandidateValidation, ...] = (),
+) -> CanonicalizationResult:
+    return CanonicalizationResult(
+        False, 0, 0, 0, "none", reason, (), candidate_validations
+    )
 
 
 def _strict_object(value: str, keys: set[str]) -> dict[str, object] | None:
@@ -242,61 +279,77 @@ def _parse_document(text: str) -> dict[str, list[_Block]]:
     if stripped in {"No blocking issues found.", "No validated blocking issues found."}:
         return {name: [] for name in SECTION_NAMES}
     lines = text.splitlines()
-    sections: dict[str, list[str]] = {}
+    sections: dict[str, list[tuple[int, str]]] = {}
+    section_heading_lines: dict[str, int] = {}
     section_order: list[str] = []
     active: str | None = None
-    for line in lines:
+    for line_number, line in enumerate(lines, 1):
         if line.startswith("####"):
             if active is None:
-                raise ValueError("finding_before_section")
-            sections[active].append(line)
+                raise _CandidateSyntaxError("finding_before_section", line_number)
+            sections[active].append((line_number, line))
         elif line.startswith("###"):
             if line not in {f"### {name}" for name in SECTION_NAMES}:
-                raise ValueError(
+                raise _CandidateSyntaxError(
                     "unknown_section_after_document"
                     if sections
-                    else "unknown_section_before_document"
+                    else "unknown_section_before_document",
+                    line_number,
                 )
             active = line[4:]
             if active in sections:
-                raise ValueError("duplicate_section")
+                raise _CandidateSyntaxError("duplicate_section", line_number)
             sections[active] = []
+            section_heading_lines[active] = line_number
             section_order.append(active)
         elif active is not None:
-            sections[active].append(line)
+            sections[active].append((line_number, line))
         elif line.strip():
-            raise ValueError("preamble")
+            raise _CandidateSyntaxError("preamble", line_number)
     if "New findings" not in sections:
-        raise ValueError("missing_new_findings")
+        raise _CandidateSyntaxError("missing_new_findings", 1)
     parsed: dict[str, list[_Block]] = {name: [] for name in SECTION_NAMES}
     index = 0
     for section in section_order:
-        contents = sections.get(section, [])
+        records = sections.get(section, [])
+        contents = [line for _, line in records]
         heading_positions = [position for position, line in enumerate(contents) if line.startswith("####")]
         if not heading_positions:
-            meaningful = [line for line in contents if line.strip()]
-            if section == "New findings" and meaningful not in (
+            meaningful = [(line_number, line) for line_number, line in records if line.strip()]
+            meaningful_lines = [line for _, line in meaningful]
+            if section == "New findings" and meaningful_lines not in (
                 ["None"],
                 ["None", "No validated blocking issues found."],
             ):
-                raise ValueError("invalid_empty_new_findings")
+                raise _CandidateSyntaxError(
+                    "invalid_empty_new_findings",
+                    meaningful[0][0] if meaningful else section_heading_lines[section],
+                )
             if section != "New findings" and meaningful:
-                raise ValueError("content_without_finding")
+                raise _CandidateSyntaxError("content_without_finding", meaningful[0][0])
             continue
         if section == "New findings" and any(line.strip() == "None" for line in contents):
-            raise ValueError("none_with_finding")
+            none_position = next(
+                position for position, line in enumerate(contents) if line.strip() == "None"
+            )
+            raise _CandidateSyntaxError("none_with_finding", records[none_position][0])
         if any(line.strip() for line in contents[:heading_positions[0]]):
-            raise ValueError("section_preamble")
+            preamble_position = next(
+                position
+                for position, line in enumerate(contents[:heading_positions[0]])
+                if line.strip()
+            )
+            raise _CandidateSyntaxError("section_preamble", records[preamble_position][0])
         for block_number, start in enumerate(heading_positions):
             parsed_heading = _heading(contents[start])
             if parsed_heading is None:
-                raise ValueError("invalid_finding_heading")
+                raise _CandidateSyntaxError("invalid_finding_heading", records[start][0])
             end = heading_positions[block_number + 1] if block_number + 1 < len(heading_positions) else len(contents)
             finding_id, severity, low_severity, title = parsed_heading
             parsed[section].append(_Block(index, section, finding_id, severity, low_severity, title, tuple(contents[start + 1:end])))
             index += 1
             if index > MAX_CANDIDATE_BLOCKS:
-                raise ValueError("too_many_blocks")
+                raise _CandidateSyntaxError("too_many_blocks", records[start][0])
     return parsed
 
 
@@ -797,7 +850,21 @@ def canonicalize(request: CanonicalizationRequest) -> CanonicalizationResult:
                         f"review-canonicalization-diagnostic: {diagnostic}",
                         file=sys.stderr,
                     )
-                    result = _hard("ambiguous_document")
+                    line = error.line if isinstance(error, _CandidateSyntaxError) else 1
+                    column = error.column if isinstance(error, _CandidateSyntaxError) else 1
+                    result = _hard(
+                        "ambiguous_document",
+                        (
+                            CandidateValidation(
+                                "initial",
+                                hashlib.sha256(payload).hexdigest(),
+                                False,
+                                diagnostic,
+                                line,
+                                column,
+                            ),
+                        ),
+                    )
                 else:
                     accepted: list[tuple[_Block, _Finding]] = []
                     still_open: list[_PriorFinding] = []
@@ -875,6 +942,7 @@ def canonicalize(request: CanonicalizationRequest) -> CanonicalizationResult:
                     result = CanonicalizationResult(
                         True, len(canonical_new) + len(still_open), filtered, normalized, maximum, "",
                         tuple(sorted(reasons, key=lambda item: item.index)),
+                        (),
                     )
                     canonical_payload = _render_document(
                         canonical_new,
@@ -927,6 +995,12 @@ def _summary(result: CanonicalizationResult) -> list[str]:
         f"candidate[{item.index}]: section={item.section} outcome={item.outcome} "
         f"reason={item.reason} claimed_severity={item.claimed_severity}"
         for item in result.candidate_reasons
+    )
+    lines.extend(
+        "candidate-validation: "
+        f"attempt={item.attempt} sha256={item.sha256} valid=false "
+        f"rule={item.rule} line={item.line} column={item.column}"
+        for item in result.candidate_validations
     )
     return lines
 

--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -947,6 +947,11 @@ def claim(state: LedgerState | None, request: ClaimRequest,
     if not request.force_review and any(
         item.head_sha == request.head_sha for item in validated.invocations
     ):
+        if (
+            request.authenticated_review.head_sha == request.head_sha
+            and request.authenticated_review.covers_hash(request.full_diff_sha256)
+        ):
+            return refuse(validated, request, "authenticated_reuse")
         return refuse(validated, request, "duplicate_head")
     if not request.force_review and any(
         item.full_diff_sha256 == request.full_diff_sha256

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -1871,6 +1871,23 @@ jobs:
           retention-days: 7
           overwrite: false
 
+      - name: Enforce authenticated review budget decision
+        if: ${{ always() && !cancelled() }}
+        shell: bash
+        env:
+          BUDGET_ALLOW_INVOCATION: ${{ steps.review-budget-claim.outputs.allow-invocation }}
+          BUDGET_DECISION: ${{ steps.review-budget-claim.outputs.decision }}
+        run: |
+          set -euo pipefail
+          if [[ "$BUDGET_ALLOW_INVOCATION" == 'true' && "$BUDGET_DECISION" == 'claimed' ]]; then
+            exit 0
+          fi
+          if [[ "$BUDGET_ALLOW_INVOCATION" == 'false' && "$BUDGET_DECISION" == 'authenticated_reuse' ]]; then
+            exit 0
+          fi
+          echo "::error::Gemini review has no authenticated checkpoint for this attempt ($BUDGET_DECISION)"
+          exit 1
+
   skipped:
     permissions: {}
     name: Workflow Skipped

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -600,6 +600,23 @@ jobs:
           retention-days: 7
           overwrite: false
 
+      - name: Enforce authenticated review budget decision
+        if: ${{ always() && !cancelled() }}
+        shell: bash
+        env:
+          BUDGET_ALLOW_INVOCATION: ${{ steps.review-budget-claim.outputs.allow-invocation }}
+          BUDGET_DECISION: ${{ steps.review-budget-claim.outputs.decision }}
+        run: |
+          set -euo pipefail
+          if [[ "$BUDGET_ALLOW_INVOCATION" == 'true' && "$BUDGET_DECISION" == 'claimed' ]]; then
+            exit 0
+          fi
+          if [[ "$BUDGET_ALLOW_INVOCATION" == 'false' && "$BUDGET_DECISION" == 'authenticated_reuse' ]]; then
+            exit 0
+          fi
+          echo "::error::OpenCode review has no authenticated checkpoint for this attempt ($BUDGET_DECISION)"
+          exit 1
+
   opencode-review:
     needs: [check-enabled, opencode-prepare]
     if: >-
@@ -955,6 +972,7 @@ jobs:
 
           contract_tool="$RUNNER_TEMP/opencode-candidate-contract.py"
           cat > "$contract_tool" <<'PY'
+          import hashlib
           import json
           import re
           import sys
@@ -1182,8 +1200,15 @@ jobs:
           )
           FENCE_LINE = re.compile(r"^ {0,3}((?:`{3,}|~{3,}))(.*)$")
 
-          def reject():
-              raise SystemExit(1)
+          class ContractRejection(Exception):
+              def __init__(self, rule="candidate_contract", line=1, column=1):
+                  super().__init__(rule)
+                  self.rule = rule
+                  self.line = line
+                  self.column = column
+
+          def reject(rule="candidate_contract", line=1, column=1):
+              raise ContractRejection(rule, line, column)
 
           def read_candidate(path):
               try:
@@ -2642,10 +2667,11 @@ jobs:
                   )
               return lines
 
-          def parse_sections(lines, signature_mode=False):
+          def parse_sections(lines, signature_mode=False, line_offset=0):
               sections = []
               section = None
-              for line in lines:
+              for index, line in enumerate(lines):
+                  line_number = line_offset + index + 1
                   if TOP_HEADING.match(line):
                       if signature_mode:
                           name = signature_section_name(line)
@@ -2653,43 +2679,72 @@ jobs:
                           match = VALID_HEADING.fullmatch(line)
                           name = match.group(1) if match is not None else None
                       if name is None:
-                          reject()
-                      section = {"name": name, "lines": []}
+                          reject("unknown_section", line_number)
+                      section = {
+                          "name": name,
+                          "lines": [],
+                          "line_numbers": [],
+                          "line": line_number,
+                      }
                       sections.append(section)
                   elif section is None:
                       if line.strip():
-                          reject()
+                          reject("section_preamble", line_number)
                   else:
                       section["lines"].append(line)
+                      section["line_numbers"].append(line_number)
               return sections
 
           def validate_outer(text, nonce):
               if re.fullmatch(r"[0-9a-f]{64}", nonce) is None:
-                  reject()
+                  reject("nonce_invalid", 2)
               nonce_line = f"<!-- automation-candidate:{nonce} -->"
               lines = text.split("\n")
-              if len(lines) < 3 or lines[0] != MARKER or lines[1] != nonce_line:
-                  reject()
+              if not lines or lines[0] != MARKER:
+                  reject("required_marker", 1)
+              if len(lines) < 2 or lines[1] != nonce_line:
+                  reject("required_nonce", 2)
+              if len(lines) < 3:
+                  reject("empty_review", 3)
               if lines.count(MARKER) != 1:
-                  reject()
+                  reject("marker_count", lines.index(MARKER, 1) + 1)
               nonce_markers = [
                   index for index, line in enumerate(lines)
                   if line.startswith("<!-- automation-candidate:")
               ]
               if nonce_markers != [1]:
-                  reject()
+                  offending_nonce = next(
+                      (index for index in nonce_markers if index != 1), 1
+                  )
+                  reject(
+                      "candidate_nonce_marker",
+                      offending_nonce + 1,
+                  )
 
-              review = "\n".join(lines[2:]).strip()
-              if not review:
-                  reject()
-              sections = parse_sections(review.split("\n"))
+              review_lines = lines[2:]
+              if not "\n".join(review_lines).strip():
+                  reject("empty_review", 3)
+              sections = parse_sections(review_lines, line_offset=2)
               names = [item["name"] for item in sections]
               if not names or names[0] != "New findings":
-                  reject()
-              if names.count("New findings") != 1 or len(set(names)) != len(names):
-                  reject()
+                  reject("new_findings_first", sections[0]["line"] if sections else 3)
+              if names.count("New findings") != 1:
+                  duplicate = next(
+                      item for item in sections[1:] if item["name"] == "New findings"
+                  )
+                  reject("duplicate_section", duplicate["line"])
+              if len(set(names)) != len(names):
+                  duplicate = next(
+                      item
+                      for index, item in enumerate(sections)
+                      if item["name"] in names[:index]
+                  )
+                  reject("duplicate_section", duplicate["line"])
               if any(not "\n".join(item["lines"]).strip() for item in sections):
-                  reject()
+                  empty = next(
+                      item for item in sections if not "\n".join(item["lines"]).strip()
+                  )
+                  reject("empty_section", empty["line"])
 
               headings = set()
               for item in sections:
@@ -2697,18 +2752,28 @@ jobs:
                   if item["name"] == "New findings" and body == "None":
                       continue
                   if re.match(r"^None(?:\s|$)", body):
-                      reject()
+                      none_line = next(
+                          line_number
+                          for line_number, line in zip(
+                              item["line_numbers"], item["lines"]
+                          )
+                          if re.match(r"^None(?:\s|$)", line.strip())
+                      )
+                      reject("none_with_finding", none_line)
                   has_block = False
-                  for line in item["lines"]:
+                  for offset, line in enumerate(item["lines"], 1):
+                      line_number = item["line"] + offset
                       if line.startswith("####"):
-                          if BLOCK_HEADING.fullmatch(line) is None or line in headings:
-                              reject()
+                          if BLOCK_HEADING.fullmatch(line) is None:
+                              reject("invalid_finding_heading", line_number)
+                          if line in headings:
+                              reject("duplicate_finding_heading", line_number)
                           headings.add(line)
                           has_block = True
                       elif not has_block and line.strip():
-                          reject()
+                          reject("section_preamble", line_number)
                   if not has_block:
-                      reject()
+                      reject("missing_finding_block", item["line"] + 1)
 
           def substance_signature(text, candidate_nonce):
               lines = text.split("\n")
@@ -2778,7 +2843,25 @@ jobs:
           mode, candidate_path, candidate_nonce = sys.argv[1:]
           candidate = read_candidate(candidate_path)
           if mode == "outer":
-              validate_outer(candidate, candidate_nonce)
+              rejection = None
+              try:
+                  validate_outer(candidate, candidate_nonce)
+              except ContractRejection as error:
+                  rejection = error
+              print(json.dumps(
+                  {
+                      "sha256": hashlib.sha256(candidate.encode("utf-8")).hexdigest(),
+                      "valid": rejection is None,
+                      "rule": None if rejection is None else rejection.rule,
+                      "line": None if rejection is None else rejection.line,
+                      "column": None if rejection is None else rejection.column,
+                  },
+                  ensure_ascii=True,
+                  separators=(",", ":"),
+                  sort_keys=True,
+              ))
+              if rejection is not None:
+                  raise SystemExit(1)
           elif mode == "signature":
               print(json.dumps(
                   substance_signature(candidate, candidate_nonce),
@@ -2792,7 +2875,20 @@ jobs:
           chmod 0500 "$contract_tool"
 
           candidate_outer_format_valid() {
-            python3 "$contract_tool" outer "$1" "$CANDIDATE_NONCE"
+            local candidate_path="$1"
+            local attempt="$2"
+            local raw_validation="$candidate_dir/.${attempt}-validation.json"
+            local validation="$candidate_dir/${attempt}-validation.json"
+            local status=0
+            python3 "$contract_tool" outer "$candidate_path" "$CANDIDATE_NONCE" \
+              > "$raw_validation" || status=$?
+            jq -ce --arg attempt "$attempt" 'select(type == "object" and (keys | sort) == ["column","line","rule","sha256","valid"] and (.sha256 | test("^[0-9a-f]{64}$")) and (.valid | type) == "boolean" and (if .valid then .rule == null and .line == null and .column == null else (.rule | test("^[a-z_]+$")) and (.line | type) == "number" and .line >= 1 and .line == (.line | floor) and (.column | type) == "number" and .column >= 1 and .column == (.column | floor) end)) | {attempt:$attempt,sha256,valid,rule,line,column}' "$raw_validation" > "$validation" || {
+              rm -f -- "$raw_validation" "$validation"
+              return 1
+            }
+            rm -f -- "$raw_validation"
+            chmod 0600 "$validation"
+            return "$status"
           }
 
           candidate_substance_signature() {
@@ -2808,7 +2904,7 @@ jobs:
           extract_candidate \
             "$RUNNER_TEMP/opencode-review.jsonl" "$candidate_dir/review.md"
 
-          if ! candidate_outer_format_valid "$candidate_dir/review.md"; then
+          if ! candidate_outer_format_valid "$candidate_dir/review.md" initial; then
             echo "OpenCode candidate outer grammar is invalid; attempting one format-only repair" >&2
             candidate_json="$RUNNER_TEMP/opencode-candidate.json"
             repair_prompt="$RUNNER_TEMP/opencode-format-repair-prompt.txt"
@@ -2842,7 +2938,7 @@ jobs:
             review_failure_reason=candidate_contract_failed
             extract_candidate \
               "$RUNNER_TEMP/opencode-format-repair.jsonl" "$candidate_dir/review-repaired.md"
-            if ! candidate_outer_format_valid "$candidate_dir/review-repaired.md"; then
+            if ! candidate_outer_format_valid "$candidate_dir/review-repaired.md" repair; then
               echo "OpenCode format repair still violates the required outer grammar" >&2
               exit 1
             fi
@@ -2969,6 +3065,65 @@ jobs:
               "candidate_contract_failed",
               "call_budget_exhausted",
           }
+          validation_rules = {
+              "candidate_contract",
+              "candidate_nonce_marker",
+              "duplicate_finding_heading",
+              "duplicate_section",
+              "empty_review",
+              "empty_section",
+              "invalid_finding_heading",
+              "marker_count",
+              "missing_finding_block",
+              "new_findings_first",
+              "nonce_invalid",
+              "none_with_finding",
+              "required_marker",
+              "required_nonce",
+              "section_preamble",
+              "unknown_section",
+          }
+
+          def load_validation(attempt: str):
+              path = candidate_dir / f"{attempt}-validation.json"
+              if not path.exists():
+                  return None
+              if not private_regular(path) or path.stat().st_size > 512:
+                  raise SystemExit(f"invalid {attempt} candidate validation")
+              try:
+                  record = json.loads(path.read_text(encoding="ascii"))
+              except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+                  raise SystemExit(f"invalid {attempt} candidate validation") from error
+              expected_keys = {"attempt", "sha256", "valid", "rule", "line", "column"}
+              if (
+                  not isinstance(record, dict)
+                  or set(record) != expected_keys
+                  or record["attempt"] != attempt
+                  or re.fullmatch(r"[0-9a-f]{64}", record["sha256"] or "") is None
+                  or not isinstance(record["valid"], bool)
+              ):
+                  raise SystemExit(f"invalid {attempt} candidate validation")
+              if record["valid"]:
+                  if any(record[field] is not None for field in ("rule", "line", "column")):
+                      raise SystemExit(f"invalid {attempt} candidate validation")
+              elif (
+                  record["rule"] not in validation_rules
+                  or isinstance(record["line"], bool)
+                  or not isinstance(record["line"], int)
+                  or record["line"] < 1
+                  or isinstance(record["column"], bool)
+                  or not isinstance(record["column"], int)
+                  or record["column"] < 1
+              ):
+                  raise SystemExit(f"invalid {attempt} candidate validation")
+              return record
+
+          candidate_validations = [
+              record
+              for attempt in ("initial", "repair")
+              for record in (load_validation(attempt),)
+              if record is not None
+          ]
           model_outcome = os.environ.get("MODEL_OUTCOME", "")
           failure_reason = os.environ.get("MODEL_FAILURE_REASON", "")
           review_path = candidate_dir / "review.md"
@@ -2987,6 +3142,10 @@ jobs:
               ):
                   raise SystemExit("successful review candidate invalid")
               review_sha256 = hashlib.sha256(review_path.read_bytes()).hexdigest()
+              if not candidate_validations or not candidate_validations[-1]["valid"]:
+                  raise SystemExit("successful review candidate validation missing")
+              if candidate_validations[-1]["sha256"] != review_sha256:
+                  raise SystemExit("successful review candidate validation mismatch")
               review_path.chmod(0o600)
               failure_reason = "none"
           else:
@@ -2994,9 +3153,11 @@ jobs:
               (candidate_dir / "review-repaired.md").unlink(missing_ok=True)
               if failure_reason not in allowed_reasons - {"none"}:
                   failure_reason = "model_job_failed"
+          for attempt in ("initial", "repair"):
+              (candidate_dir / f"{attempt}-validation.json").unlink(missing_ok=True)
 
           envelope = {
-              "schema": 1,
+              "schema": 2,
               "repository": identity["repository"],
               "pr": int(identity["pr"]),
               "run_id": int(identity["run_id"]),
@@ -3011,6 +3172,7 @@ jobs:
               "outcome": "success" if succeeded else "failure",
               "failure_reason": failure_reason,
               "review_sha256": review_sha256,
+              "candidate_validations": candidate_validations,
           }
           candidate_json = candidate_dir / "candidate.json"
           candidate_json.write_text(
@@ -3051,7 +3213,8 @@ jobs:
       needs.check-enabled.outputs.safe_pr == 'true' &&
       needs.opencode-prepare.result == 'success' &&
       (needs.opencode-prepare.outputs.allow_invocation == 'true' ||
-      needs.opencode-prepare.outputs.budget_decision == 'authenticated_reuse')
+      (needs.opencode-prepare.outputs.budget_decision == 'authenticated_reuse' &&
+      needs.opencode-prepare.outputs.diff_mode == 'unchanged'))
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -3365,15 +3528,37 @@ jobs:
                 candidateEnvelope = JSON.parse(
                   new TextDecoder('utf-8', { fatal: true })
                     .decode(fs.readFileSync(candidateEnvelopePath)));
-                const candidateKeys = ['call_count','claim_checkpoint_sha256','diff_mode',
+                const candidateKeys = ['call_count','candidate_validations','claim_checkpoint_sha256','diff_mode',
                   'elapsed_seconds','failure_reason','full_diff_sha256','head_sha','model_route',
                   'outcome','pr','repository','review_sha256','run_attempt','run_id','schema'];
                 const nonnegativeInteger = (value) => Number.isSafeInteger(value) && value >= 0;
+                const validationRules = new Set([
+                  'candidate_contract', 'candidate_nonce_marker', 'duplicate_finding_heading',
+                  'duplicate_section', 'empty_review', 'empty_section', 'invalid_finding_heading',
+                  'marker_count', 'missing_finding_block', 'new_findings_first', 'nonce_invalid',
+                  'none_with_finding', 'required_marker', 'required_nonce', 'section_preamble',
+                  'unknown_section',
+                ]);
+                const candidateValidationKeys = ['attempt','column','line','rule','sha256','valid'];
+                const validations = candidateEnvelope?.candidate_validations;
+                const validationsValid = Array.isArray(validations) && validations.length <= 2
+                  && validations.every((record, index) => record && typeof record === 'object'
+                    && !Array.isArray(record)
+                    && JSON.stringify(Object.keys(record).sort())
+                      === JSON.stringify(candidateValidationKeys)
+                    && record.attempt === ['initial', 'repair'][index]
+                    && /^[0-9a-f]{64}$/.test(record.sha256 || '')
+                    && typeof record.valid === 'boolean'
+                    && (record.valid
+                      ? record.rule === null && record.line === null && record.column === null
+                      : validationRules.has(record.rule)
+                        && Number.isSafeInteger(record.line) && record.line >= 1
+                        && Number.isSafeInteger(record.column) && record.column >= 1));
                 if (!candidateEnvelope || typeof candidateEnvelope !== 'object'
                   || Array.isArray(candidateEnvelope)
                   || JSON.stringify(Object.keys(candidateEnvelope).sort())
                     !== JSON.stringify(candidateKeys)
-                  || candidateEnvelope.schema !== 1
+                  || candidateEnvelope.schema !== 2
                   || candidateEnvelope.repository !== repository
                   || candidateEnvelope.pr !== issueNumber
                   || candidateEnvelope.run_id !== runId
@@ -3381,6 +3566,7 @@ jobs:
                   || candidateEnvelope.head_sha !== attemptHead
                   || candidateEnvelope.full_diff_sha256 !== fullDiffSha256
                   || candidateEnvelope.diff_mode !== diffMode
+                  || !validationsValid
                   || candidateEnvelope.claim_checkpoint_sha256
                     !== handoff.budget_checkpoint_sha256) {
                   throw new Error('candidate claim identity mismatch');
@@ -3414,7 +3600,10 @@ jobs:
                 }
                 if (candidateEnvelope.outcome === 'success') {
                   if (candidateEnvelope.failure_reason !== 'none'
-                    || !/^[0-9a-f]{64}$/.test(candidateEnvelope.review_sha256 || '')) {
+                    || !/^[0-9a-f]{64}$/.test(candidateEnvelope.review_sha256 || '')
+                    || validations.length === 0
+                    || validations.at(-1).valid !== true
+                    || validations.at(-1).sha256 !== candidateEnvelope.review_sha256) {
                     throw new Error('successful candidate mode invalid');
                   }
                   const candidateStat = fs.lstatSync(candidatePath);

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -64,7 +64,7 @@ OPENCODE_REVIEW_RUN_SHA256 = (
     "9f1468128086b438cce0ce53fc20a9f0e02a14d581cd12b63f021c8c3a7620c6"
 )
 OPENCODE_REVIEW_RUN_V147_SHA256 = (
-    "d5b3cd5349d5bfd0d78aab2a925891a5e1e2c9f0d44cd86c1876c5cc28ea4b70"
+    "be6e7fc1c937cacc1c789463ec80a1612621395b02a5050b0923fe373fb4265d"
 )
 OPENCODE_AUTO_REVIEW_SHA256 = (
     "a38218bc27e672f7f7bde1873b9fa3de811057490f3fab7dc91c74d03d80ba97"
@@ -488,7 +488,7 @@ EXPECTED_CANONICALIZER_SOFT_REASONS = frozenset(
     }
 )
 EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256 = (
-    "36babc0bc0159e7f1315cadca22ba8a7e1a8756bfd929637bab0fe1d21ed8d68"
+    "eb4ba827d3b03e3c9169cd95e9194d49b2b8b9b6956e7317b5c9cc9b7bb04fc5"
 )
 EXPECTED_REVIEW_SCOPE_HELPER_SHA256 = (
     "68779c9038c31aa09a846b643bc0178b147798527e1a34ee5821ab539f10b19a"
@@ -531,6 +531,14 @@ EXPECTED_CANONICALIZER_RECORDS = {
         ("reason", "str"),
         ("claimed_severity", "Literal['none', 'MEDIUM', 'HIGH', 'CRITICAL']"),
     ),
+    "CandidateValidation": (
+        ("attempt", "Literal['initial']"),
+        ("sha256", "str"),
+        ("valid", "Literal[False]"),
+        ("rule", "str"),
+        ("line", "int"),
+        ("column", "int"),
+    ),
     "CanonicalizationResult": (
         ("document_valid", "bool"),
         ("accepted_count", "int"),
@@ -539,6 +547,7 @@ EXPECTED_CANONICALIZER_RECORDS = {
         ("filtered_max_severity", "Literal['none', 'MEDIUM', 'HIGH', 'CRITICAL']"),
         ("failure_reason", "str"),
         ("candidate_reasons", "tuple[CandidateReason, ...]"),
+        ("candidate_validations", "tuple[CandidateValidation, ...]"),
     ),
 }
 EXPECTED_SCOPE_RECORDS = {
@@ -644,12 +653,12 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256 = (
     "70b50ce482ff0e54df9fff88d5126cd8e760ed8bdabfefcc2f2ccdc639cb693b"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256 = (
-    "a2ccb7dcfa131186ed302836172f03502d71ec191bf58780477b2e447a42c594"
+    "43f15d59df0f529e2fa4f06488e49dc5ff78280762ee8d7248dbecb45cbb609d"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
     "claude": "d34dfc388a393a6679bfd6a38ac281cc2c14a843063a010e9f1303c68df58cc7",
-    "gemini": "6837358dbbdcc2f3f5ebf6aca3956b646f89b35fed7c9a201bbde2d6af7519dd",
-    "opencode": "28791fa77f05454775043cb5b582f849aef7fe81c109c65161bcf860a6d6531a",
+    "gemini": "cf3da7805be2f707f07eb2fa01e812083412d4dfb87d81ba3990f6222e616e9e",
+    "opencode": "7bff235fe723c79eaf34d21ebc3e8032ade23da82dd22fa61c4a3a3aa5f5d31c",
 }
 EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION = yaml.load(
     r"""name: Review invocation budget
@@ -2102,11 +2111,19 @@ def verify_opencode_runtime(
         "opencode run --model zai-coding-plan/glm-4.7 --format json "
         "--file review-full.diff --file review-scope.json"
     ) in run_script
+    current_diagnostics_contract = (
+        workflow_sha256
+        == EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256["opencode"]
+    )
+    initial_validation_argument = " initial" if current_diagnostics_contract else ""
+    repair_validation_argument = " repair" if current_diagnostics_contract else ""
     format_sequence = (
         'run_opencode "$initial_prompt" "$RUNNER_TEMP/opencode-review.jsonl"',
-        'if ! candidate_outer_format_valid "$candidate_dir/review.md"; then',
+        'if ! candidate_outer_format_valid "$candidate_dir/review.md"'
+        f'{initial_validation_argument}; then',
         '"$repair_prompt" "$RUNNER_TEMP/opencode-format-repair.jsonl"',
-        'if ! candidate_outer_format_valid "$candidate_dir/review-repaired.md"; then',
+        'if ! candidate_outer_format_valid "$candidate_dir/review-repaired.md"'
+        f'{repair_validation_argument}; then',
         'echo "OpenCode format repair still violates the required outer grammar" >&2',
         "exit 1",
         'if ! initial_signature="$(candidate_substance_signature "$candidate_dir/review.md")"; then',
@@ -4130,6 +4147,10 @@ def require_budget_helper_contract(source: str) -> None:
             "        return refuse(validated, request, 'authenticated_reuse')\n"
             "    if not request.force_review and any("
             "item.head_sha == request.head_sha for item in validated.invocations):\n"
+            "        if (request.authenticated_review.head_sha == request.head_sha "
+            "and request.authenticated_review.covers_hash("
+            "request.full_diff_sha256)):\n"
+            "            return refuse(validated, request, 'authenticated_reuse')\n"
             "        return refuse(validated, request, 'duplicate_head')\n"
             "    if not request.force_review and any("
             "item.full_diff_sha256 == request.full_diff_sha256 "
@@ -5117,8 +5138,8 @@ def require_budget_workflow_contract(
                     'run_opencode "$repair_prompt" '
                     '"$RUNNER_TEMP/opencode-format-repair.jsonl"',
                     (
-                        "if:if ! candidate_outer_format_valid "
-                        '"$candidate_dir/review.md"; then',
+                            "if:if ! candidate_outer_format_valid "
+                            '"$candidate_dir/review.md" initial; then',
                     ),
                 ),
             )

--- a/tests/test_canonicalize_review.py
+++ b/tests/test_canonicalize_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import hashlib
 import json
 from types import SimpleNamespace
 from pathlib import Path
@@ -316,6 +317,36 @@ def test_hard_document_failures_are_exact_and_write_no_canonical_body(case_facto
     assert result.candidate_reasons == ()
 
 
+def test_ambiguous_document_records_only_rule_location_and_candidate_hash(case_factory):
+    """Dropping parser context must not leave a paid rejected candidate undiagnosable."""
+    secret_claim = "UNTRUSTED-GEMINI-CANDIDATE"
+    payload = (
+        "### New findings\n"
+        "None\n\n"
+        "### New findings\n"
+        f"{secret_claim}\n"
+    ).encode("utf-8")
+
+    result, canonical = case_factory(payload).run()
+    encoded = json.dumps(result.to_dict(), sort_keys=True)
+
+    assert result.document_valid is False
+    assert result.failure_reason == "ambiguous_document"
+    assert canonical is None
+    assert result.to_dict()["schema"] == 2
+    assert result.to_dict()["candidate_validations"] == [
+        {
+            "attempt": "initial",
+            "sha256": hashlib.sha256(payload).hexdigest(),
+            "valid": False,
+            "rule": "duplicate_section",
+            "line": 4,
+            "column": 1,
+        }
+    ]
+    assert secret_claim not in encoded
+
+
 def test_result_json_never_repeats_rejected_model_text(case_factory):
     """Leaking rejected prose into the result would expose untrusted model text."""
     secret_claim = "INJECTED-REJECTED-CLAIM"
@@ -333,7 +364,8 @@ def test_result_json_never_repeats_rejected_model_text(case_factory):
     assert result.candidate_reasons == (
         CandidateReason(0, "New findings", "filtered", "invalid_anchor", "HIGH"),
     )
-    assert set(result.to_dict()) == {"schema", "document_valid", "accepted_count", "filtered_count", "normalized_count", "filtered_max_severity", "failure_reason", "candidate_reasons"}
+    assert set(result.to_dict()) == {"schema", "document_valid", "accepted_count", "filtered_count", "normalized_count", "filtered_max_severity", "failure_reason", "candidate_reasons", "candidate_validations"}
+    assert result.to_dict()["candidate_validations"] == []
     assert set(result.to_dict()["candidate_reasons"][0]) == {"index", "section", "outcome", "reason", "claimed_severity"}
 
 
@@ -521,7 +553,7 @@ def test_clean_candidate_accepts_a_tree_equivalent_empty_full_scope(tmp_path: Pa
     ))
 
     assert result == canonicalize_review.CanonicalizationResult(
-        True, 0, 0, 0, "none", "", (),
+        True, 0, 0, 0, "none", "", (), (),
     )
     assert canonical.read_text(encoding="utf-8") == (
         "### New findings\n\nNone\n\nNo validated blocking issues found.\n"
@@ -559,7 +591,7 @@ def test_preexisting_canonical_symlink_is_never_followed(case_factory):
     target.write_text("preserve", encoding="utf-8")
     case.canonical.symlink_to(target)
     result, canonical = case.run()
-    assert result == canonicalize_review.CanonicalizationResult(False, 0, 0, 0, "none", "canonicalizer_error", ())
+    assert result == canonicalize_review.CanonicalizationResult(False, 0, 0, 0, "none", "canonicalizer_error", (), ())
     assert canonical is None
     assert target.read_text(encoding="utf-8") == "preserve"
 
@@ -590,7 +622,7 @@ def test_performance_basis_is_canonicalized_from_validated_fields(scoped_case, k
 - Material impact: The changed exception path is exercised for every invalid request.
 - Performance basis: {basis}
 ''')
-    assert result == canonicalize_review.CanonicalizationResult(True, 1, 0, 0, "none", "", ())
+    assert result == canonicalize_review.CanonicalizationResult(True, 1, 0, 0, "none", "", (), ())
     assert expected_basis in canonical
     assert canonical == f'''### New findings
 
@@ -733,7 +765,8 @@ def test_cli_writes_bounded_schema_result_scalar_outputs_and_metadata_only_logs(
     completed = subprocess.run(_cli_args(case, github_output), cwd=ACTION_DIR, capture_output=True, text=True)
     assert completed.returncode == 0
     result = json.loads(case.result.read_text(encoding="utf-8"))
-    assert set(result) == {"schema", "document_valid", "accepted_count", "filtered_count", "normalized_count", "filtered_max_severity", "failure_reason", "candidate_reasons"}
+    assert set(result) == {"schema", "document_valid", "accepted_count", "filtered_count", "normalized_count", "filtered_max_severity", "failure_reason", "candidate_reasons", "candidate_validations"}
+    assert result["candidate_validations"] == []
     assert len(case.result.read_bytes()) <= 131_072
     assert secret not in case.result.read_text(encoding="utf-8")
     assert secret not in completed.stdout
@@ -843,9 +876,10 @@ def test_cli_canonical_symlink_becomes_closed_canonicalizer_error(case_factory):
     completed = subprocess.run(_cli_args(case), cwd=ACTION_DIR, capture_output=True, text=True)
     assert completed.returncode == 0
     assert json.loads(case.result.read_text(encoding="utf-8")) == {
-        "schema": 1, "document_valid": False, "accepted_count": 0,
+        "schema": 2, "document_valid": False, "accepted_count": 0,
         "filtered_count": 0, "normalized_count": 0, "filtered_max_severity": "none",
         "failure_reason": "canonicalizer_error", "candidate_reasons": [],
+        "candidate_validations": [],
     }
     assert not case.canonical.exists()
     assert target.read_text(encoding="utf-8") == "preserve"
@@ -984,6 +1018,7 @@ def test_duplicate_generated_new_id_is_normalized_before_rendering(review_qualit
         (canonicalize_review.CandidateReason(
             1, "New findings", "normalized", "duplicate_prior_binding", "MEDIUM",
         ),),
+        (),
     )
     assert canonical.count("#### RVW-61d4cd9ac260 [MEDIUM]") == 1
     followup, _ = review_quality_repo._run(review_quality_repo._request(
@@ -1019,6 +1054,7 @@ def test_new_finding_cannot_duplicate_a_carried_active_id(review_quality_repo):
         (canonicalize_review.CandidateReason(
             0, "New findings", "normalized", "duplicate_prior_binding", "HIGH",
         ),),
+        (),
     )
     assert canonical.count("#### RVW-3253866a28c6 [HIGH]") == 1
     assert "### Still open" in canonical
@@ -1078,7 +1114,7 @@ def test_retracted_prior_renders_canonical_reason(review_quality_repo):
     result, canonical = review_quality_repo.run_carryover(
         accepted_rejected_plan_review(), retracted_rejected_plan_candidate(),
     )
-    assert result == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", ())
+    assert result == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", (), ())
     assert canonical == '''### New findings
 
 None
@@ -1117,7 +1153,7 @@ def test_known_prior_still_open_renders_prior_identity_and_exact_markdown(review
     result, canonical = review_quality_repo.run_delta(
         accepted_rejected_plan_review(), valid_still_open_candidate(),
     )
-    assert result == canonicalize_review.CanonicalizationResult(True, 1, 0, 0, "none", "", ())
+    assert result == canonicalize_review.CanonicalizationResult(True, 1, 0, 0, "none", "", (), ())
     assert canonical == '''### New findings
 
 None
@@ -1392,7 +1428,7 @@ def test_escape_expansion_over_canonical_ceiling_fails_before_publication(
     ))
 
     assert result == canonicalize_review.CanonicalizationResult(
-        False, 0, 0, 0, "none", "candidate_oversize", (),
+        False, 0, 0, 0, "none", "candidate_oversize", (), (),
     )
     assert canonical == ""
     assert not review_quality_repo.canonical.exists()
@@ -1421,7 +1457,7 @@ def test_max_candidate_renderer_output_is_valid_authenticated_previous_input(rev
         candidate, reviewer="gemini", head=review_quality_repo.review_head,
     ))
     previous_bytes = previous.encode("utf-8")
-    assert initial == canonicalize_review.CanonicalizationResult(True, 200, 0, 0, "none", "", ())
+    assert initial == canonicalize_review.CanonicalizationResult(True, 200, 0, 0, "none", "", (), ())
     assert len(previous_bytes) == canonicalize_review.MAX_CANDIDATE_BYTES + (17 * 200)
     assert (
         canonicalize_review.MAX_CANDIDATE_BYTES
@@ -1437,7 +1473,7 @@ def test_max_candidate_renderer_output_is_valid_authenticated_previous_input(rev
     assert request.previous_review_file is not None
     assert request.previous_review_file.read_bytes() == previous_bytes
     followup, canonical = review_quality_repo._run(request)
-    assert followup == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", ())
+    assert followup == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", (), ())
     assert canonical == "### New findings\n\nNone\n\nNo validated blocking issues found.\n"
 
 
@@ -1570,7 +1606,7 @@ def test_accepted_new_free_text_is_visible_safe_and_uses_canonical_title_identit
 ):
     """Accepted free text must not create a marker, metadata line, or sticky Markdown heading."""
     result, canonical = scoped_case.run(_new_free_text_candidate(title, material, prose))
-    assert result == canonicalize_review.CanonicalizationResult(True, 1, 0, 0, "none", "", ())
+    assert result == canonicalize_review.CanonicalizationResult(True, 1, 0, 0, "none", "", (), ())
     assert expected in canonical
     assert "<!-- automation:" not in canonical
     assert "<!-- automation-state:" not in canonical
@@ -1610,7 +1646,7 @@ def test_accepted_resolution_and_reason_are_visible_safe_without_counter_changes
     """Renderer-only escaping must preserve accepted carryover classification and counts."""
     runner = review_quality_repo.run_delta if "### Resolved" in candidate else review_quality_repo.run_carryover
     result, canonical = runner(accepted_rejected_plan_review(), candidate)
-    assert result == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", ())
+    assert result == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", (), ())
     assert expected in canonical
     assert f": {raw}" not in canonical
     assert "<!-- automation:" not in canonical
@@ -1666,7 +1702,7 @@ def test_current_resolved_fix_anchor_accepts_literal_json_controls_and_authentic
     )
     result, canonical = review_quality_repo.run_delta(accepted_rejected_plan_review(), candidate)
 
-    assert result == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", ())
+    assert result == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", (), ())
     encoded = next(
         line.removeprefix("- Fix anchor: ")
         for line in canonical.splitlines()
@@ -1680,7 +1716,7 @@ def test_current_resolved_fix_anchor_accepts_literal_json_controls_and_authentic
         "### New findings\n\nNone\n", reviewer="gemini", head=review_quality_repo.fixed_head,
         previous_sha=review_quality_repo.fixed_head, previous_review=canonical,
     ))
-    assert followup == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", ())
+    assert followup == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", (), ())
 
 
 def test_current_retracted_trigger_accepts_literal_json_controls_and_authenticates_output(
@@ -1694,7 +1730,7 @@ def test_current_retracted_trigger_accepts_literal_json_controls_and_authenticat
     )
     result, canonical = review_quality_repo.run_carryover(accepted_rejected_plan_review(), candidate)
 
-    assert result == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", ())
+    assert result == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", (), ())
     encoded = next(
         line.removeprefix("- Trigger evidence: ")
         for line in canonical.splitlines()
@@ -1707,7 +1743,7 @@ def test_current_retracted_trigger_accepts_literal_json_controls_and_authenticat
     followup, _ = review_quality_repo.run_carryover(
         canonical, "### New findings\n\nNone\n",
     )
-    assert followup == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", ())
+    assert followup == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", (), ())
 
 
 def test_canonicalized_marker_title_is_strict_byte_stable_authenticated_prior_input(review_quality_repo):
@@ -1719,7 +1755,7 @@ def test_canonicalized_marker_title_is_strict_byte_stable_authenticated_prior_in
         initial, reviewer="gemini", head=review_quality_repo.review_head,
     ))
     expected_id = stable_finding_id("gemini", SourceAnchor("review_cases.py", 26), "HIGH", canonical_title)
-    assert prior_result == canonicalize_review.CanonicalizationResult(True, 1, 0, 0, "none", "", ())
+    assert prior_result == canonicalize_review.CanonicalizationResult(True, 1, 0, 0, "none", "", (), ())
     assert f"#### {expected_id} [HIGH] {canonical_title}" in previous
     request = review_quality_repo._request(
         "### New findings\n\nNone\n", reviewer="gemini", head=review_quality_repo.review_head,
@@ -1738,7 +1774,7 @@ None
 - Material impact: The rejection remains visible to callers.
 '''
     result, canonical = review_quality_repo.run_delta(previous, still_open)
-    assert result == canonicalize_review.CanonicalizationResult(True, 1, 0, 0, "none", "", ())
+    assert result == canonicalize_review.CanonicalizationResult(True, 1, 0, 0, "none", "", (), ())
     assert canonical_title in canonical
     assert "<!-- automation:" not in canonical
     assert "<!-- automation-state:" not in canonical
@@ -1750,7 +1786,7 @@ None
     loaded_followup = canonicalize_review._load_prior_active(followup_request)
     assert loaded_followup[expected_id].finding.anchor == SourceAnchor("review_cases.py", 20)
     followup, followup_canonical = review_quality_repo._run(followup_request)
-    assert followup == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", ())
+    assert followup == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", (), ())
     assert followup_canonical == "### New findings\n\nNone\n\nNo validated blocking issues found.\n"
 
 
@@ -1774,7 +1810,7 @@ def test_bulleted_supplemental_prose_round_trips_as_authenticated_prior(
         "gemini", SourceAnchor("review_cases.py", 26), "HIGH", title,
     )
     assert prior_result == canonicalize_review.CanonicalizationResult(
-        True, 1, 0, 0, "none", "", (),
+        True, 1, 0, 0, "none", "", (), (),
     )
     assert detail in previous
 

--- a/tests/test_review_invocation_budget.py
+++ b/tests/test_review_invocation_budget.py
@@ -389,6 +389,35 @@ def test_quality_filtered_is_terminal_and_duplicate_input_stays_blocked():
     assert not again.allow_invocation
 
 
+def test_same_head_noop_requires_exact_authenticated_checkpoint():
+    """A rerun may be green only when the prior checkpoint covers this exact head and diff."""
+    existing = budget.LedgerState.initial(
+        REPOSITORY,
+        PR,
+        "gemini",
+        invocations=(invocation(reviewer="gemini", outcome="success"),),
+    )
+    exact_request = replace(
+        request(reviewer="gemini"),
+        authenticated_review=budget.AuthenticatedReview(True, HEAD_A, HASH_1),
+    )
+    exact = budget.claim(
+        existing, exact_request, claim_provenances(existing, exact_request)
+    )
+    missing_request = replace(
+        exact_request,
+        authenticated_review=budget.AuthenticatedReview(False, None, None),
+    )
+    missing = budget.claim(
+        existing, missing_request, claim_provenances(existing, missing_request)
+    )
+
+    assert exact.decision == "authenticated_reuse"
+    assert not exact.allow_invocation
+    assert missing.decision == "duplicate_head"
+    assert not missing.allow_invocation
+
+
 def test_force_review_claims_same_head_once_with_dispatch_and_authorized_override():
     existing = budget.LedgerState.initial(
         REPOSITORY,

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -8171,7 +8171,7 @@ def test_opencode_budget_candidate_envelope_is_exact_and_mode_aware():
         "schema", "repository", "pr", "run_id", "run_attempt", "head_sha",
         "full_diff_sha256", "diff_mode", "claim_checkpoint_sha256",
         "call_count", "elapsed_seconds", "model_route", "outcome",
-        "failure_reason", "review_sha256",
+        "failure_reason", "review_sha256", "candidate_validations",
     ):
         assert f'"{field}"' in materialize
     assert "lstat" in materialize and "S_ISREG" in materialize
@@ -8277,6 +8277,49 @@ def test_opencode_budget_refusal_skips_model_and_schema2_publication_but_uploads
     assert "needs.opencode-prepare.outputs.budget_decision == 'authenticated_reuse'" in canonical_job["if"]
     assert "needs.opencode-prepare.outputs.allow_invocation == 'true'" in canonicalize["if"]
     assert "authenticated_reuse" in canonicalize["if"]
+
+
+@pytest.mark.parametrize(
+    ("workflow_name", "job_name"),
+    (
+        ("gemini-auto-review.yml", "gemini-review"),
+        ("opencode-auto-review.yml", "opencode-prepare"),
+    ),
+)
+@pytest.mark.parametrize(
+    "decision",
+    (
+        "duplicate_head",
+        "duplicate_effective_diff",
+        "input_budget_exhausted",
+        "round_budget_exhausted",
+        "total_usage_budget_exhausted",
+    ),
+)
+def test_review_budget_refusal_fails_without_authenticated_checkpoint(
+    tmp_path, workflow_name, job_name, decision
+):
+    """A normal budget refusal is not approval for a successful required check."""
+    workflow = _load(workflow_name)
+    enforce = _step(workflow, job_name, "Enforce authenticated review budget decision")
+
+    def run(allow_invocation: str, decision: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", "-c", enforce["run"]],
+            cwd=tmp_path,
+            env={
+                **os.environ,
+                "BUDGET_ALLOW_INVOCATION": allow_invocation,
+                "BUDGET_DECISION": decision,
+            },
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+    assert run("false", decision).returncode != 0
+    assert run("false", "authenticated_reuse").returncode == 0
+    assert run("true", "claimed").returncode == 0
 
 
 def test_opencode_model_and_privileged_canonicalization_have_separate_token_boundaries():
@@ -8513,6 +8556,46 @@ def _run_opencode_model_step(
     return result, calls, candidate
 
 
+def _run_opencode_materialize_step(tmp_path: Path, model_outcome: str) -> dict[str, object]:
+    materialize = _step(
+        _load("opencode-auto-review.yml"),
+        "opencode-review",
+        "Materialize sealed OpenCode candidate",
+    )
+    runner_temp = tmp_path / "runner"
+    github_output = tmp_path / "materialize-output"
+    model_outputs = _github_outputs(tmp_path / "github-output")
+    env = {
+        **os.environ,
+        "RUNNER_TEMP": str(runner_temp),
+        "GITHUB_OUTPUT": str(github_output),
+        "GITHUB_REPOSITORY": "example/repo",
+        "GITHUB_RUN_ID": "101",
+        "GITHUB_RUN_ATTEMPT": "1",
+        "MODEL_OUTCOME": model_outcome,
+        "MODEL_FAILURE_REASON": model_outputs["failure_reason"],
+        "PR_NUMBER": "7",
+        "ATTEMPT_HEAD": "12" * 20,
+        "FULL_DIFF_SHA256": "34" * 32,
+        "DIFF_MODE": "full",
+        "CLAIM_CHECKPOINT_SHA256": "56" * 32,
+    }
+    completed = subprocess.run(
+        ["bash", "-c", materialize["run"]],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(
+        (runner_temp / "opencode-candidate" / "candidate.json").read_text(
+            encoding="ascii"
+        )
+    )
+
+
 def test_opencode_invocation_budget_persists_count_before_raised_cli(tmp_path):
     result, calls, _ = _run_opencode_model_step(tmp_path, [])
 
@@ -8614,6 +8697,80 @@ def test_opencode_format_repair_still_requires_exact_final_section_case(tmp_path
 
     assert result.returncode != 0
     assert len(calls) == 2
+
+
+def test_opencode_failed_initial_and_repair_keep_separate_sanitized_diagnostics(tmp_path):
+    secret_claim = "UNTRUSTED-OPENCODE-CANDIDATE"
+    initial = secret_claim + "\n" + _opencode_candidate()
+    repaired = _opencode_candidate("### New Findings\nNone")
+
+    result, calls, _ = _run_opencode_model_step(tmp_path, [initial, repaired])
+    envelope = _run_opencode_materialize_step(tmp_path, "failure")
+    encoded = json.dumps(envelope, sort_keys=True)
+
+    assert result.returncode != 0
+    assert len(calls) == 2
+    assert envelope["schema"] == 2
+    assert envelope["failure_reason"] == "candidate_contract_failed"
+    assert envelope["candidate_validations"] == [
+        {
+            "attempt": "initial",
+            "sha256": hashlib.sha256((initial + "\n").encode()).hexdigest(),
+            "valid": False,
+            "rule": "required_marker",
+            "line": 1,
+            "column": 1,
+        },
+        {
+            "attempt": "repair",
+            "sha256": hashlib.sha256((repaired + "\n").encode()).hexdigest(),
+            "valid": False,
+            "rule": "unknown_section",
+            "line": 3,
+            "column": 1,
+        },
+    ]
+    assert secret_claim not in encoded
+
+
+@pytest.mark.parametrize(
+    ("candidate", "rule", "line"),
+    (
+        (
+            _opencode_candidate("\n\n### New Findings\nNone"),
+            "unknown_section",
+            5,
+        ),
+        (
+            _opencode_candidate()
+            + f"\n<!-- automation-candidate:{OPENCODE_CANDIDATE_NONCE} -->",
+            "candidate_nonce_marker",
+            5,
+        ),
+        (
+            _opencode_candidate(
+                "### New findings\n\n\nNone\n" + OPENCODE_FINDING_BLOCK
+            ),
+            "none_with_finding",
+            6,
+        ),
+    ),
+    ids=("leading-blank-lines", "extra-nonce", "padded-none"),
+)
+def test_opencode_rejected_candidate_diagnostics_report_actual_source_line(
+    tmp_path, candidate, rule, line
+):
+    result, calls, _ = _run_opencode_model_step(
+        tmp_path, [candidate, candidate]
+    )
+    envelope = _run_opencode_materialize_step(tmp_path, "failure")
+
+    assert result.returncode != 0
+    assert len(calls) == 2
+    assert [
+        (record["attempt"], record["rule"], record["line"])
+        for record in envelope["candidate_validations"]
+    ] == [("initial", rule, line), ("repair", rule, line)]
 
 
 def test_opencode_format_repair_rejects_non_ascii_case_lookalike(tmp_path):
@@ -13210,8 +13367,18 @@ def _run_opencode_canonicalize(
                 encoding="utf-8",
             )
             review_sha256 = hashlib.sha256(candidate_path.read_bytes()).hexdigest()
+        candidate_validations = []
+        if candidate_succeeded:
+            candidate_validations.append({
+                "attempt": "initial",
+                "sha256": review_sha256,
+                "valid": True,
+                "rule": None,
+                "line": None,
+                "column": None,
+            })
         envelope = {
-            "schema": 1,
+            "schema": 2,
             "repository": "example/repo",
             "pr": 7,
             "run_id": int(run_id),
@@ -13233,6 +13400,7 @@ def _run_opencode_canonicalize(
                 else "provider_failed"
             ),
             "review_sha256": review_sha256,
+            "candidate_validations": candidate_validations,
         }
         envelope.update(candidate_envelope_changes or {})
         candidate_envelope_path.write_text(

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -855,8 +855,8 @@ def test_approved_legacy_opencode_releases_remain_verifiable(
             "true",
         ),
         (
-            'if ! candidate_outer_format_valid "$candidate_dir/review.md"; then',
-            'if candidate_outer_format_valid "$candidate_dir/review.md"; then',
+            'if ! candidate_outer_format_valid "$candidate_dir/review.md" initial; then',
+            'if candidate_outer_format_valid "$candidate_dir/review.md" initial; then',
         ),
         (
             'echo "OpenCode format repair still violates the required outer grammar" >&2\n'
@@ -1834,6 +1834,12 @@ def test_v147_budget_helper_semantics_bind_live_ast_relationships(
             "        item.head_sha == request.head_sha "
             "for item in validated.invocations\n"
             "    ):\n"
+            "        if (\n"
+            "            request.authenticated_review.head_sha == request.head_sha\n"
+            "            and request.authenticated_review.covers_hash("
+            "request.full_diff_sha256)\n"
+            "        ):\n"
+            "            return refuse(validated, request, \"authenticated_reuse\")\n"
             "        return refuse(validated, request, \"duplicate_head\")\n",
             "    if False:\n"
             "        return refuse(validated, request, \"duplicate_head\")\n",


### PR DESCRIPTION
## Summary
- preserve bounded Gemini candidate diagnostics as SHA-256, fixed grammar rule, and source location
- retain separate sanitized OpenCode initial and repair validation records without uploading rejected raw output
- require exact authenticated same-head coverage for successful budget reuse and fail unauthenticated duplicate-head reruns
- keep current and immutable historical release contracts strictly verified

## Validation
- python3 -m pytest -q
  - 2750 passed, 48 subtests passed
- git diff --check
- Python compile and workflow YAML load
- independent code review: no Critical or Important findings after re-review

Closes #61