### PR TITLE
chore(workflows): default rollout to v1.50

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.49",
+  "automation_ref": "v1.50",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -33,7 +33,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.49"
+    assert config.automation_ref == "v1.50"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
## Summary

- advance the fleet default from immutable v1.49 to verified v1.50
- update the closed catalog expectation only

## Release evidence

- v1.50 annotated tag resolves to ffdf5c1ff6237502ac67296ffabb9146d623c7a6
- public remote workflow release verification passed
- rollout/catalog/release tests: 880 passed, 46 subtests passed
- git diff --check: passed

Release follow-up for #61.