### PR TITLE
fix(gemini): skip identical manual review fallback

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -395,6 +395,19 @@ jobs:
           private-key: ${{ inputs.repo_write_auth == 'github_app' && secrets.APP_PRIVATE_KEY || '' }}
           fallback-token: ${{ inputs.repo_write_auth == 'github_token' && github.token || '' }}
 
+      - name: Resolve Gemini review fallback route
+        id: gemini_review_fallback_route
+        env:
+          PRIMARY_MODEL: '${{ vars.GEMINI_MODEL }}'
+          FALLBACK_MODEL: '${{ vars.GEMINI_FALLBACK_MODEL }}'
+        run: |
+          set -euo pipefail
+          enabled=false
+          if [[ -n "$FALLBACK_MODEL" && "$FALLBACK_MODEL" != "$PRIMARY_MODEL" ]]; then
+            enabled=true
+          fi
+          printf 'enabled=%s\n' "$enabled" >> "$GITHUB_OUTPUT"
+
       - name: Run Gemini pull request review (primary)
         id: gemini_review_primary
         uses: google-github-actions/run-gemini-cli@v0
@@ -452,7 +465,7 @@ jobs:
             Keep the response concise and structured with clear headings.
 
       - name: Log primary model failure
-        if: steps.gemini_review_primary.outcome == 'failure' && vars.GEMINI_FALLBACK_MODEL != '' && vars.GEMINI_FALLBACK_MODEL != vars.GEMINI_MODEL
+        if: steps.gemini_review_primary.outcome == 'failure' && steps.gemini_review_fallback_route.outputs.enabled == 'true'
         env:
           GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
           ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
@@ -478,7 +491,7 @@ jobs:
 
       - name: Run Gemini pull request review (fallback)
         id: gemini_review_fallback
-        if: steps.gemini_review_primary.outcome == 'failure' && vars.GEMINI_FALLBACK_MODEL != '' && vars.GEMINI_FALLBACK_MODEL != vars.GEMINI_MODEL
+        if: steps.gemini_review_primary.outcome == 'failure' && steps.gemini_review_fallback_route.outputs.enabled == 'true'
         uses: google-github-actions/run-gemini-cli@v0
         continue-on-error: true
         env:

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -452,7 +452,7 @@ jobs:
             Keep the response concise and structured with clear headings.
 
       - name: Log primary model failure
-        if: steps.gemini_review_primary.outcome == 'failure' && vars.GEMINI_FALLBACK_MODEL != ''
+        if: steps.gemini_review_primary.outcome == 'failure' && vars.GEMINI_FALLBACK_MODEL != '' && vars.GEMINI_FALLBACK_MODEL != vars.GEMINI_MODEL
         env:
           GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
           ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
@@ -478,7 +478,7 @@ jobs:
 
       - name: Run Gemini pull request review (fallback)
         id: gemini_review_fallback
-        if: steps.gemini_review_primary.outcome == 'failure' && vars.GEMINI_FALLBACK_MODEL != ''
+        if: steps.gemini_review_primary.outcome == 'failure' && vars.GEMINI_FALLBACK_MODEL != '' && vars.GEMINI_FALLBACK_MODEL != vars.GEMINI_MODEL
         uses: google-github-actions/run-gemini-cli@v0
         continue-on-error: true
         env:

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -6495,6 +6495,33 @@ def _dispatch_extract_outputs(tmp_path: Path, comments: list[dict]) -> dict:
 
 
 @node_required
+def test_dispatch_rejects_unauthorized_review_command_before_model_job(tmp_path):
+    context = {
+        "eventName": "issue_comment",
+        "payload": {
+            "comment": {
+                "body": "@gemini-cli /review",
+                "author_association": "NONE",
+            },
+            "issue": {"number": 7},
+        },
+    }
+    calls = _run_upsert(
+        tmp_path,
+        "gemini-dispatch.yml",
+        "dispatch",
+        "Extract command",
+        {},
+        [],
+        context=context,
+    )
+    outputs = {call[1]: call[2] for call in calls if call[0] == "output"}
+
+    assert outputs["command"] == "unauthorized"
+    assert "additional_context" not in outputs
+
+
+@node_required
 def test_dispatch_extract_takes_sha_from_newest_bot_sticky_only(tmp_path):
     forged = _human(
         "attacker",
@@ -6601,6 +6628,21 @@ def test_dispatch_checks_out_resolved_head_trusts_ci_workspace_and_records_sha()
 
     upsert = _step(workflow, "review", "Upsert PR comment (Gemini Review)")
     assert upsert["env"]["REVIEWED_SHA"] == "${{ needs.dispatch.outputs.reviewed_sha }}"
+
+
+def test_dispatch_skips_identical_fallback_model_route():
+    workflow = _load("gemini-dispatch.yml")
+    expected = (
+        "steps.gemini_review_primary.outcome == 'failure' && "
+        "vars.GEMINI_FALLBACK_MODEL != '' && "
+        "vars.GEMINI_FALLBACK_MODEL != vars.GEMINI_MODEL"
+    )
+
+    assert _step(workflow, "review", "Log primary model failure")["if"] == expected
+    assert (
+        _step(workflow, "review", "Run Gemini pull request review (fallback)")["if"]
+        == expected
+    )
 
 
 def _extract_gemini_python() -> str:

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -6630,12 +6630,51 @@ def test_dispatch_checks_out_resolved_head_trusts_ci_workspace_and_records_sha()
     assert upsert["env"]["REVIEWED_SHA"] == "${{ needs.dispatch.outputs.reviewed_sha }}"
 
 
+def test_dispatch_resolves_fallback_route_with_case_sensitive_model_comparison(
+    tmp_path,
+):
+    workflow = _load("gemini-dispatch.yml")
+    resolver = next(
+        (
+            step
+            for step in workflow["jobs"]["review"]["steps"]
+            if step.get("name") == "Resolve Gemini review fallback route"
+        ),
+        None,
+    )
+    assert resolver is not None, "case-sensitive fallback route resolver is missing"
+
+    cases = (
+        ("gemini-3-flash-preview", "", "false"),
+        ("gemini-3-flash-preview", "gemini-3-flash-preview", "false"),
+        ("Gemini-3-Flash-Preview", "gemini-3-flash-preview", "true"),
+        ("gemini-3-flash-preview", "gemini-2.5-flash", "true"),
+    )
+    for index, (primary, fallback, expected) in enumerate(cases):
+        output = tmp_path / f"github-output-{index}"
+        result = subprocess.run(
+            ["bash", "-c", resolver["run"]],
+            cwd=tmp_path,
+            env={
+                **os.environ,
+                "PRIMARY_MODEL": primary,
+                "FALLBACK_MODEL": fallback,
+                "GITHUB_OUTPUT": str(output),
+            },
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert _github_outputs(output) == {"enabled": expected}
+
+
 def test_dispatch_skips_identical_fallback_model_route():
     workflow = _load("gemini-dispatch.yml")
     expected = (
         "steps.gemini_review_primary.outcome == 'failure' && "
-        "vars.GEMINI_FALLBACK_MODEL != '' && "
-        "vars.GEMINI_FALLBACK_MODEL != vars.GEMINI_MODEL"
+        "steps.gemini_review_fallback_route.outputs.enabled == 'true'"
     )
 
     assert _step(workflow, "review", "Log primary model failure")["if"] == expected


### PR DESCRIPTION
## Summary
- skip the manual review fallback when it resolves to the same model as the primary route
- avoid posting a misleading primary-failure fallback announcement for that identical route
- preserve the existing step-scoped trusted-workspace setting and authorization gate
- add regression coverage for identical routes and unauthorized commands

## Validation
- `python3 -m pytest -q` — 2760 passed, 48 subtests passed
- actionlint 1.7.12 over central and baseline workflows — passed
- TDD regression test observed failing before the workflow condition change

Closes #62