### PR TITLE
feat(review): add command-controlled review mode

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,3 @@
+code_review:
+  pull_request_opened:
+    code_review: false

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,13 +8,16 @@ paths:
       - 'specifying action "\$/\.github/actions/prepare-review-diff" in invalid format because ref is missing'
       - 'specifying action "\$/\.github/actions/review-invocation-budget" in invalid format because ref is missing'
       - 'specifying action "\$/\.github/actions/canonicalize-review" in invalid format because ref is missing'
+      - 'specifying action "\$/\.github/actions/resolve-review-policy" in invalid format because ref is missing'
   .github/workflows/gemini-auto-review.yml:
     ignore:
       - 'specifying action "\$/\.github/actions/setup-gemini-auth" in invalid format because ref is missing'
       - 'specifying action "\$/\.github/actions/prepare-review-diff" in invalid format because ref is missing'
       - 'specifying action "\$/\.github/actions/review-invocation-budget" in invalid format because ref is missing'
       - 'specifying action "\$/\.github/actions/canonicalize-review" in invalid format because ref is missing'
+      - 'specifying action "\$/\.github/actions/resolve-review-policy" in invalid format because ref is missing'
   .github/workflows/opencode-auto-review.yml:
     ignore:
       - 'specifying action "\$/\.github/actions/prepare-review-diff" in invalid format because ref is missing'
       - 'specifying action "\$/\.github/actions/review-invocation-budget" in invalid format because ref is missing'
+      - 'specifying action "\$/\.github/actions/resolve-review-policy" in invalid format because ref is missing'

--- a/.github/actions/resolve-review-policy/action.yml
+++ b/.github/actions/resolve-review-policy/action.yml
@@ -1,0 +1,88 @@
+name: Resolve Review Policy
+description: Resolve a deterministic review policy before model invocation.
+
+inputs:
+  workflow-name:
+    description: Workflow name in workflow-config.yml.
+    required: true
+  pr-number:
+    description: Pull request number.
+    required: true
+  review-mode:
+    description: Requested review mode.
+    required: true
+  force-run:
+    description: Run even when the workflow is disabled.
+    required: true
+  force-review:
+    description: Request a review for a manual dispatch.
+    required: true
+  github-token:
+    description: Token used to read the pull request.
+    required: true
+
+outputs:
+  run-review:
+    description: Whether a review may run.
+    value: ${{ steps.resolve.outputs.run-review }}
+  effective-mode:
+    description: The resolved review mode.
+    value: ${{ steps.resolve.outputs.effective-mode }}
+  reason:
+    description: Deterministic resolution reason.
+    value: ${{ steps.resolve.outputs.reason }}
+  head-sha:
+    description: Validated pull request head SHA.
+    value: ${{ steps.resolve.outputs.head-sha }}
+
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        REVIEW_MODE: ${{ inputs.review-mode }}
+        WORKFLOW_NAME: ${{ inputs.workflow-name }}
+        FORCE_RUN: ${{ inputs.force-run }}
+        FORCE_REVIEW: ${{ inputs.force-review }}
+      run: |
+        set -euo pipefail
+        policy_dir="$RUNNER_TEMP/review-policy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        install -d -m 0700 "$policy_dir"
+        gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > "$policy_dir/pr.json"
+        ruby -ryaml -rjson -e 'cfg = File.file?(ARGV[0]) ? (YAML.safe_load_file(ARGV[0], aliases: false) || {}) : {}; File.write(ARGV[1], JSON.generate(cfg))' \
+          .github/workflow-config.yml "$policy_dir/config.json"
+        python3 - "$policy_dir/pr.json" "$policy_dir/config.json" "$policy_dir/request.json" <<'PY'
+        import json
+        import os
+        import sys
+        from pathlib import Path
+
+        def boolean(name: str) -> bool:
+            value = os.environ[name]
+            if value not in {"true", "false"}:
+                raise SystemExit(f"{name.lower()}_invalid")
+            return value == "true"
+
+        pr_path, config_path, request_path = map(Path, sys.argv[1:])
+        payload = {
+            "workflow_name": os.environ["WORKFLOW_NAME"],
+            "review_mode": os.environ["REVIEW_MODE"],
+            "force_run": boolean("FORCE_RUN"),
+            "force_review": boolean("FORCE_REVIEW"),
+            "event_name": os.environ["GITHUB_EVENT_NAME"],
+            "repository": os.environ["GITHUB_REPOSITORY"],
+            "pr": json.loads(pr_path.read_text(encoding="utf-8")),
+            "config": json.loads(config_path.read_text(encoding="utf-8")),
+        }
+        request_path.write_text(
+            json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        PY
+        python3 "$GITHUB_ACTION_PATH/resolve_review_policy.py" \
+          --request-file "$policy_dir/request.json" \
+          --result-file "$policy_dir/result.json" \
+          --github-output "$GITHUB_OUTPUT"

--- a/.github/actions/resolve-review-policy/resolve_review_policy.py
+++ b/.github/actions/resolve-review-policy/resolve_review_policy.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Resolve whether a pull request review may invoke a model."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+class PolicyError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class PolicyRequest:
+    workflow_name: str
+    review_mode: str
+    force_run: bool
+    force_review: bool
+    event_name: str
+    repository: str
+    pr: dict[str, object]
+    config: dict[str, object]
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    run_review: bool
+    effective_mode: str
+    reason: str
+    head_sha: str
+
+
+_REPOSITORY_PATTERN = re.compile(r"[^/\s]+/[^/\s]+\Z")
+_SHA_PATTERN = re.compile(r"[0-9a-fA-F]{40}\Z")
+_MODES = {"auto", "request", "skip", "conflict"}
+
+
+def resolve_policy(request: PolicyRequest) -> PolicyDecision:
+    _validate_request(request)
+    labels = _label_names(request.pr)
+    if {"review:request", "review:skip"} <= labels:
+        raise PolicyError("review_label_conflict")
+    label_mode = (
+        "request"
+        if "review:request" in labels
+        else "skip"
+        if "review:skip" in labels
+        else "auto"
+    )
+    if request.review_mode not in _MODES:
+        raise PolicyError("review_mode_invalid")
+    if request.review_mode == "conflict":
+        raise PolicyError("review_label_conflict")
+    manual_request = request.event_name == "workflow_dispatch" and request.force_review
+    if manual_request and request.review_mode != "request":
+        raise PolicyError("force_review_mode_invalid")
+    if not manual_request and request.review_mode != label_mode:
+        raise PolicyError("review_mode_label_mismatch")
+    head_sha = _validated_head(request.pr, request.repository)
+    if request.pr.get("state") != "open":
+        return PolicyDecision(False, request.review_mode, "closed", head_sha)
+    if request.pr.get("draft") is True:
+        return PolicyDecision(False, request.review_mode, "draft", head_sha)
+    if head_sha == "":
+        return PolicyDecision(False, request.review_mode, "unsafe_pr", "")
+    if not _workflow_enabled(request.config, request.workflow_name) and not request.force_run:
+        return PolicyDecision(False, request.review_mode, "workflow_disabled", head_sha)
+    if request.review_mode == "skip":
+        return PolicyDecision(False, "skip", "skip", head_sha)
+    if request.review_mode == "request" or request.force_run:
+        return PolicyDecision(True, "request", "request", head_sha)
+    return _automatic_decision(request, head_sha)
+
+
+def _validate_request(request: PolicyRequest) -> None:
+    if not isinstance(request.workflow_name, str) or not request.workflow_name:
+        raise PolicyError("workflow_name_invalid")
+    if not isinstance(request.review_mode, str):
+        raise PolicyError("review_mode_invalid")
+    if type(request.force_run) is not bool:
+        raise PolicyError("force_run_invalid")
+    if type(request.force_review) is not bool:
+        raise PolicyError("force_review_invalid")
+    if not isinstance(request.event_name, str) or not request.event_name:
+        raise PolicyError("event_name_invalid")
+    if not isinstance(request.pr, dict):
+        raise PolicyError("pr_invalid")
+    if not isinstance(request.config, dict):
+        raise PolicyError("config_invalid")
+    _validate_repository(request.repository, "repository_invalid")
+
+
+def _label_names(pr: dict[str, object]) -> set[str]:
+    labels = pr.get("labels", [])
+    if not isinstance(labels, list):
+        raise PolicyError("pr_labels_invalid")
+    names: set[str] = set()
+    for label in labels:
+        if not isinstance(label, dict) or not isinstance(label.get("name"), str):
+            raise PolicyError("pr_label_invalid")
+        names.add(label["name"])
+    return names
+
+
+def _validated_head(pr: dict[str, object], repository: str) -> str:
+    head = pr.get("head")
+    if not isinstance(head, dict):
+        raise PolicyError("pr_head_invalid")
+    head_repository = head.get("repo")
+    if not isinstance(head_repository, dict):
+        return ""
+    full_name = head_repository.get("full_name")
+    fork = head_repository.get("fork")
+    if not isinstance(full_name, str):
+        raise PolicyError("head_repository_invalid")
+    _validate_repository(full_name, "head_repository_invalid")
+    if type(fork) is not bool:
+        raise PolicyError("head_repository_invalid")
+    if fork or full_name != repository:
+        return ""
+    sha = head.get("sha")
+    if not isinstance(sha, str) or _SHA_PATTERN.fullmatch(sha) is None:
+        raise PolicyError("head_sha_invalid")
+    return sha
+
+
+def _validate_repository(repository: str, error: str) -> None:
+    if not isinstance(repository, str) or _REPOSITORY_PATTERN.fullmatch(repository) is None:
+        raise PolicyError(error)
+
+
+def _workflow_enabled(config: dict[str, object], workflow_name: str) -> bool:
+    workflows = config.get("workflows")
+    if workflows is None:
+        return True
+    if not isinstance(workflows, dict):
+        raise PolicyError("workflows_config_invalid")
+    workflow = workflows.get(workflow_name)
+    if workflow is None:
+        return True
+    if not isinstance(workflow, dict):
+        raise PolicyError("workflow_config_invalid")
+    enabled = workflow.get("enabled")
+    if enabled is None:
+        return True
+    if type(enabled) is not bool:
+        raise PolicyError("workflow_enabled_invalid")
+    return enabled
+
+
+def _automatic_decision(request: PolicyRequest, head_sha: str) -> PolicyDecision:
+    workflows = request.config.get("workflows")
+    if workflows is not None and not isinstance(workflows, dict):
+        raise PolicyError("workflows_config_invalid")
+    workflow = workflows.get(request.workflow_name) if workflows else None
+    if workflow is not None and not isinstance(workflow, dict):
+        raise PolicyError("workflow_config_invalid")
+    if workflow is not None and "auto" in workflow:
+        automatic = _required_boolean(workflow["auto"], "workflow_auto_invalid")
+        return PolicyDecision(
+            automatic,
+            "auto",
+            f"workflow_auto_{str(automatic).lower()}",
+            head_sha,
+        )
+    review = request.config.get("review")
+    if review is not None and not isinstance(review, dict):
+        raise PolicyError("review_config_invalid")
+    if review is not None and "auto" in review:
+        automatic = _required_boolean(review["auto"], "review_auto_invalid")
+        return PolicyDecision(
+            automatic,
+            "auto",
+            f"review_auto_{str(automatic).lower()}",
+            head_sha,
+        )
+    return PolicyDecision(True, "auto", "default_auto_true", head_sha)
+
+
+def _required_boolean(value: object, error: str) -> bool:
+    if type(value) is not bool:
+        raise PolicyError(error)
+    return value
+
+
+def _read_request(path: Path) -> PolicyRequest:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise PolicyError("request_invalid")
+    try:
+        return PolicyRequest(**payload)
+    except TypeError as error:
+        raise PolicyError("request_invalid") from error
+
+
+def _write_result(path: Path, decision: PolicyDecision) -> None:
+    path.write_text(
+        json.dumps(asdict(decision), separators=(",", ":"), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _append_github_outputs(path: Path, decision: PolicyDecision) -> None:
+    values = {
+        "run-review": str(decision.run_review).lower(),
+        "effective-mode": decision.effective_mode,
+        "reason": decision.reason,
+        "head-sha": decision.head_sha,
+    }
+    with path.open("a", encoding="utf-8") as output:
+        for key, value in values.items():
+            output.write(f"{key}={value}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--request-file", type=Path, required=True)
+    parser.add_argument("--result-file", type=Path, required=True)
+    parser.add_argument("--github-output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        decision = resolve_policy(_read_request(args.request_file))
+        _write_result(args.result_file, decision)
+        _append_github_outputs(args.github_output, decision)
+    except (OSError, TypeError, ValueError, json.JSONDecodeError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/resolve-review-policy/resolve_review_policy.py
+++ b/.github/actions/resolve-review-policy/resolve_review_policy.py
@@ -59,7 +59,9 @@ def resolve_policy(request: PolicyRequest) -> PolicyDecision:
     manual_request = request.event_name == "workflow_dispatch" and request.force_review
     if manual_request and request.review_mode != "request":
         raise PolicyError("force_review_mode_invalid")
-    if not manual_request and request.review_mode != label_mode:
+    if request.review_mode != label_mode and not (
+        manual_request and label_mode == "auto"
+    ):
         raise PolicyError("review_mode_label_mismatch")
     head_sha = _validated_head(request.pr, request.repository)
     if request.pr.get("state") != "open":

--- a/.github/workflow-config.yml
+++ b/.github/workflow-config.yml
@@ -63,6 +63,9 @@ workflows:
     description: "Auto-notify reviewers when review feedback is addressed"
 
 # === Shared Settings ===
+review:
+  auto: false
+
 claude:
   # Optional. If empty/omitted, claude-code-action default is used.
   # Examples: claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5-20251001

--- a/.github/workflows/_self-claude-review.yml
+++ b/.github/workflows/_self-claude-review.yml
@@ -7,11 +7,14 @@ name: Self Claude Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
 
 jobs:
   claude-review:
-    if: ${{ github.event.pull_request.head.repo.fork == false }}
+    if: >-
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
     permissions:
       actions: read
       contents: read
@@ -22,5 +25,14 @@ jobs:
     with:
       pr_number: '${{ github.event.pull_request.number }}'
       force_run: false
+      force_review: false
+      review_mode: >-
+        ${{
+          contains(github.event.pull_request.labels.*.name, 'review:request') &&
+          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'conflict' ||
+          contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||
+          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'skip' ||
+          'auto'
+        }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/_self-gemini-auto-review.yml
+++ b/.github/workflows/_self-gemini-auto-review.yml
@@ -9,7 +9,7 @@ name: Self Gemini Auto Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
 
 jobs:
   check-secret:
@@ -36,7 +36,8 @@ jobs:
     if: >-
       needs.check-secret.outputs.has_key == 'true' &&
       github.event.pull_request.head.repo.fork == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
     permissions:
       actions: read
       contents: read
@@ -45,6 +46,15 @@ jobs:
     uses: ./.github/workflows/gemini-auto-review.yml
     with:
       pr_number: ${{ github.event.pull_request.number }}
+      force_review: false
+      review_mode: >-
+        ${{
+          contains(github.event.pull_request.labels.*.name, 'review:request') &&
+          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'conflict' ||
+          contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||
+          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'skip' ||
+          'auto'
+        }}
       repo_write_auth: github_token
       publisher_app_id: ${{ vars.APP_ID }}
     secrets:

--- a/.github/workflows/_self-opencode-auto-review.yml
+++ b/.github/workflows/_self-opencode-auto-review.yml
@@ -8,7 +8,7 @@ name: Self OpenCode Auto Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
 
 jobs:
   check-secret:
@@ -37,7 +37,8 @@ jobs:
     if: >-
       needs.check-secret.outputs.has_key == 'true' &&
       github.event.pull_request.head.repo.fork == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
     permissions:
       actions: read
       checks: write
@@ -47,5 +48,14 @@ jobs:
     uses: ./.github/workflows/opencode-auto-review.yml
     with:
       pr_number: ${{ github.event.pull_request.number }}
+      force_review: false
+      review_mode: >-
+        ${{
+          contains(github.event.pull_request.labels.*.name, 'review:request') &&
+          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'conflict' ||
+          contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||
+          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'skip' ||
+          'auto'
+        }}
     secrets:
       ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,6 +7,11 @@ on:
         description: 'Pull request number (optional; defaults to event PR number)'
         type: string
         required: false
+      review_mode:
+        description: Resolved PR review policy
+        type: string
+        required: false
+        default: auto
       force_run:
         description: 'Run even if disabled in workflow-config.yml'
         type: boolean
@@ -35,7 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
-      auto_enabled: ${{ steps.auto_mode.outputs.auto_enabled }}
+      policy_run: ${{ steps.review_policy.outputs.run-review }}
+      policy_reason: ${{ steps.review_policy.outputs.reason }}
+      policy_head: ${{ steps.review_policy.outputs.head-sha }}
       model: ${{ steps.model.outputs.model }}
     steps:
       - name: Checkout
@@ -48,32 +55,18 @@ jobs:
         uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
         with:
           workflow-name: claude-code-review
-          force-run: ${{ (inputs.force_run || inputs.force_review) && 'true' || 'false' }}
+          force-run: ${{ inputs.force_run && 'true' || 'false' }}
 
-      - name: Check auto review mode
-        id: auto_mode
-        env:
-          FORCE_RUN: ${{ (inputs.force_run || inputs.force_review) && 'true' || 'false' }}
-        run: |-
-          CONFIG_FILE=".github/workflow-config.yml"
-          if [[ "$FORCE_RUN" == 'true' ]]; then
-            echo "auto_enabled=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          auto_enabled="true"
-          if [[ -f "$CONFIG_FILE" ]]; then
-            # Per-workflow auto field: workflows.<name>.auto (default: true)
-            # Falls back to global review.auto for backward compatibility
-            auto_enabled="$(ruby -ryaml -e '
-              cfg = (YAML.load_file(ARGV[0]) rescue {}) || {}
-              v = cfg.dig("workflows", "claude-code-review", "auto")
-              v = cfg.dig("review", "auto") if v.nil?
-              v = true if v.nil?
-              puts(v ? "true" : "false")
-            ' "$CONFIG_FILE" 2>/dev/null || echo true)"
-          fi
-          echo "auto_enabled=${auto_enabled}" >> "$GITHUB_OUTPUT"
+      - name: Resolve PR review policy
+        id: review_policy
+        uses: $/.github/actions/resolve-review-policy
+        with:
+          workflow-name: claude-code-review
+          pr-number: ${{ inputs.pr_number || github.event.pull_request.number }}
+          review-mode: ${{ inputs.review_mode }}
+          force-run: ${{ inputs.force_run && 'true' || 'false' }}
+          force-review: ${{ inputs.force_review && 'true' || 'false' }}
+          github-token: ${{ github.token }}
 
       - name: Resolve Claude model from config
         id: model
@@ -95,7 +88,7 @@ jobs:
 
   claude-review:
     needs: check-enabled
-    if: needs.check-enabled.outputs.enabled == 'true' && needs.check-enabled.outputs.auto_enabled == 'true'
+    if: needs.check-enabled.outputs.enabled == 'true' && needs.check-enabled.outputs.policy_run == 'true'
     concurrency:
       group: automation-claude-review-${{ github.repository }}-${{ inputs.pr_number || github.event.pull_request.number }}
       cancel-in-progress: true
@@ -1138,7 +1131,7 @@ jobs:
   skipped:
     name: Workflow Skipped
     needs: check-enabled
-    if: needs.check-enabled.outputs.enabled != 'true' || needs.check-enabled.outputs.auto_enabled != 'true'
+    if: needs.check-enabled.outputs.enabled != 'true' || needs.check-enabled.outputs.policy_run != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Notice

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -21,6 +21,11 @@ on:
         description: 'Pull request number (optional; defaults to event PR number)'
         type: string
         required: false
+      review_mode:
+        description: Resolved PR review policy
+        type: string
+        required: false
+        default: auto
       force_run:
         description: 'Run even if disabled in workflow-config.yml'
         type: boolean
@@ -48,7 +53,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
-      auto_enabled: ${{ steps.auto_mode.outputs.auto_enabled }}
+      policy_run: ${{ steps.review_policy.outputs.run-review }}
+      policy_reason: ${{ steps.review_policy.outputs.reason }}
+      policy_head: ${{ steps.review_policy.outputs.head-sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -60,36 +67,22 @@ jobs:
         uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
         with:
           workflow-name: gemini-auto-review
-          force-run: ${{ (inputs.force_run || inputs.force_review) && 'true' || 'false' }}
+          force-run: ${{ inputs.force_run && 'true' || 'false' }}
 
-      - name: Check auto review mode
-        id: auto_mode
-        env:
-          FORCE_RUN: ${{ (inputs.force_run || inputs.force_review) && 'true' || 'false' }}
-        run: |-
-          CONFIG_FILE=".github/workflow-config.yml"
-          if [[ "$FORCE_RUN" == 'true' ]]; then
-            echo "auto_enabled=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          auto_enabled="true"
-          if [[ -f "$CONFIG_FILE" ]]; then
-            # Per-workflow auto field: workflows.<name>.auto (default: true)
-            # Falls back to global review.auto for backward compatibility
-            auto_enabled="$(ruby -ryaml -e '
-              cfg = (YAML.load_file(ARGV[0]) rescue {}) || {}
-              v = cfg.dig("workflows", "gemini-auto-review", "auto")
-              v = cfg.dig("review", "auto") if v.nil?
-              v = true if v.nil?
-              puts(v ? "true" : "false")
-            ' "$CONFIG_FILE" 2>/dev/null || echo true)"
-          fi
-          echo "auto_enabled=${auto_enabled}" >> "$GITHUB_OUTPUT"
+      - name: Resolve PR review policy
+        id: review_policy
+        uses: $/.github/actions/resolve-review-policy
+        with:
+          workflow-name: gemini-auto-review
+          pr-number: ${{ inputs.pr_number || github.event.pull_request.number }}
+          review-mode: ${{ inputs.review_mode }}
+          force-run: ${{ inputs.force_run && 'true' || 'false' }}
+          force-review: ${{ inputs.force_review && 'true' || 'false' }}
+          github-token: ${{ github.token }}
 
   gemini-review:
     needs: check-enabled
-    if: needs.check-enabled.outputs.enabled == 'true' && needs.check-enabled.outputs.auto_enabled == 'true'
+    if: needs.check-enabled.outputs.enabled == 'true' && needs.check-enabled.outputs.policy_run == 'true'
     concurrency:
       group: automation-gemini-auto-review-${{ github.repository }}-${{ inputs.pr_number || github.event.pull_request.number }}
       cancel-in-progress: true
@@ -1892,7 +1885,7 @@ jobs:
     permissions: {}
     name: Workflow Skipped
     needs: check-enabled
-    if: needs.check-enabled.outputs.enabled != 'true' || needs.check-enabled.outputs.auto_enabled != 'true'
+    if: needs.check-enabled.outputs.enabled != 'true' || needs.check-enabled.outputs.policy_run != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Notice

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -49,6 +49,7 @@ jobs:
   check-enabled:
     permissions:
       contents: read
+      pull-requests: read
     name: Check if enabled
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -7,8 +7,18 @@ on:
         description: 'Pull request number (optional; defaults to event PR number)'
         type: string
         required: false
+      review_mode:
+        description: Resolved PR review policy
+        type: string
+        required: false
+        default: auto
       force_run:
         description: 'Run even if disabled in workflow-config.yml'
+        type: boolean
+        required: false
+        default: false
+      force_review:
+        description: Perform one explicitly authorized review even when HEAD is unchanged
         type: boolean
         required: false
         default: false
@@ -31,8 +41,9 @@ jobs:
       pull-requests: read
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
-      auto_enabled: ${{ steps.auto_mode.outputs.auto_enabled }}
-      safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}
+      policy_run: ${{ steps.review_policy.outputs.run-review }}
+      policy_reason: ${{ steps.review_policy.outputs.reason }}
+      policy_head: ${{ steps.review_policy.outputs.head-sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -46,47 +57,22 @@ jobs:
           workflow-name: opencode-auto-review
           force-run: ${{ inputs.force_run && 'true' || 'false' }}
 
-      - name: Check auto review mode
-        id: auto_mode
-        env:
-          FORCE_RUN: ${{ inputs.force_run && 'true' || 'false' }}
-        run: |-
-          CONFIG_FILE=".github/workflow-config.yml"
-          if [[ "$FORCE_RUN" == 'true' ]]; then
-            echo "auto_enabled=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          auto_enabled="true"
-          if [[ -f "$CONFIG_FILE" ]]; then
-            # Precedence (matches claude/gemini): workflows.opencode-auto-review.auto → review.auto → default true
-            auto_enabled="$(ruby -ryaml -e 'cfg = (YAML.load_file(ARGV[0]) rescue {}) || {}; v = cfg.dig("workflows", "opencode-auto-review", "auto"); v = cfg.dig("review", "auto") if v.nil?; v = true if v.nil?; puts(v ? "true" : "false")' "$CONFIG_FILE" 2>/dev/null || echo true)"
-          fi
-          echo "auto_enabled=${auto_enabled}" >> "$GITHUB_OUTPUT"
-
-      - name: Verify same-repository PR
-        id: pr_scope
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
-        run: |
-          echo "safe_pr=false" >> "$GITHUB_OUTPUT"
-          if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            exit 0
-          fi
-          metadata="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
-            --jq '[.head.repo.full_name, .head.repo.fork] | @tsv' 2>/dev/null)" || exit 0
-          IFS=$'\t' read -r head_repo head_fork <<< "$metadata"
-          if [[ "$head_repo" == "$GITHUB_REPOSITORY" && "$head_fork" == "false" ]]; then
-            echo "safe_pr=true" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Resolve PR review policy
+        id: review_policy
+        uses: $/.github/actions/resolve-review-policy
+        with:
+          workflow-name: opencode-auto-review
+          pr-number: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
+          review-mode: ${{ inputs.review_mode }}
+          force-run: ${{ inputs.force_run && 'true' || 'false' }}
+          force-review: ${{ inputs.force_review && 'true' || 'false' }}
+          github-token: ${{ github.token }}
 
   opencode-prepare:
     needs: check-enabled
     if: >-
       needs.check-enabled.outputs.enabled == 'true' &&
-      needs.check-enabled.outputs.auto_enabled == 'true' &&
-      needs.check-enabled.outputs.safe_pr == 'true'
+      needs.check-enabled.outputs.policy_run == 'true'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -470,6 +456,7 @@ jobs:
           pr-number: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
           previous-sha: ${{ steps.ctx.outputs.previous_sha }}
           previous-full-hash: ${{ steps.ctx.outputs.previous_full_hash }}
+          force-full: ${{ inputs.force_review && 'true' || 'false' }}
           context-lines: '3'
           output-directory: ${{ github.workspace }}
 
@@ -485,11 +472,18 @@ jobs:
           expected-head-sha: ${{ steps.prepare-diff.outputs.head-sha }}
           full-diff-sha256: ${{ steps.prepare-diff.outputs.full-diff-sha256 }}
           diff-mode: ${{ steps.prepare-diff.outputs.diff-mode }}
+          force-review: ${{ inputs.force_review && 'true' || 'false' }}
           input-files-json: ${{ format('["{0}/review-full.diff","{0}/review-scope.json"]', github.workspace) }}
           authenticated-review-json: ${{ steps.ctx.outputs.authenticated_review_json }}
           model-route-json: '["zai-coding-plan/glm-4.7"]'
           effort: final-review/default
           checkpoint-file: ${{ runner.temp }}/opencode-review-budget-claim.json
+
+      - name: Enforce force-review claim
+        if: ${{ always() && !cancelled() && inputs.force_review && steps.review-budget-claim.outputs.allow-invocation != 'true' }}
+        run: |
+          echo '::error::force-review was not authorized by the bounded review budget'
+          exit 1
 
       - name: Seal review scope manifest
         id: scope-integrity
@@ -621,8 +615,7 @@ jobs:
     needs: [check-enabled, opencode-prepare]
     if: >-
       needs.check-enabled.outputs.enabled == 'true' &&
-      needs.check-enabled.outputs.auto_enabled == 'true' &&
-      needs.check-enabled.outputs.safe_pr == 'true' &&
+      needs.check-enabled.outputs.policy_run == 'true' &&
       needs.opencode-prepare.result == 'success' &&
       needs.opencode-prepare.outputs.allow_invocation == 'true'
     runs-on: ubuntu-latest
@@ -3209,8 +3202,7 @@ jobs:
     if: >-
       always() && !cancelled() &&
       needs.check-enabled.outputs.enabled == 'true' &&
-      needs.check-enabled.outputs.auto_enabled == 'true' &&
-      needs.check-enabled.outputs.safe_pr == 'true' &&
+      needs.check-enabled.outputs.policy_run == 'true' &&
       needs.opencode-prepare.result == 'success' &&
       (needs.opencode-prepare.outputs.allow_invocation == 'true' ||
       (needs.opencode-prepare.outputs.budget_decision == 'authenticated_reuse' &&
@@ -5102,8 +5094,7 @@ jobs:
     needs: check-enabled
     if: >-
       needs.check-enabled.outputs.enabled != 'true' ||
-      needs.check-enabled.outputs.auto_enabled != 'true' ||
-      needs.check-enabled.outputs.safe_pr != 'true'
+      needs.check-enabled.outputs.policy_run != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Notice

--- a/docs/superpowers/plans/2026-08-31-review-mode-jhw-commands.md
+++ b/docs/superpowers/plans/2026-08-31-review-mode-jhw-commands.md
@@ -1,0 +1,683 @@
+# Review-mode JHW Commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `/jhw:ship` with canonical `/jhw:pr`, add per-operation review selection, and add `/jhw:issue` with bounded supported-reviewer waiting and summaries.
+
+**Architecture:** Keep the existing Markdown skill runtime: move the mature ship review-round contract into canonical `pr.md`, add small tested shell contracts for policy/mutation ordering and explicit App requests, and leave `ship.md` as an argument-preserving alias. `issue.md` reuses the same mode vocabulary and response classifications but has its own narrow creation/reviewer plan. Generated Codex skills continue to come only from `scripts/sync-codex-skills.mjs`.
+
+**Tech Stack:** Markdown skill workflows, Bash snippets executed by agent tools, GitHub CLI/API, Node.js contract tests, canonical-to-Codex skill generator, shell install-safety tests.
+
+**Spec:** `/home/jhw/ai/opencode/projects/automation/.worktrees/review-mode-command-control/docs/superpowers/specs/2026-08-31-review-mode-command-control-design.md`
+
+## Global Constraints
+
+- Target repository: `/home/jhw/ai/opencode/projects/jhw-notion-runtime`; implement from a fresh isolated worktree based on current `origin/main`.
+- Before editing skill content, use `skill-creator` and `superpowers:writing-skills`; use `superpowers:test-driven-development` for every behavior change.
+- Canonical sources are only `skills/claude/*.md`; never hand-edit generated `skills/codex/jhw-*` content.
+- `/jhw:pr` keeps every current `/jhw:ship` option and adds exactly `--review` and `--no-review`.
+- `/jhw:ship` remains a deprecated argument-compatible alias.
+- `--review` and `--no-review` together fail before labels, push, PR, issue, comment, dispatch, or merge.
+- Explicit modes use only `review:request` and `review:skip`; no option removes both overrides and follows configuration.
+- New PR ordering is push -> draft PR -> label reconcile/verify -> ready -> App requests.
+- Existing PR ordering is label reconcile/verify -> push -> App requests.
+- `--no-review` invokes and awaits no AI reviewer; CI, target, head, mergeability, and explicit merge requirements remain.
+- App requests are idempotent per reviewer and PR head.
+- Issue review never edits/closes the issue or implements feedback automatically.
+- Codex standalone-issue review is planned only after demonstrated connector/environment support; Gemini Assist and OpenCode are not issue reviewers.
+- Do not modify Notion databases, Project Control state, or issue #52.
+- Automation `v1.51` remote verification and the canary caller rollout are prerequisites.
+- Every shell command in this environment starts with `rtk`.
+
+## File map
+
+All paths below are relative to the jhw-notion target repository.
+
+| Path | Responsibility |
+| --- | --- |
+| `skills/claude/pr.md` | Canonical PR creation, review policy, waiting, repair, and merge workflow |
+| `skills/claude/ship.md` | Deprecated alias that forwards to `pr.md` |
+| `skills/claude/issue.md` | Issue creation and supported-reviewer workflow |
+| `scripts/test-pr-skill-contract.mjs` | Executable PR option, ordering, trigger, and merge contracts |
+| `scripts/test-issue-skill-contract.mjs` | Executable issue policy, reviewer-plan, and wait contracts |
+| `scripts/test-install-safety.sh` | Runs both skill contracts in the existing install-safety suite |
+| `skills/claude/AGENTS.md` | User-facing canonical/alias command inventory |
+| `README.md` | Installation and command summary |
+| `skills/codex/jhw-pr/*` | Generated Codex PR skill |
+| `skills/codex/jhw-issue/*` | Generated Codex issue skill |
+| `skills/codex/jhw-ship/*` | Regenerated deprecated alias skill |
+
+---
+
+### Task 1: Establish `/jhw:pr` as the canonical skill without behavior drift
+
+**Files:**
+- Create from rename: `skills/claude/pr.md`
+- Create: `skills/claude/ship.md`
+- Rename: `scripts/test-ship-skill-contract.mjs` -> `scripts/test-pr-skill-contract.mjs`
+- Modify: `scripts/test-install-safety.sh`
+
+**Interfaces:**
+- Preserves: all current v3 Claude/Gemini, OpenCode, Codex, timeout, severity, target, and auto-fix behavior.
+- Produces: canonical markers and state paths prefixed `jhw-pr`.
+- Produces: alias file containing no duplicate review implementation.
+
+- [ ] **Step 1: Write the RED canonical/alias assertions**
+
+Rename the test file, then change its source paths:
+
+```bash
+rtk git mv scripts/test-ship-skill-contract.mjs scripts/test-pr-skill-contract.mjs
+```
+
+```javascript
+const canonicalPr = join(repoRoot, "skills", "claude", "pr.md");
+const shipAlias = join(repoRoot, "skills", "claude", "ship.md");
+const prText = readFileSync(canonicalPr, "utf8");
+const aliasText = readFileSync(shipAlias, "utf8");
+
+assert.match(prText, /^# \/jhw:pr — PR 생성/m);
+assert.match(prText, /<!-- jhw-pr:codex-review round=/);
+assert.doesNotMatch(prText, /<!-- jhw-ship:codex-review/);
+assert.match(aliasText, /deprecated/i);
+assert.match(aliasText, /\/jhw:pr/);
+assert.doesNotMatch(aliasText, /ship-round-contract: trigger-and-scope:begin/);
+```
+
+Keep every existing executable round test, but make it extract the block from `prText` and expect `jhw-pr` marker/state names.
+
+- [ ] **Step 2: Run the renamed test and confirm RED**
+
+```bash
+rtk node scripts/test-pr-skill-contract.mjs
+```
+
+Expected: failure reports missing `skills/claude/pr.md`.
+
+- [ ] **Step 3: Move the mature implementation and create a thin alias**
+
+Use Git rename so history follows the implementation:
+
+```bash
+rtk git mv skills/claude/ship.md skills/claude/pr.md
+```
+
+Change the canonical frontmatter/title/examples and these internal names only:
+
+```text
+/jhw:ship                         -> /jhw:pr
+jhw-ship:codex-review             -> jhw-pr:codex-review
+jhw-ship.${PR}.round.${ROUND}     -> jhw-pr.${PR}.round.${ROUND}
+```
+
+Create `skills/claude/ship.md` with this complete alias behavior:
+
+```markdown
+---
+description: "(deprecated) /jhw:pr 사용 — 모든 인자를 변경 없이 전달"
+argument-hint: "[same arguments as /jhw:pr]"
+---
+
+# /jhw:ship (deprecated)
+
+이 명령은 `/jhw:pr`의 호환 alias다.
+
+1. 같은 canonical 디렉터리의 `pr.md`를 읽는다.
+2. 사용자가 `/jhw:ship` 뒤에 준 모든 인자를 순서와 값 변경 없이 `/jhw:pr` 인자로 해석한다.
+3. 실행 시작 시 `/jhw:ship`이 deprecated이며 `/jhw:pr`로 대체되었다고 한 줄 알린다.
+4. 이후에는 `pr.md`의 승인점·안전 규칙·테스트·리뷰·머지 절차만 실행한다.
+
+별도 PR·리뷰·머지 로직을 이 alias에 복제하지 않는다.
+```
+
+- [ ] **Step 4: Point install safety at the canonical test**
+
+Replace only:
+
+```bash
+node "$REPO_ROOT/scripts/test-ship-skill-contract.mjs"
+```
+
+with:
+
+```bash
+node "$REPO_ROOT/scripts/test-pr-skill-contract.mjs"
+```
+
+- [ ] **Step 5: Run preserved behavior tests**
+
+```bash
+rtk node scripts/test-pr-skill-contract.mjs
+```
+
+Expected: `pr skill contract: ok`; every pre-existing round/polling assertion remains present.
+
+- [ ] **Step 6: Commit the canonical rename**
+
+```bash
+rtk git add skills/claude/pr.md skills/claude/ship.md scripts/test-pr-skill-contract.mjs scripts/test-install-safety.sh
+rtk git commit -m "refactor(skills): make jhw pr the canonical ship workflow"
+```
+
+---
+
+### Task 2: Add PR review-mode parsing, labels, and race-free mutation order
+
+**Files:**
+- Modify: `skills/claude/pr.md`
+- Modify: `scripts/test-pr-skill-contract.mjs`
+
+**Interfaces:**
+- Produces shell functions: `jhw_pr_review_mode_from_args`, `jhw_pr_global_auto_enabled`, `jhw_pr_ensure_review_labels`, `jhw_pr_reconcile_review_labels`, `jhw_pr_verify_remote_policy`.
+- Produces scalar mode: `request`, `skip`, or `auto`.
+- Consumes: `REPO_NWO`, optional `PR`, and original command arguments.
+
+- [ ] **Step 1: Write RED executable mode tests**
+
+Extract a new `<!-- pr-review-mode-contract:begin -->` Bash block and execute it with the existing fake-command test harness. Assert:
+
+```javascript
+const runMode = (args) => run(baseState(), `jhw_pr_review_mode_from_args ${args}`);
+
+assert.equal((await runMode("--review")).stdout.trim(), "request");
+assert.equal((await runMode("--no-review")).stdout.trim(), "skip");
+assert.equal((await runMode("--merge --target")).stdout.trim(), "auto");
+assert.notEqual((await runMode("--review --no-review")).code, 0);
+```
+
+Add global-config cases proving `review.auto: true`, `review.auto: false`, and missing config resolve to `true`, `false`, and compatibility `true`; a non-boolean value must fail before mutation.
+
+Add a mutation-log fake `gh` and assert exact order for new and existing PRs:
+
+```javascript
+assert.deepEqual(newPrLog, ["ensure-labels", "push", "create-draft", "set-request", "verify", "ready"]);
+assert.deepEqual(existingPrLog, ["ensure-labels", "set-skip", "verify", "push"]);
+assert.deepEqual(autoExistingLog, ["ensure-labels", "remove-request", "remove-skip", "verify", "push"]);
+```
+
+- [ ] **Step 2: Run the focused mode tests and confirm RED**
+
+```bash
+rtk node scripts/test-pr-skill-contract.mjs
+```
+
+Expected: missing contract marker/function failures.
+
+- [ ] **Step 3: Implement option resolution before all mutations**
+
+Add the exact parser:
+
+```bash
+jhw_pr_review_mode_from_args() {
+  local arg saw_review=0 saw_no_review=0
+  for arg in "$@"; do
+    case "$arg" in
+      --review) saw_review=1 ;;
+      --no-review) saw_no_review=1 ;;
+    esac
+  done
+  (( saw_review == 0 || saw_no_review == 0 )) || {
+    echo "--review and --no-review are mutually exclusive" >&2
+    return 2
+  }
+  (( saw_review == 1 )) && { printf 'request\n'; return; }
+  (( saw_no_review == 1 )) && { printf 'skip\n'; return; }
+  printf 'auto\n'
+}
+```
+
+Call it during the first preflight, before dirty-tree repair or any GitHub mutation. Add both options to frontmatter, the option table, examples, and merge rules.
+
+Implement `jhw_pr_global_auto_enabled` with Ruby's standard YAML library, reading only global `review.auto`. It prints `true` or `false`, defaults to `true` only when the file/key is absent, and exits nonzero when the present value is not a Boolean. Per-workflow automatic overrides remain owned by the managed workflows and are not reimplemented in the skill.
+
+- [ ] **Step 4: Implement fixed-label preflight and reconciliation**
+
+`jhw_pr_ensure_review_labels` validates `REPO_NWO`, reads labels first, and creates only a missing label with fixed descriptions/colors. `jhw_pr_reconcile_review_labels` uses `gh pr edit` to remove the opposite label before adding the selected label; `auto` removes both. `jhw_pr_verify_remote_policy` reads back `.labels[].name` and fails on both labels, a missing explicit label, or a remaining override in auto mode.
+
+Before label creation, query `gh repo view --json viewerPermission -q .viewerPermission` and require `ADMIN`, `MAINTAIN`, or `WRITE`. The test must prove a read-only permission exits before label creation, push, or PR creation. Missing labels may then be created as the single reported prerequisite mutation.
+
+The contract must use these exact names and never infer by prefix:
+
+```bash
+JHW_REVIEW_REQUEST_LABEL='review:request'
+JHW_REVIEW_SKIP_LABEL='review:skip'
+```
+
+- [ ] **Step 5: Encode the new/existing PR state machines**
+
+Document and test these exact transitions:
+
+```text
+new:      label-definition preflight -> push -> gh pr create --draft -> reconcile -> verify head/labels/draft -> gh pr ready
+existing: label-definition preflight -> reconcile -> verify labels/current remote head -> push -> verify new remote head
+```
+
+Do not rely on `gh pr create --label` ordering. After any push, refresh `SHA` from `git rev-parse HEAD` and require `gh pr view --json headRefOid -q .headRefOid` to equal it.
+
+- [ ] **Step 6: Add explicit skip merge semantics**
+
+The skill must reject implicit review waiver. Only the literal combination `--no-review --merge` waives the AI gate, and the final receipt must include:
+
+```text
+AI review: explicitly skipped (--no-review; review:skip)
+```
+
+It must still require required CI, target PASS when requested, current head, mergeability, and supported merge method.
+
+- [ ] **Step 7: Run tests and commit**
+
+```bash
+rtk node scripts/test-pr-skill-contract.mjs
+rtk git add skills/claude/pr.md scripts/test-pr-skill-contract.mjs
+rtk git commit -m "feat(skills): add PR review policy options"
+```
+
+---
+
+### Task 3: Request every PR reviewer exactly once and preserve wait semantics
+
+**Files:**
+- Modify: `skills/claude/pr.md`
+- Modify: `scripts/test-pr-skill-contract.mjs`
+
+**Interfaces:**
+- Produces: `jhw_pr_request_app_review(reviewer, command, head)`.
+- Produces: `jhw_pr_dispatch_same_head(workflow_file, workflow_name, head)`.
+- Produces: `jhw_pr_wait_required_checks(pr, head)` independent of the AI-review mode.
+- Reuses: existing reviewer classifications and head-scoped polling.
+
+- [ ] **Step 1: Write RED request/deduplication tests**
+
+Add fake GitHub responses proving:
+
+- Codex posts exactly `@codex review` plus a hidden marker whose `head=` value matches `[a-f0-9]{40}`;
+- Gemini Assist posts exactly `/gemini review` plus reviewer/head marker;
+- one existing actor-owned matching marker is reused;
+- duplicate matching markers are `TRIGGER_FAILED`;
+- a marker for an old head does not suppress the current request; and
+- `skip` produces zero comments, zero workflow dispatches, and zero AI waits while still invoking the required-CI and optional target gates.
+
+- [ ] **Step 2: Run request tests and confirm RED**
+
+```bash
+rtk node scripts/test-pr-skill-contract.mjs
+```
+
+Expected: Gemini request helper and generic head marker are absent.
+
+- [ ] **Step 3: Generalize the current Codex trigger helper**
+
+Replace the round-specific Codex posting path with a generic helper that validates reviewer, command, actor, PR, and 40-character head. It searches actor-owned issue comments for the exact hidden marker before posting. Accepted pairs are closed:
+
+```text
+codex         -> @codex review
+gemini-assist -> /gemini review
+```
+
+Keep the current trigger grace, acknowledgment, bot identity discovery, and response classification. Auto-fix rounds call the same helper after every successful push.
+
+- [ ] **Step 4: Add central same-head dispatch with deduplication**
+
+For explicit `--review` on an unchanged remote head, query Actions runs by exact `head_sha` and workflow name. Reuse an existing queued/in-progress/completed current-head `workflow_dispatch` run; otherwise run exactly one:
+
+```bash
+gh workflow run claude-code-review.yml --repo "$REPO_NWO" -f pr_number="$PR" -f force_review=true
+gh workflow run gemini-auto-review.yml --repo "$REPO_NWO" -f pr_number="$PR" -f force_review=true
+gh workflow run opencode-auto-review.yml --repo "$REPO_NWO" -f pr_number="$PR" -f force_review=true
+```
+
+Dispatch only installed/enabled reviewers. A missing caller is `UNAVAILABLE`; an API rejection is `TRIGGER_FAILED`; an accepted run that exceeds the review timeout is `TIMEOUT`.
+
+- [ ] **Step 5: Define mode-to-wait behavior**
+
+Add a single table to the skill and assertions to the test:
+
+| Effective command policy | Managed workflows | Apps | AI wait |
+| --- | --- | --- | --- |
+| request | event run or same-head dispatch | explicit head-scoped request | planned reviewers |
+| skip | policy-only terminal checks | none | none |
+| auto=true | ordinary event runs | explicit head-scoped request | planned reviewers |
+| auto=false | no provider runs | none | none |
+
+`--reviewers` remains a user-selected waiting subset; it does not change the repository-wide label consumed by managed workflows. State this limitation plainly so it is not mistaken for a per-provider enable switch.
+
+- [ ] **Step 6: Add the AI-independent required-CI gate**
+
+For every mode, start a current-PR required-check wait using `gh pr checks "$PR" --required --watch --interval 10`. Verify the PR head before and after the wait; a changed head restarts policy resolution. Treat a failed/cancelled required check or an inability to read required checks as a failed merge gate. Run the existing optional target gate in parallel. In `skip`/auto-false mode, completion of CI and target ends the wait without inspecting AI artifacts.
+
+- [ ] **Step 7: Preserve auto-fix and current-head merge gates**
+
+Update every old `jhw-ship` state/marker expectation to `jhw-pr`, request Codex and Gemini Assist after each new head, and retain the rule that no new push occurs while any planned reviewer is pending/failed/timed out. A later push invalidates every prior App response and workflow result.
+
+- [ ] **Step 8: Run the complete PR skill contract and commit**
+
+```bash
+rtk node scripts/test-pr-skill-contract.mjs
+rtk git add skills/claude/pr.md scripts/test-pr-skill-contract.mjs
+rtk git commit -m "feat(skills): request head-scoped PR reviews"
+```
+
+---
+
+### Task 4: Generate and document `/jhw:pr` plus the ship alias
+
+**Files:**
+- Modify: `skills/claude/AGENTS.md`
+- Modify: `README.md`
+- Generate: `skills/codex/jhw-pr/SKILL.md`
+- Generate: `skills/codex/jhw-pr/references/pr.md`
+- Modify generated: `skills/codex/jhw-ship/SKILL.md`
+- Preserve generated link: `skills/codex/jhw-ship/references/ship.md`
+
+**Interfaces:**
+- Consumes: canonical `pr.md` and alias `ship.md`.
+- Produces: discoverable `$jhw-pr`; keeps `$jhw-ship` discoverable but deprecated.
+
+- [ ] **Step 1: Add RED sync/inventory assertions**
+
+Extend `scripts/test-pr-skill-contract.mjs` to require `skills/claude/AGENTS.md` lists `pr.md` under custom skills and `ship.md` under deprecated aliases. Require README mentions `/jhw:pr --review`, `/jhw:pr --no-review`, and `/jhw:ship` replacement.
+
+- [ ] **Step 2: Update canonical documentation**
+
+Move the current ship custom-skill row/pattern to `pr.md`, list all existing options plus the two new flags, and add `ship.md -> /jhw:pr` to the deprecated table. Update README's command summary without changing Notion/MCP sections.
+
+- [ ] **Step 3: Generate Codex skills from canonical sources**
+
+```bash
+rtk node scripts/sync-codex-skills.mjs
+rtk node scripts/sync-codex-skills.mjs --check
+```
+
+Expected: `jhw-pr` is created, `jhw-ship` description is regenerated from the alias, and every reference is a relative symlink to its canonical Claude file.
+
+- [ ] **Step 4: Run PR and install-safety tests**
+
+```bash
+rtk node scripts/test-pr-skill-contract.mjs
+rtk bash scripts/test-install-safety.sh
+```
+
+Expected: both exit zero.
+
+- [ ] **Step 5: Commit canonical and generated PR skills**
+
+```bash
+rtk git add skills/claude/AGENTS.md README.md skills/codex/jhw-pr skills/codex/jhw-ship
+rtk git commit -m "docs(skills): publish jhw pr and deprecate ship"
+```
+
+---
+
+### Task 5: Add `/jhw:issue` creation and reviewer-plan policy
+
+**Files:**
+- Create: `skills/claude/issue.md`
+- Create: `scripts/test-issue-skill-contract.mjs`
+- Modify: `scripts/test-install-safety.sh`
+
+**Interfaces:**
+- Produces: modes `request`, `skip`, `auto` with the same mutual exclusion as PR.
+- Produces: planned issue reviewer set from enabled Claude, enabled central Gemini, and capability-proven Codex.
+- Produces: issue labels and one hidden request marker per planned reviewer.
+
+- [ ] **Step 1: Write RED issue option and no-mutation tests**
+
+Create the test with a fake `gh` command and mutation log. Assert:
+
+```javascript
+const mode = (args) => runIssueContract(
+  `jhw_issue_review_mode_from_args ${args}`,
+  { viewerPermission: "WRITE", workflows: [] },
+);
+
+assert.equal((await mode("--review")).stdout.trim(), "request");
+assert.equal((await mode("--no-review")).stdout.trim(), "skip");
+assert.equal((await mode("")).stdout.trim(), "auto");
+assert.notEqual((await mode("--review --no-review")).code, 0);
+assert.deepEqual(mutatingCalls, []);
+```
+
+Add cases proving `--review` with zero eligible reviewers fails before `gh issue create`, while a later reviewer failure never invokes issue delete/close/edit.
+
+- [ ] **Step 2: Run the new test and confirm missing skill failure**
+
+```bash
+rtk node scripts/test-issue-skill-contract.mjs
+```
+
+Expected: failure reports missing `skills/claude/issue.md`.
+
+- [ ] **Step 3: Create the narrow issue skill interface**
+
+Use exact frontmatter:
+
+```yaml
+---
+description: "GitHub 이슈 생성 · --review 지원 리뷰어 요청·대기·요약 · --no-review 리뷰 생략 · --timeout 대기한도"
+argument-hint: "[title/body] [--review|--no-review] [--timeout <min>]"
+---
+```
+
+The first phase resolves title/body, repository, mode, timeout, permission, labels, and reviewer plan. It must not expose assignee/milestone/project/bulk-management options.
+
+- [ ] **Step 4: Implement reviewer discovery without secret guessing**
+
+Claude is eligible only when `.github/workflows/claude.yml` exists and `workflows.claude.enabled` is true. Central Gemini is eligible only when `gemini-chat.yml` or its documented managed mention route exists and the corresponding config is enabled. Codex is eligible only when repository-local capability evidence named in the skill exists or the operator explicitly confirms a successful issue canary for that repository. GitHub secret values are never claimed during preflight.
+
+If mode is `auto`, read global `review.auto`, default true only when missing, and turn the reviewer plan on/off accordingly. `skip` plans no reviewer. `request` requires at least one eligible reviewer.
+
+- [ ] **Step 5: Implement create/label/request ordering**
+
+Use this exact order:
+
+```text
+validate options/content -> ensure label definitions -> discover reviewers -> create issue -> apply one explicit label or neither -> verify -> post planned mentions
+```
+
+Apply `review:request` for request, `review:skip` for skip, and neither for auto. Verify the issue labels by reading the created issue back before posting any mention. Auto mode uses global `review.auto` to decide whether the already-created issue receives reviewer requests; it still carries neither override label.
+
+Request bodies and markers are:
+
+```text
+@claude 이 이슈의 요구사항·누락 조건·구현 위험을 검토해 주세요.
+<!-- jhw-issue:review-request reviewer=claude -->
+
+@gemini 이 이슈의 요구사항·누락 조건·구현 위험을 검토해 주세요.
+<!-- jhw-issue:review-request reviewer=gemini -->
+
+@codex 이 이슈의 요구사항·누락 조건·구현 위험을 검토해 주세요.
+<!-- jhw-issue:review-request reviewer=codex -->
+```
+
+Post each in its own issue comment. On resume, reuse exactly one actor-owned matching marker; multiple markers are `FAILED`.
+
+- [ ] **Step 6: Add the issue contract to install safety**
+
+Append exactly:
+
+```bash
+node "$REPO_ROOT/scripts/test-issue-skill-contract.mjs"
+```
+
+beside the PR skill contract invocation.
+
+- [ ] **Step 7: Run issue tests and commit**
+
+```bash
+rtk node scripts/test-issue-skill-contract.mjs
+rtk git add skills/claude/issue.md scripts/test-issue-skill-contract.mjs scripts/test-install-safety.sh
+rtk git commit -m "feat(skills): add review-aware issue creation"
+```
+
+---
+
+### Task 6: Add bounded issue waiting and response summaries
+
+**Files:**
+- Modify: `skills/claude/issue.md`
+- Modify: `scripts/test-issue-skill-contract.mjs`
+
+**Interfaces:**
+- Produces reviewer states: `PENDING`, `CLEAN`, `FEEDBACK`, `FAILED`, `TIMEOUT`, `UNAVAILABLE`.
+- Produces final fields: issue URL, requested reviewers, unavailable reviewers, response links, highest disposition, diagnostics.
+
+- [ ] **Step 1: Write RED response-classification tests**
+
+Use fixtures for comments, reactions, and Actions runs to prove:
+
+- acknowledged mention plus substantive no-problem response -> `CLEAN`;
+- response containing actionable requirements/risks -> `FEEDBACK`;
+- workflow conclusion failure or explicit connector rejection -> `FAILED`;
+- no trigger acknowledgment within the short trigger window -> `FAILED`, not `TIMEOUT`;
+- acknowledged trigger with no terminal response by `--timeout` -> `TIMEOUT`;
+- preflight unsupported channel -> `UNAVAILABLE` and no wait; and
+- a response/request from before issue creation or wrong bot identity is ignored.
+
+- [ ] **Step 2: Run classification tests and confirm RED**
+
+```bash
+rtk node scripts/test-issue-skill-contract.mjs
+```
+
+Expected: missing wait-contract marker and classifier functions.
+
+- [ ] **Step 3: Implement a bounded poll loop**
+
+Add `<!-- issue-review-wait-contract:begin -->` with functions that poll issue comments, reactions on each request comment, and relevant Actions runs at approximately 60-second intervals. Default timeout is 20 minutes and must be a positive integer. Capture issue creation time and request comment IDs so old signals cannot finish the run.
+
+The loop terminates when every requested reviewer is terminal or the deadline is reached. It never calls issue edit/delete/close endpoints.
+
+- [ ] **Step 4: Implement the summary and exit policy**
+
+Render one compact table:
+
+```text
+Reviewer | Status | Response | Diagnostic
+```
+
+Highest disposition order is `FAILED/TIMEOUT > FEEDBACK > CLEAN`; `UNAVAILABLE` is listed separately because it was never requested. Return the issue URL even on partial failure. Do not convert review feedback into body edits or implementation work.
+
+- [ ] **Step 5: Run the complete issue contract**
+
+```bash
+rtk node scripts/test-issue-skill-contract.mjs
+```
+
+Expected: all issue states and preservation behavior pass. The combined install suite runs after generated issue output exists in Task 7.
+
+- [ ] **Step 6: Commit waiting and reporting**
+
+```bash
+rtk git add skills/claude/issue.md scripts/test-issue-skill-contract.mjs
+rtk git commit -m "feat(skills): wait for issue review responses"
+```
+
+---
+
+### Task 7: Publish generated issue skill and verify the jhw-notion PR
+
+**Files:**
+- Modify: `skills/claude/AGENTS.md`
+- Modify: `README.md`
+- Generate: `skills/codex/jhw-issue/SKILL.md`
+- Generate: `skills/codex/jhw-issue/references/issue.md`
+- Modify only on demonstrated defects: prior Task files.
+
+**Interfaces:**
+- Produces: reviewed and merged jhw-notion skill PR.
+- Consumes: remotely verified automation `v1.51` and jhw-notion canary callers.
+
+- [ ] **Step 1: Document the issue skill and generate Codex output**
+
+Add `issue.md` to the custom skill table and README examples for `--review`, `--no-review`, and timeout. Then run:
+
+```bash
+rtk node scripts/sync-codex-skills.mjs
+rtk node scripts/sync-codex-skills.mjs --check
+```
+
+- [ ] **Step 2: Run complete repository verification**
+
+```bash
+rtk node scripts/test-pr-skill-contract.mjs
+rtk node scripts/test-issue-skill-contract.mjs
+rtk bash scripts/test-install-safety.sh
+rtk npm test --prefix mcp-server
+rtk git diff --check origin/main...HEAD
+```
+
+Expected: every command exits zero and only planned skill/docs/test/generated paths differ.
+
+- [ ] **Step 3: Inspect generated ownership and symlinks**
+
+Run `rtk node scripts/sync-codex-skills.mjs --check` again after tests and verify `jhw-pr`, `jhw-ship`, and `jhw-issue` each contain only `SKILL.md` plus one relative reference symlink. Confirm the installed `/home/jhw/.codex/skills/jhw-*` targets remain repository-owned and no foreign target was replaced.
+
+- [ ] **Step 4: Open the skill PR with explicit review request**
+
+Push the isolated branch, use the branch's `pr.md` workflow to create a draft PR, apply/verify `review:request`, make it ready, and request installed external Apps exactly once for the final head. The managed v1.51 caller policy must report `request` while the repository default remains auto-off.
+
+- [ ] **Step 5: Review, repair, and reverify**
+
+Inspect every central/App finding against current skill contracts. Apply only validated changes with a failing regression assertion first, regenerate Codex skills, and rerun Step 2 after every final-head change. Do not accept duplicate, stale-head, or unsupported issue-App findings as blockers without evidence.
+
+- [ ] **Step 6: Merge the verified current head**
+
+Merge only when required CI, PR/issue skill tests, sync check, install safety, requested reviewers, and current-head identity are green. Confirm the merged main includes the exact verified PR head and the live repository-backed Codex skill symlinks expose `$jhw-pr` and `$jhw-issue`.
+
+---
+
+### Task 8: Run live issue canary and bounded fleet activation
+
+**Files:**
+- Consumer configuration changes only in repositories where the corresponding App is installed.
+- Preserve all unrelated `.gemini/config.yaml` keys.
+- No Notion/Project Control writes.
+
+**Interfaces:**
+- Produces: one live `/jhw:issue --review` evidence set.
+- Produces: fleet callers pinned to verified `v1.51` and App automatic-review prerequisites applied.
+
+- [ ] **Step 1: Run a standalone issue canary in jhw-notion**
+
+Create one clearly marked review canary issue using `/jhw:issue --review --timeout 20`. Require Claude and central Gemini when enabled. Include Codex only if the repository's connector/environment was proven during preflight. Record request comment IDs, acknowledgments, response URLs, terminal classifications, and the final summary.
+
+- [ ] **Step 2: Verify preservation behavior**
+
+Confirm the command did not edit the issue body, close it, change milestone/project, or implement feedback. After evidence is attached to the rollout record, the operator may close the canary issue as explicit cleanup; the command itself must not do so.
+
+- [ ] **Step 3: Plan the managed workflow fleet from immutable `v1.51`**
+
+From a clean automation checkout, first require an unused task-specific workspace, then run the fleet tool in plan mode for every repository in `scripts/workflow-config.json`:
+
+```bash
+rtk python3 -c 'from pathlib import Path; p=Path("/tmp/automation-v151-fleet-plan"); assert not p.exists(), f"workspace already exists: {p}"'
+rtk python3 scripts/rollout_workflow_fleet.py --automation . --workspace /tmp/automation-v151-fleet-plan --initialize-workspace --mode plan --ref v1.51
+```
+
+Require the release verifier to identify the remote peeled `v1.51` commit and inspect each proposed diff for only catalog-owned workflow/config paths.
+
+- [ ] **Step 4: Prepare App settings only where installed**
+
+For repositories with Gemini Code Assist, create a normal merge-preserving setup PR that sets only:
+
+```yaml
+code_review:
+  pull_request_opened:
+    code_review: false
+```
+
+For repositories with Codex Code review, record operator confirmation that Code review remains enabled and Automatic reviews is disabled. Do not install a new App merely to satisfy this feature. Repositories without an App mark that channel `UNAVAILABLE`.
+
+- [ ] **Step 5: Publish in bounded batches**
+
+Publish the fleet plan first to the already-proven jhw-notion canary, then batches of at most four repositories. For each rollout PR, verify immutable caller pins, `ready_for_review`, `review_mode`, unchanged auth profile, actionlint, and config preservation before merge. Stop the batch on any duplicate App review, provider invocation under skip/draft/conflict, label race, or verifier mismatch.
+
+For each approved batch, rerun the same workspace with `--mode publish --ref v1.51 --confirm` and explicit `--repo` arguments for only the repositories in that batch. Never use publish without reviewing the immediately preceding plan output.
+
+- [ ] **Step 6: Run one request and one skip smoke check per batch**
+
+Use an existing normal PR when safe; otherwise a bounded disposable docs PR. `review:request` on an auto-off repository must produce the planned reviewers. `review:skip` on an auto-on test head must produce successful policy checks and zero providers/Apps. Close/delete only explicitly created disposable smoke branches after evidence capture.
+
+- [ ] **Step 7: Record final activation evidence**
+
+Produce a repository table containing automation pin, request/skip support, Codex setting, Gemini config, available issue reviewers, rollout PR, and smoke evidence. A repository remains not activated when any required cell is missing; this does not roll back already verified repositories or move `v1.51`.

--- a/docs/superpowers/plans/2026-08-31-review-mode-workflow-control.md
+++ b/docs/superpowers/plans/2026-08-31-review-mode-workflow-control.md
@@ -1,0 +1,771 @@
+# Review-mode Workflow Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every managed PR review workflow honor `review:request`, `review:skip`, draft state, and repository automatic-review configuration before any model invocation.
+
+**Architecture:** A small release-owned composite action resolves PR metadata, labels, explicit mode, and existing YAML configuration into one fail-closed decision shared by Claude, Gemini, and OpenCode. Thin managed callers pass the label-derived mode and support `ready_for_review`; reusable workflows retain their existing provider, canonicalization, and invocation-budget paths. The feature ships as immutable automation release `v1.51`, followed by a separate fleet-default PR.
+
+**Tech Stack:** GitHub Actions YAML, Python 3 standard library, Ruby stdlib YAML bridge on `ubuntu-latest`, GitHub CLI/API, pytest, actionlint.
+
+**Spec:** `docs/superpowers/specs/2026-08-31-review-mode-command-control-design.md`
+
+## Global Constraints
+
+- Do not modify Notion databases, Project Control state, or issue #52.
+- `--review` and `--no-review` are represented by exactly `review:request` and `review:skip`.
+- Effective modes are exactly `auto`, `request`, `skip`, and `conflict`.
+- Both labels or an input/label mismatch fail without invoking a model.
+- Draft, skip, unsafe-fork, and closed PR decisions terminate successfully without invoking a model.
+- `review:request` overrides automatic mode but never overrides `workflows.<name>.enabled`.
+- Automatic precedence remains `workflows.<name>.auto -> review.auto -> true`.
+- The baseline remains explicit `review.auto: false`.
+- Keep existing review prompts, finding grammar, quality schemas, and blocking thresholds unchanged.
+- Preserve historical releases; the new local action is required only for `v1.51+`.
+- Do not move or recreate an immutable release tag.
+- Every implementation change follows RED-GREEN-REFACTOR and ends in a focused commit.
+- Every shell command in this environment starts with `rtk`.
+
+## File map
+
+| Path | Responsibility |
+| --- | --- |
+| `.github/actions/resolve-review-policy/action.yml` | Fetch current PR/config inputs and publish the shared decision |
+| `.github/actions/resolve-review-policy/resolve_review_policy.py` | Pure validation and mode-resolution logic |
+| `.github/workflows/{claude-code-review,gemini-auto-review,opencode-auto-review}.yml` | Consume the policy and gate existing provider jobs |
+| `.github/workflows/_self-*-review.yml` | Dogfood label mode and ready transition locally |
+| `examples/baseline-workflows/.github/workflows/*auto-review*.yml` | Managed consumer callers |
+| `scripts/workflow-catalog.json` | Exact caller triggers, inputs, permissions, and `with` keys |
+| `scripts/workflow_release_inventory.py` | `v1.51` release capability and immutable action roots |
+| `scripts/verify_workflow_release.py` | Authenticate the action and all caller/reusable wiring |
+| `tests/test_review_policy_action.py` | Pure policy behavior and action transport tests |
+| `tests/test_review_workflow_logic.py` | Reusable workflow provider-gating behavior |
+| `tests/test_canonical_workflow_tree.py` | Baseline/self caller exact shapes |
+| `tests/test_workflow_catalog.py` | Catalog parity and fleet default |
+| `tests/test_verify_workflow_release.py` | Historical and `v1.51` verifier mutation tests |
+| `.github/workflow-config.yml` | Explicit automation dogfood default |
+| `.gemini/config.yaml` | Disable only Gemini PR-open review for the automation repository |
+| `docs/workflows/contracts.md` | Consumer, label, App, release, and rollback contract |
+
+---
+
+### Task 1: Add the deterministic review-policy resolver
+
+**Files:**
+- Create: `.github/actions/resolve-review-policy/action.yml`
+- Create: `.github/actions/resolve-review-policy/resolve_review_policy.py`
+- Create: `tests/test_review_policy_action.py`
+
+**Interfaces:**
+- Consumes: `PolicyRequest(workflow_name, review_mode, force_run, force_review, event_name, repository, pr, config)`.
+- Produces: `PolicyDecision(run_review: bool, effective_mode: str, reason: str, head_sha: str)`.
+- Raises: `PolicyError` for invalid input, both labels, non-boolean config, or event/input label mismatch.
+- Action outputs: `run-review`, `effective-mode`, `reason`, and `head-sha`.
+
+- [ ] **Step 1: Write RED unit tests for precedence and safety states**
+
+Create `tests/test_review_policy_action.py` with a helper that loads the module and these table-driven cases:
+
+```python
+def base_pr() -> dict[str, object]:
+    return {
+        "state": "open",
+        "draft": False,
+        "head": {
+            "sha": "a" * 40,
+            "repo": {"full_name": "jhw7500/example", "fork": False},
+        },
+        "labels": [],
+    }
+
+
+def request(*, labels=None, mode="auto", config=None, pr=None, event="pull_request", force_review=False):
+    payload = base_pr() if pr is None else pr
+    payload["labels"] = [{"name": name} for name in (labels or [])]
+    return PolicyRequest(
+        workflow_name="claude-code-review",
+        review_mode=mode,
+        force_run=False,
+        force_review=force_review,
+        event_name=event,
+        repository="jhw7500/example",
+        pr=payload,
+        config={} if config is None else config,
+    )
+
+
+@pytest.mark.parametrize(
+    ("labels", "mode", "config", "expected"),
+    [
+        ([], "auto", {"review": {"auto": True}}, (True, "review_auto_true")),
+        ([], "auto", {"review": {"auto": False}}, (False, "review_auto_false")),
+        ([], "auto", {"workflows": {"claude-code-review": {"auto": False}}, "review": {"auto": True}}, (False, "workflow_auto_false")),
+        (["review:request"], "request", {"review": {"auto": False}}, (True, "request")),
+        (["review:skip"], "skip", {"review": {"auto": True}}, (False, "skip")),
+    ],
+)
+def test_policy_precedence(labels, mode, config, expected):
+    decision = resolve_policy(request(labels=labels, mode=mode, config=config))
+    assert (decision.run_review, decision.reason) == expected
+
+
+def test_both_labels_fail_closed():
+    with pytest.raises(PolicyError, match="review_label_conflict"):
+        resolve_policy(request(labels=["review:request", "review:skip"], mode="conflict"))
+
+
+@pytest.mark.parametrize(("change", "reason"), [
+    ({"draft": True}, "draft"),
+    ({"state": "closed"}, "closed"),
+    ({"head": {"repo": {"full_name": "fork/repo", "fork": True}}}, "unsafe_pr"),
+])
+def test_noneligible_pr_never_runs(change, reason):
+    pr = base_pr() | change
+    decision = resolve_policy(request(pr=pr))
+    assert decision.run_review is False
+    assert decision.reason == reason
+
+
+def test_pull_request_mode_must_match_labels():
+    with pytest.raises(PolicyError, match="review_mode_label_mismatch"):
+        resolve_policy(request(labels=["review:skip"], mode="request"))
+
+
+def test_manual_force_review_allows_request_without_label():
+    decision = resolve_policy(request(mode="request", event="workflow_dispatch", force_review=True))
+    assert decision.run_review is True
+    assert decision.reason == "request"
+```
+
+- [ ] **Step 2: Run the new tests and confirm the missing module failure**
+
+Run:
+
+```bash
+rtk python3 -m pytest tests/test_review_policy_action.py -q
+```
+
+Expected: collection fails because `.github/actions/resolve-review-policy/resolve_review_policy.py` does not exist.
+
+- [ ] **Step 3: Implement the pure resolver**
+
+Define these exact public types and resolution order:
+
+```python
+class PolicyError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class PolicyRequest:
+    workflow_name: str
+    review_mode: str
+    force_run: bool
+    force_review: bool
+    event_name: str
+    repository: str
+    pr: dict[str, object]
+    config: dict[str, object]
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    run_review: bool
+    effective_mode: str
+    reason: str
+    head_sha: str
+
+
+def resolve_policy(request: PolicyRequest) -> PolicyDecision:
+    labels = _label_names(request.pr)
+    if {"review:request", "review:skip"} <= labels:
+        raise PolicyError("review_label_conflict")
+    label_mode = "request" if "review:request" in labels else "skip" if "review:skip" in labels else "auto"
+    if request.review_mode not in {"auto", "request", "skip", "conflict"}:
+        raise PolicyError("review_mode_invalid")
+    if request.review_mode == "conflict":
+        raise PolicyError("review_label_conflict")
+    manual_request = request.event_name == "workflow_dispatch" and request.force_review
+    if manual_request and request.review_mode != "request":
+        raise PolicyError("force_review_mode_invalid")
+    if not manual_request and request.review_mode != label_mode:
+        raise PolicyError("review_mode_label_mismatch")
+    head_sha = _validated_head(request.pr, request.repository)
+    if request.pr.get("state") != "open":
+        return PolicyDecision(False, request.review_mode, "closed", head_sha)
+    if request.pr.get("draft") is True:
+        return PolicyDecision(False, request.review_mode, "draft", head_sha)
+    if head_sha == "":
+        return PolicyDecision(False, request.review_mode, "unsafe_pr", "")
+    if request.review_mode == "skip":
+        return PolicyDecision(False, "skip", "skip", head_sha)
+    if request.review_mode == "request" or request.force_run:
+        return PolicyDecision(True, "request", "request", head_sha)
+    return _automatic_decision(request, head_sha)
+```
+
+`_automatic_decision` must require real booleans when a key exists, choose the per-workflow value first, then global `review.auto`, and return `default_auto_true` only when both are absent.
+
+- [ ] **Step 4: Add the JSON command boundary and composite action**
+
+The Python entry point accepts `--request-file`, `--result-file`, and `--github-output`, writes a sorted compact JSON result, and appends these exact output keys with scalar values. The composite action declares inputs `workflow-name`, `pr-number`, `review-mode`, `force-run`, `force-review`, and `github-token`; it:
+
+```yaml
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        REVIEW_MODE: ${{ inputs.review-mode }}
+        WORKFLOW_NAME: ${{ inputs.workflow-name }}
+        FORCE_RUN: ${{ inputs.force-run }}
+        FORCE_REVIEW: ${{ inputs.force-review }}
+      run: |
+        set -euo pipefail
+        policy_dir="$RUNNER_TEMP/review-policy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        install -d -m 0700 "$policy_dir"
+        gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > "$policy_dir/pr.json"
+        ruby -ryaml -rjson -e 'cfg = File.file?(ARGV[0]) ? (YAML.safe_load_file(ARGV[0], aliases: false) || {}) : {}; File.write(ARGV[1], JSON.generate(cfg))' \
+          .github/workflow-config.yml "$policy_dir/config.json"
+        python3 - "$policy_dir/pr.json" "$policy_dir/config.json" "$policy_dir/request.json" <<'PY'
+        import json
+        import os
+        import sys
+        from pathlib import Path
+
+        def boolean(name: str) -> bool:
+            value = os.environ[name]
+            if value not in {"true", "false"}:
+                raise SystemExit(f"{name.lower()}_invalid")
+            return value == "true"
+
+        pr_path, config_path, request_path = map(Path, sys.argv[1:])
+        payload = {
+            "workflow_name": os.environ["WORKFLOW_NAME"],
+            "review_mode": os.environ["REVIEW_MODE"],
+            "force_run": boolean("FORCE_RUN"),
+            "force_review": boolean("FORCE_REVIEW"),
+            "event_name": os.environ["GITHUB_EVENT_NAME"],
+            "repository": os.environ["GITHUB_REPOSITORY"],
+            "pr": json.loads(pr_path.read_text(encoding="utf-8")),
+            "config": json.loads(config_path.read_text(encoding="utf-8")),
+        }
+        request_path.write_text(
+            json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        PY
+        python3 "$GITHUB_ACTION_PATH/resolve_review_policy.py" \
+          --request-file "$policy_dir/request.json" \
+          --result-file "$policy_dir/result.json" \
+          --github-output "$GITHUB_OUTPUT"
+```
+
+The transport passes scalars through environment variables and JSON through files; it never interpolates API JSON into shell code.
+
+- [ ] **Step 5: Add transport and malformed-input tests**
+
+Parse `action.yml` with `yaml.BaseLoader` and assert exact inputs, outputs, `using: composite`, `set -euo pipefail`, the two fixed API/config paths, and absence of `eval`. Add CLI tests proving malformed JSON, a non-object config, a non-boolean `review.auto`, invalid SHA, and invalid repository name exit nonzero without writing GitHub outputs.
+
+- [ ] **Step 6: Run focused tests and commit**
+
+Run:
+
+```bash
+rtk python3 -m pytest tests/test_review_policy_action.py -q
+rtk git add .github/actions/resolve-review-policy tests/test_review_policy_action.py
+rtk git commit -m "feat(review): add shared review policy resolver"
+```
+
+Expected: all policy tests pass and the commit contains only the new action and tests.
+
+---
+
+### Task 2: Gate Claude, Gemini, and OpenCode with the shared policy
+
+**Files:**
+- Modify: `.github/workflows/claude-code-review.yml`
+- Modify: `.github/workflows/gemini-auto-review.yml`
+- Modify: `.github/workflows/opencode-auto-review.yml`
+- Modify: `tests/test_review_workflow_logic.py`
+
+**Interfaces:**
+- Consumes: Task 1 action outputs and existing `check-workflow-enabled` output.
+- Produces: all provider jobs require `enabled == 'true' && policy_run == 'true'`.
+- Adds reusable input: `review_mode` string, default `auto`, to all three workflows.
+- Adds OpenCode reusable input: `force_review` boolean, default `false`.
+
+- [ ] **Step 1: Write RED workflow-parity tests**
+
+Add tests that load all three workflows and assert:
+
+```python
+REVIEW_WORKFLOWS = {
+    name: _load(f"{name}.yml")
+    for name in ("claude-code-review", "gemini-auto-review", "opencode-auto-review")
+}
+
+
+def _step(workflow, name):
+    return next(
+        step
+        for step in workflow["jobs"]["check-enabled"]["steps"]
+        if step.get("name") == name
+    )
+
+
+for workflow_name, workflow in REVIEW_WORKFLOWS.items():
+    mode = workflow["on"]["workflow_call"]["inputs"]["review_mode"]
+    assert mode == {"description": "Resolved PR review policy", "type": "string", "required": "false", "default": "auto"}
+    policy = _step(workflow, "Resolve PR review policy")
+    assert policy["uses"] == "$/.github/actions/resolve-review-policy"
+    assert policy["with"]["review-mode"] == "${{ inputs.review_mode }}"
+
+
+def test_every_provider_job_is_policy_gated():
+    assert "needs.check-enabled.outputs.policy_run == 'true'" in claude["jobs"]["claude-review"]["if"]
+    assert "needs.check-enabled.outputs.policy_run == 'true'" in gemini["jobs"]["gemini-review"]["if"]
+    assert "needs.check-enabled.outputs.policy_run == 'true'" in opencode["jobs"]["opencode-prepare"]["if"]
+```
+
+Also assert the old three inline `Check auto review mode` steps are absent.
+
+- [ ] **Step 2: Run focused tests and confirm the missing-input/action failures**
+
+Run:
+
+```bash
+rtk python3 -m pytest tests/test_review_workflow_logic.py -q -k 'review_policy or force_review'
+```
+
+Expected: failures show missing `review_mode`, missing shared-action references, and missing OpenCode `force_review` plumbing.
+
+- [ ] **Step 3: Replace duplicated automatic-mode scripts**
+
+In every `check-enabled` job:
+
+- add outputs `policy_run`, `policy_reason`, and `policy_head` from `steps.review_policy.outputs`;
+- keep `Check workflow config` for `workflows.<name>.enabled`;
+- remove `Check auto review mode`; and
+- add `Resolve PR review policy` with exact workflow name, PR number, token, mode, force-run, and force-review values.
+
+For OpenCode, retain its same-repository defense but make the shared action authoritative and remove the now-duplicate `Verify same-repository PR` step/output. Update the first provider-bearing job condition to use `policy_run` and remove `auto_enabled`/`safe_pr`.
+
+- [ ] **Step 4: Add bounded OpenCode same-head review**
+
+Add `force_review` to OpenCode and wire it exactly where Claude/Gemini already do:
+
+```yaml
+force_review:
+  description: Perform one explicitly authorized review even when HEAD is unchanged
+  type: boolean
+  required: false
+  default: false
+```
+
+Pass `force-full: ${{ inputs.force_review && 'true' || 'false' }}` to `prepare-review-diff`, pass `force-review: ${{ inputs.force_review && 'true' || 'false' }}` to the claim action, and add an enforcement step that fails only when an explicit force request was not authorized by the invocation budget. Do not alter ordinary authenticated reuse behavior.
+
+- [ ] **Step 5: Prove skip/draft/conflict cannot reach providers**
+
+Add static path tests that start from each provider action/CLI step and assert every job dependency includes the policy-gated first job. Assert `resolve-review-policy` appears exactly once per reusable workflow, before diff preparation, and that conflict cannot be converted to a skipped step via an `if` condition on the policy step.
+
+- [ ] **Step 6: Run reviewer and invocation-budget suites**
+
+Run:
+
+```bash
+rtk python3 -m pytest tests/test_review_workflow_logic.py tests/test_review_invocation_budget.py tests/test_review_invocation_budget_action.py -q
+```
+
+Expected: all tests pass; no finding/canonicalization snapshot changes.
+
+- [ ] **Step 7: Commit reusable workflow integration**
+
+```bash
+rtk git add .github/workflows/claude-code-review.yml .github/workflows/gemini-auto-review.yml .github/workflows/opencode-auto-review.yml tests/test_review_workflow_logic.py
+rtk git commit -m "feat(review): gate model invocation by PR policy"
+```
+
+---
+
+### Task 3: Update managed callers, self-dogfood, and the exact catalog
+
+**Files:**
+- Modify: `.github/workflows/_self-claude-review.yml`
+- Modify: `.github/workflows/_self-gemini-auto-review.yml`
+- Modify: `.github/workflows/_self-opencode-auto-review.yml`
+- Modify: `examples/baseline-workflows/.github/workflows/claude-code-review.yml`
+- Modify: `examples/baseline-workflows/.github/workflows/gemini-auto-review.yml`
+- Modify: `examples/baseline-workflows/.github/workflows/opencode-auto-review.yml`
+- Modify: `examples/baseline-workflows/.github/workflow-config.yml`
+- Modify: `.github/workflow-config.yml`
+- Modify: `scripts/workflow-catalog.json`
+- Modify: `tests/test_canonical_workflow_tree.py`
+- Modify: `tests/test_workflow_catalog.py`
+
+**Interfaces:**
+- Produces: event label expression -> reusable `review_mode`.
+- Produces: `ready_for_review` trigger for all six PR callers.
+- Produces: manual `force_review` dispatch for all three baseline reviewers.
+
+- [ ] **Step 1: Write RED exact-caller tests**
+
+Extend canonical-tree tests with this exact trigger and input contract:
+
+```python
+assert caller["on"]["pull_request"]["types"] == ["opened", "synchronize", "ready_for_review"]
+assert caller["jobs"][job]["with"]["review_mode"] == REVIEW_MODE_EXPRESSION
+assert "github.event.pull_request.draft == false" in caller["jobs"][job]["if"]
+```
+
+Define `REVIEW_MODE_EXPRESSION` once as the whitespace-normalized expression whose precedence is workflow dispatch request, both-label conflict, request, skip, then auto. Add OpenCode dispatch assertions matching Claude/Gemini's `pr_number` and `force_review` shapes.
+
+- [ ] **Step 2: Run caller/catalog tests and confirm RED**
+
+```bash
+rtk python3 -m pytest tests/test_canonical_workflow_tree.py tests/test_workflow_catalog.py -q
+```
+
+Expected: all six callers lack `ready_for_review`/`review_mode`; OpenCode lacks dispatch.
+
+- [ ] **Step 3: Implement the label-derived expression in baseline callers**
+
+Use this semantic ordering in each baseline caller:
+
+```yaml
+review_mode: >-
+  ${{
+    github.event_name == 'workflow_dispatch' && inputs.force_review && 'request' ||
+    contains(github.event.pull_request.labels.*.name, 'review:request') &&
+    contains(github.event.pull_request.labels.*.name, 'review:skip') && 'conflict' ||
+    contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||
+    contains(github.event.pull_request.labels.*.name, 'review:skip') && 'skip' ||
+    'auto'
+  }}
+```
+
+The pull-request arm of every job `if` must require same-repository, non-fork, and `draft == false`. The workflow-dispatch arm remains authorized only when `force_review` is true.
+
+- [ ] **Step 4: Update self callers without adding manual dispatch**
+
+Add `ready_for_review`, the non-draft condition, and the same label expression without the dispatch arm. Pass `force_review: false` where the reusable declares it. Preserve existing secret-presence preflight jobs for Gemini and OpenCode.
+
+- [ ] **Step 5: Update the catalog and explicit defaults**
+
+Change only the three auto-review entries:
+
+- add `ready_for_review` to pull-request types;
+- add `review_mode` to each caller `with` list;
+- add OpenCode `workflow_dispatch` inputs identical to Claude/Gemini; and
+- add OpenCode `force_review` to its caller `with` list.
+
+Keep baseline `review.auto: false`. Add this explicit section to automation's root config to replace compatibility inference:
+
+```yaml
+review:
+  auto: false
+```
+
+- [ ] **Step 6: Run exact tree, catalog, and YAML suites**
+
+```bash
+rtk python3 -m pytest tests/test_canonical_workflow_tree.py tests/test_workflow_catalog.py -q
+rtk python3 -c 'from pathlib import Path; import yaml; paths=sorted(Path(".github/workflows").glob("*.yml"))+sorted(Path("examples/baseline-workflows/.github/workflows").glob("*.yml")); [(_ for _ in ()).throw(AssertionError(p)) for p in paths if not isinstance(yaml.load(p.read_text(), Loader=yaml.BaseLoader), dict)]; print(len(paths))'
+```
+
+Expected: both commands exit zero.
+
+- [ ] **Step 7: Commit caller and catalog parity**
+
+```bash
+rtk git add .github/workflows/_self-claude-review.yml .github/workflows/_self-gemini-auto-review.yml .github/workflows/_self-opencode-auto-review.yml .github/workflow-config.yml examples/baseline-workflows/.github scripts/workflow-catalog.json tests/test_canonical_workflow_tree.py tests/test_workflow_catalog.py
+rtk git commit -m "feat(review): pass label policy through managed callers"
+```
+
+---
+
+### Task 4: Configure external App opt-in behavior and document operations
+
+**Files:**
+- Create: `.gemini/config.yaml`
+- Modify: `docs/workflows/contracts.md`
+- Modify: `tests/test_canonical_workflow_tree.py`
+
+**Interfaces:**
+- Produces: Gemini Code Assist does not review on PR open in automation; `/gemini review` remains available.
+- Records: Codex Code review enabled + Automatic reviews disabled is a required operator confirmation.
+
+- [ ] **Step 1: Write RED repository-config tests**
+
+Add:
+
+```python
+def test_automation_gemini_app_is_manual_review_only():
+    config = yaml.safe_load((ROOT / ".gemini/config.yaml").read_text())
+    assert config == {"code_review": {"pull_request_opened": {"code_review": False}}}
+    assert config["code_review"].get("disable") is None
+```
+
+- [ ] **Step 2: Run the test and confirm the missing file failure**
+
+```bash
+rtk python3 -m pytest tests/test_canonical_workflow_tree.py -q -k gemini_app
+```
+
+Expected: failure reports missing `.gemini/config.yaml`.
+
+- [ ] **Step 3: Add the minimal Gemini configuration**
+
+Create exactly:
+
+```yaml
+code_review:
+  pull_request_opened:
+    code_review: false
+```
+
+Do not set `code_review.disable` and do not add summary/help/ignore defaults.
+
+- [ ] **Step 4: Document operator and command boundaries**
+
+In `docs/workflows/contracts.md`, add sections that state:
+
+- labels control only managed Claude/Gemini/OpenCode workflows;
+- `/jhw:pr` posts `@codex review` and `/gemini review` after the final ready head;
+- Codex Code review remains enabled while Automatic reviews is disabled in ChatGPT Codex settings;
+- Gemini uses only `pull_request_opened.code_review: false` and preserves all unrelated existing keys;
+- `review:skip` cannot cancel an already-started App or workflow review; and
+- fleet activation stops without Codex operator confirmation and mechanically verified Gemini config.
+
+- [ ] **Step 5: Run docs/config tests and commit**
+
+```bash
+rtk python3 -m pytest tests/test_canonical_workflow_tree.py -q
+rtk git add .gemini/config.yaml docs/workflows/contracts.md tests/test_canonical_workflow_tree.py
+rtk git commit -m "docs(review): define manual GitHub App review mode"
+```
+
+---
+
+### Task 5: Close the immutable `v1.51` release boundary
+
+**Files:**
+- Modify: `scripts/workflow_release_inventory.py`
+- Modify: `scripts/workflow_release_bundle.py`
+- Modify: `scripts/verify_workflow_release.py`
+- Modify: `tests/test_workflow_release_bundle.py`
+- Modify: `tests/test_verify_workflow_release.py`
+- Modify: `docs/workflows/contracts.md`
+
+**Interfaces:**
+- Produces: `release_supports_review_policy(ref: str) -> bool` with boundary `(1, 51)`.
+- Produces: exact `100644` roots for policy `action.yml` and `resolve_review_policy.py` in `v1.51+`.
+- Verifies: each auto-review reusable uses the policy action once; each caller passes the mode and ready trigger exactly.
+
+- [ ] **Step 1: Write RED inventory capability tests**
+
+```python
+def test_review_policy_release_boundary():
+    assert release_supports_review_policy("v1.50") is False
+    assert release_supports_review_policy("v1.51") is True
+    paths = {root.path.as_posix() for root in release_roots_for("v1.51")}
+    assert {
+        ".github/actions/resolve-review-policy/action.yml",
+        ".github/actions/resolve-review-policy/resolve_review_policy.py",
+    } <= paths
+```
+
+Add a historical fake-tree test that removes both new files and verifies `v1.50`, plus a `v1.51` test that rejects either missing file, wrong mode, or an extra file under the action directory.
+
+- [ ] **Step 2: Add release inventory roots and update bundle defaults**
+
+Define `REVIEW_POLICY_RELEASE = (1, 51)`, two exact roots, `REVIEW_POLICY_ROOTS`, and append them only when `release_supports_review_policy(ref)` is true. Change `_build_git_archive`, `_git_archive`, `_safe_member`, and `_extract_archive` convenience defaults from `v1.46` to `v1.51`; explicit historical callers continue passing their own ref.
+
+- [ ] **Step 3: Write RED verifier mutation tests**
+
+For commit-only `v1.51`, mutate one property at a time and assert rejection for:
+
+- missing/extra/reordered action input or output;
+- executable or symlink policy files;
+- missing `set -euo pipefail`, fixed PR API fetch, or JSON-file transport;
+- a reusable missing/duplicating the action;
+- a provider job not depending on `policy_run`;
+- a caller missing `ready_for_review`, draft guard, or `review_mode`;
+- changed label spelling or expression precedence; and
+- OpenCode manual dispatch not matching the Claude/Gemini shape.
+
+- [ ] **Step 4: Implement exact action and workflow verification**
+
+Add `EXPECTED_REVIEW_POLICY_ACTION` as the `yaml.BaseLoader` representation and authenticate the Python blob from the commit tree. Require these literals/signatures in the helper:
+
+```text
+PolicyError
+PolicyRequest
+PolicyDecision
+resolve_policy
+review:request
+review:skip
+review_label_conflict
+review_mode_label_mismatch
+workflow_auto_false
+review_auto_false
+default_auto_true
+```
+
+Compile the helper, require the exact public dataclass fields, and add the policy action to the approved local-action list only for `v1.51+`.
+
+- [ ] **Step 5: Run inventory and verifier suites**
+
+```bash
+rtk python3 -m pytest tests/test_workflow_release_bundle.py tests/test_verify_workflow_release.py -q
+```
+
+Expected: all historical release cases remain green and all `v1.51` mutations fail closed.
+
+- [ ] **Step 6: Commit release enforcement**
+
+```bash
+rtk git add scripts/workflow_release_inventory.py scripts/workflow_release_bundle.py scripts/verify_workflow_release.py tests/test_workflow_release_bundle.py tests/test_verify_workflow_release.py docs/workflows/contracts.md
+rtk git commit -m "feat(review): close v1.51 policy release contract"
+```
+
+---
+
+### Task 6: Verify, review, merge, and tag the automation implementation
+
+**Files:**
+- Modify only when a failing verification proves a defect in Tasks 1-5.
+- Preserve all unrelated root worktree files and branches.
+
+**Interfaces:**
+- Produces: merged automation feature PR and immutable annotated `v1.51` tag.
+- Canary A: `review:request` overrides automation's explicit auto-off setting.
+
+- [ ] **Step 1: Run focused syntax and contract suites**
+
+```bash
+rtk python3 -m py_compile .github/actions/resolve-review-policy/resolve_review_policy.py
+rtk python3 -m pytest tests/test_review_policy_action.py tests/test_review_workflow_logic.py tests/test_canonical_workflow_tree.py tests/test_workflow_catalog.py tests/test_workflow_release_bundle.py tests/test_verify_workflow_release.py -q
+```
+
+Expected: both commands exit zero.
+
+- [ ] **Step 2: Run the complete repository verification**
+
+```bash
+rtk python3 -m pytest -q
+rtk actionlint -shellcheck= -pyflakes= .github/workflows/*.yml examples/baseline-workflows/.github/workflows/*.yml
+rtk git diff --check origin/main...HEAD
+```
+
+Expected: full pytest and actionlint pass; no whitespace errors.
+
+- [ ] **Step 3: Verify proposed `v1.51` content against the literal head SHA**
+
+Pass the exact current 40-character commit directly to the verifier:
+
+```bash
+rtk python3 -m scripts.verify_workflow_release --automation . --ref v1.51 --expected-commit "$(rtk git rev-parse HEAD)" --commit-only
+```
+
+Expected output starts `PASS: v1.51 commit content is secure at` and ends with the SHA printed by `rtk git rev-parse HEAD`.
+
+- [ ] **Step 4: Confirm App preconditions before opening the ready PR**
+
+Mechanically verify `.gemini/config.yaml` and ask the operator for one explicit confirmation that Codex Code review is enabled and Automatic reviews is disabled for `jhw7500/automation`. Stop before `gh pr ready` if confirmation is unavailable.
+
+- [ ] **Step 5: Open the implementation PR as draft and apply request before ready**
+
+```bash
+rtk git push -u origin feat/review-mode-command-control
+rtk gh pr create --repo jhw7500/automation --base main --head feat/review-mode-command-control --draft --title "feat(review): add command-controlled review mode" --body "Adds the review label policy, draft-safe callers, external App opt-in configuration, and the immutable v1.51 release boundary.\n\nSpec: docs/superpowers/specs/2026-08-31-review-mode-command-control-design.md"
+rtk gh label list --repo jhw7500/automation --limit 100 --json name,description,color
+```
+
+Run `rtk gh label create review:request --repo jhw7500/automation --color 0E8A16 --description "Explicitly request AI review"` only when that label is absent, and the corresponding `review:skip` command with color `BFDADC` and description `Explicitly skip AI review` only when it is absent. Add only `review:request` to the draft, verify labels/head through `gh pr view --json labels,headRefOid,isDraft`, then run:
+
+```bash
+rtk gh pr ready "$(rtk gh pr view --repo jhw7500/automation --json number -q .number)" --repo jhw7500/automation
+```
+
+- [ ] **Step 6: Execute Canary A and obtain review**
+
+Confirm the ready event creates exactly one eligible current-head run for each enabled managed reviewer even though `review.auto` is false. Post exactly one `@codex review` and one `/gemini review` comment with head-scoped hidden markers. Inspect every result; repair only validated findings with RED/GREEN commits and repeat current-head verification.
+
+- [ ] **Step 7: Merge only the verified current head**
+
+When required CI, target verification, managed reviewers, Codex, and Gemini Assist are terminal and no blocking finding remains, verify the PR head equals the last locally verified SHA and merge using the repository-supported merge method. Confirm `origin/main` contains that exact head ancestry.
+
+- [ ] **Step 8: Create and verify immutable `v1.51`**
+
+From a clean checkout of updated main:
+
+```bash
+rtk git tag -a v1.51 -m "automation workflows v1.51"
+rtk git push origin refs/tags/v1.51
+```
+
+Run the remote verifier against the exact merged main:
+
+```bash
+rtk python3 -m scripts.verify_workflow_release --automation . --ref v1.51 --expected-commit "$(rtk git rev-parse origin/main)" --remote origin
+```
+
+Confirm local annotated tag, peeled commit, remote tag, and authenticated content all match. Never recreate the tag.
+
+---
+
+### Task 7: Validate skip behavior and advance the fleet default
+
+**Files:**
+- Modify after the immutable tag: `scripts/workflow-config.json`
+- Modify after the immutable tag: `tests/test_workflow_catalog.py`
+- Operational canary: one disposable automation PR carrying `review:skip`
+
+**Interfaces:**
+- Canary B: `review:skip` overrides an auto-on PR head and invokes zero AI providers/Apps.
+- Produces: reviewed default-advance PR from `v1.50` to `v1.51`.
+
+- [ ] **Step 1: Run the skip canary on a disposable branch**
+
+Create a fresh branch from tagged/merged main, make one canary-only config commit that sets `review.auto: true`, push it, create a draft PR, apply only `review:skip`, verify it, and mark ready. Do not post App mentions and do not merge this temporary config change.
+
+- [ ] **Step 2: Prove zero invocation**
+
+For each self caller, record the policy job URL and `reason=skip`; verify no provider job started and no new Claude/Gemini/OpenCode/Codex/Gemini Assist review artifact exists for the canary SHA. Required policy checks must reach a successful terminal state. Close the disposable PR and delete only its explicit canary branch after attaching the evidence to the implementation PR or release notes.
+
+- [ ] **Step 3: Write RED fleet-default assertion**
+
+Change the catalog test expectation to:
+
+```python
+assert config.automation_ref == "v1.51"
+```
+
+Run `rtk python3 -m pytest tests/test_workflow_catalog.py -q` and confirm it fails while config remains `v1.50`.
+
+- [ ] **Step 4: Advance only the fleet default**
+
+Change exactly `scripts/workflow-config.json` `automation_ref` to `v1.51`, run the catalog test and complete pytest, then commit:
+
+```bash
+rtk git add scripts/workflow-config.json tests/test_workflow_catalog.py
+rtk git commit -m "chore(workflows): default rollout to v1.51"
+```
+
+- [ ] **Step 5: Open, review, and merge the default PR**
+
+Push a dedicated `chore/workflow-default-v1.51` branch, open a normal PR, and require the same current-head CI/review verification. The immutable `v1.51` tag must continue pointing to the feature merge, not this later default commit.
+
+- [ ] **Step 6: Prepare jhw-notion as the first pinned consumer**
+
+If Gemini Code Assist is installed on `jhw7500/jhw-notion`, open and merge one setup PR that creates or merge-preserves `.gemini/config.yaml` while changing only `code_review.pull_request_opened.code_review` to false. Record operator confirmation for the jhw-notion Codex Automatic reviews setting when Codex is installed.
+
+From a new `rtk mktemp -d /tmp/automation-v151-jhw-notion.XXXXXX` directory, run `scripts/rollout_workflow_fleet.py` first with `--mode plan --ref v1.51 --repo jhw-notion --initialize-workspace`, inspect the exact managed diff, then rerun the same workspace with `--mode publish --ref v1.51 --repo jhw-notion --confirm`. Review and merge that rollout PR only after actionlint, immutable pins, auth profile, `ready_for_review`, and `review_mode` are verified.
+
+- [ ] **Step 7: Hand off to the JHW command plan**
+
+Record the exact `v1.51` peeled commit, implementation PR URL, default PR URL, request canary run URLs, skip canary policy URLs, jhw-notion setup/rollout PR URLs, and Codex/Gemini setting evidence. The next plan may start only when these coordinates are available and the tag verifier passes remotely.

--- a/docs/superpowers/specs/2026-08-31-review-mode-command-control-design.md
+++ b/docs/superpowers/specs/2026-08-31-review-mode-command-control-design.md
@@ -1,0 +1,400 @@
+# Review-mode command control design
+
+Date: 2026-08-31
+Status: conversation design approved; internally reviewed; awaiting user review
+
+## 1. Decision
+
+Add one explicit review policy to pull-request and issue creation commands without replacing the
+existing repository configuration:
+
+- `--review` requests AI review;
+- `--no-review` suppresses AI review for the affected PR head or new issue; and
+- no option follows the repository's existing review configuration.
+
+The canonical pull-request command becomes `/jhw:pr`. `/jhw:ship` remains as a deprecated,
+argument-compatible alias. A new `/jhw:issue` command creates GitHub issues and can request and wait
+for supported issue reviewers.
+
+Repository-managed PR workflows use two GitHub labels as the durable override contract:
+
+| Labels on the PR | Effective workflow policy |
+| --- | --- |
+| `review:request` only | Run enabled Claude, Gemini, and OpenCode review workflows |
+| `review:skip` only | Do not invoke any repository-managed AI reviewer |
+| neither | Use each workflow's existing `workflows.<name>.auto`, then `review.auto`, then compatibility default |
+| both | Configuration error; fail closed without invoking a model |
+
+The labels control repository-managed workflows. `/jhw:pr` applies the same effective policy to
+external GitHub Apps by posting their documented manual commands when review is requested. App
+automatic-review settings are disabled separately so PR-open events do not bypass the command
+policy.
+
+## 2. Goals
+
+1. Let a user decide per PR creation or commit push whether AI review runs.
+2. Apply that decision before the event that starts review, avoiding an opened/synchronize race.
+3. Control the existing Claude, Gemini, and OpenCode workflows plus Codex and Gemini Code Assist.
+4. Preserve current repository defaults when neither option is given.
+5. Let issue creation use the same options and, when requested, wait for supported issue-review
+   responses and summarize them.
+6. Keep `/jhw:ship` users working while moving the primary name to `/jhw:pr`.
+7. Keep review advisory: review results never edit or close an issue automatically.
+
+## 3. Non-goals
+
+- Replacing workflow-specific `enabled` settings, required CI, branch protection, or human approval.
+- Turning GitHub labels into general-purpose commands for external Apps; Apps are invoked by the
+  JHW command because they do not consume these labels.
+- Cancelling or deleting a review that started before `review:skip` was applied.
+- Making unsupported standalone-issue behavior a required capability of a PR-only GitHub App.
+- Changing reviewer prompts, finding grammar, severity policy, or review quality gates.
+- Changing Notion databases, Project Control state, or issue #52.
+- Adding a new executable CLI or service when the existing JHW skill workflow and `gh` are enough.
+
+## 4. Command interface
+
+### 4.1 `/jhw:pr`
+
+`/jhw:pr` keeps the current `/jhw:ship` options and behavior, including `--merge`, `--target`,
+`--auto-fix`, `--base`, reviewer selection, timeout, round limits, and blocking threshold. It adds:
+
+```text
+/jhw:pr [existing options] [--review | --no-review]
+```
+
+`--review` and `--no-review` are mutually exclusive. Supplying both stops before any label, push,
+PR, comment, or merge mutation.
+
+The option changes review policy only. It does not imply `--merge`, weaken CI, or change the target
+test. `--no-review --merge` is allowed only when both were explicitly supplied; the final receipt
+and durable `review:skip` label state that AI review was explicitly skipped.
+
+`/jhw:ship` is retained as a thin deprecated alias to `/jhw:pr` and forwards every argument. Its
+output identifies the replacement command but otherwise follows the same state machine.
+
+### 4.2 `/jhw:issue`
+
+`/jhw:issue` creates an issue in the current repository from the user-supplied or current-task title
+and body:
+
+```text
+/jhw:issue [issue content] [--review | --no-review] [--timeout <duration>]
+```
+
+If the title or body cannot be derived unambiguously, the command obtains them before mutation. The
+new command is intentionally narrow; ordinary assignee, milestone, project, and bulk-issue
+management remain outside this feature.
+
+- `--review`: create the issue, request every preflight-supported issue reviewer once, wait up to
+  the bounded timeout, apply `review:request`, and summarize responses.
+- `--no-review`: apply `review:skip` and create the issue without reviewer mentions or review
+  waiting.
+- no option: apply neither override, read `review.auto`, and request and wait when true; otherwise
+  create only.
+
+An issue-review result never rewrites the issue body, closes the issue, changes its milestone, or
+implements the feedback automatically.
+
+## 5. Policy resolution and compatibility
+
+The command resolves its mode before mutation:
+
+1. reject mutually exclusive options;
+2. explicit `--review` selects `request`;
+3. explicit `--no-review` selects `skip`; and
+4. otherwise select `auto` and read the checked-out target repository configuration.
+
+For external App requests and issue review, `auto` uses global `review.auto`. A missing value keeps
+the existing compatibility default (`true`); the baseline file continues to declare `false`
+explicitly so managed repositories are not surprised. Repository-managed PR workflows additionally
+preserve their existing per-workflow override precedence:
+
+```text
+workflows.<review-workflow>.auto -> review.auto -> true
+```
+
+An explicit label overrides only automatic mode, not `workflows.<name>.enabled`. A disabled or
+unconfigured reviewer remains unavailable under `review:request`; the command reports that rather
+than treating it as a successful review.
+
+When `/jhw:pr` operates on an existing PR, it removes the opposite override before applying the
+selected one. With no option it removes both override labels, restoring configuration-driven
+behavior. If both labels are observed after reconciliation, execution stops as a policy conflict.
+
+## 6. PR event ordering
+
+### 6.1 New PR
+
+To prevent `opened` from running reviewers before the override exists:
+
+1. preflight permissions, workflow capability, labels, and App prerequisites;
+2. push the branch if needed;
+3. create a draft PR;
+4. reconcile the selected override label while the PR is still draft;
+5. verify the remote PR labels and head SHA;
+6. mark the PR ready for review; and
+7. request external App reviews for that exact ready head when effective policy is `request`.
+
+The managed callers add `ready_for_review` and refuse model invocation while the PR is a draft.
+Thus correctness does not depend on whether `gh pr create --label` applies a label before or after
+GitHub emits `opened`: the draft event is harmless and the ready event is the first eligible review
+event.
+
+### 6.2 Existing PR with a new head
+
+Before push, the command reconciles the override labels and verifies them through the GitHub API.
+The subsequent `synchronize` event sees the intended mode. External App comments are posted only
+after the remote PR head equals the pushed head.
+
+### 6.3 Existing PR with an unchanged head
+
+`--review` uses each installed caller's authorized manual dispatch path for one same-head central
+review and posts each external App request once for the same SHA. OpenCode gains the same bounded
+manual same-head contract already used by Claude and Gemini. No-option automatic mode does not force
+a duplicate same-head review.
+
+Requests are idempotent per reviewer and PR head. Command-owned App comments include a hidden
+reviewer/SHA marker, and central workflows retain their authenticated same-head invocation budget.
+Re-running the command for the same reviewer and SHA observes the existing request instead of
+posting or dispatching another.
+
+### 6.4 `--no-review`
+
+The skip label is verified before a push or before a draft becomes ready. Repository-managed callers
+complete their policy gate without a model invocation. The command posts no App mention and does not
+wait for AI review. It still waits for required CI and an explicitly requested target test. It does
+not cancel a run that began before the label was applied.
+
+## 7. Workflow contract
+
+Claude, Gemini, and OpenCode reusable review workflows accept a validated `review_mode` input with
+exact values `auto`, `request`, `skip`, or `conflict`:
+
+- `auto` preserves current workflow/global/default precedence;
+- `request` enables review when that workflow is installed and enabled;
+- `skip` returns a successful policy result without provider invocation; and
+- `conflict` fails the policy result with an explicit diagnostic and no provider invocation.
+
+`force_review` remains a separate authorized same-head mechanism. A caller may set it only for a
+manual dispatch that represents `request`; it forces a full current-head review subject to the
+existing invocation budget. It never legitimizes `skip` or `conflict`.
+
+Managed callers:
+
+- listen to `opened`, `synchronize`, and `ready_for_review`;
+- derive `review_mode` from the PR labels for event-driven calls;
+- pass `request` for an authorized `force_review` dispatch;
+- keep same-repository/fork checks; and
+- pass every mode, including `skip` and `conflict`, to the reusable policy gate so required checks
+  get a terminal result.
+
+The exact trigger/input/permission changes are recorded in `scripts/workflow-catalog.json`, baseline
+callers, release inventory/verifiers, and `docs/workflows/contracts.md`. Self-review callers follow
+the same contract so automation dogfoods the behavior before fleet rollout.
+
+Implementation reuses the existing workflow/config gates and invocation-budget machinery. It does
+not add a persistent service, database, or general command runtime; a shared policy helper is added
+only if the test-first implementation shows that exact behavior cannot remain consistent in the
+three workflows without it.
+
+## 8. Labels and permissions
+
+Every managed target repository uses these fixed labels for PRs and issues:
+
+- `review:request`: explicitly request AI review for the current operation;
+- `review:skip`: explicitly skip AI review for the current operation.
+
+The command preflights repository write access and ensures missing labels exist before creating the
+PR/issue or pushing a review-triggering commit. Lack of permission stops the operation with no
+branch push, PR, issue, or reviewer comment. Label creation itself is the only allowed prerequisite
+mutation and is reported in the receipt.
+
+Label application is verified by reading the PR or issue back from the API. Workflows independently
+reject the both-label state; they never trust command-side validation alone.
+
+## 9. External GitHub Apps
+
+External Apps must not retain PR-open automatic review while command-level selection is active.
+
+### 9.1 Codex
+
+Keep repository Code review enabled, turn off **Automatic reviews** in Codex repository settings,
+and use the documented `@codex review` PR comment for explicit requests. This separates App access
+from automatic invocation. The JHW command cannot safely mutate this account-level setting, so
+activation requires a one-time operator confirmation.
+
+### 9.2 Gemini Code Assist
+
+Keep Gemini Code Assist installed and disable only PR-open code review in repository configuration:
+
+```yaml
+code_review:
+  pull_request_opened:
+    code_review: false
+```
+
+Do not use `code_review.disable: true`, because that disables Gemini acting on pull requests rather
+than merely disabling the opened-event review. Explicit requests use the documented `/gemini review`
+PR comment. Existing unrelated `.gemini/config.yaml` settings must be preserved.
+
+Fleet preflight verifies the Gemini repository file mechanically and records a one-time operator
+confirmation for the Codex setting, which GitHub does not expose as repository content. If either
+cannot be confirmed, the implementation and canary PRs may remain reviewable, but fleet activation
+stops before broad rollout. Updating an existing `.gemini/config.yaml` is a merge-preserving,
+separately reviewed setup change; unrelated keys are never regenerated or removed.
+
+## 10. Issue-review channels
+
+`/jhw:issue --review` builds a reviewer plan before creating the issue:
+
+- Claude is eligible when the managed issue-mention caller is installed and enabled.
+- Central Gemini is eligible when the managed issue chat/dispatch caller is installed, enabled, and
+  configured.
+- Codex issue mention is eligible only for repositories where the connector/environment has been
+  explicitly configured and a canary has demonstrated standalone-issue response. Official Codex
+  code-review documentation guarantees PR review, so issue support is never inferred from PR setup.
+- Gemini Code Assist `/gemini review` is PR-only and is not requested or awaited on standalone
+  issues.
+- OpenCode's current safe-review contract is PR-only and is not requested or awaited on standalone
+  issues.
+
+If no issue reviewer is eligible, `--review` stops before issue creation. Otherwise the command
+creates the issue, applies `review:request`, posts one command-owned request per planned reviewer,
+and records hidden request markers for retry idempotence.
+
+GitHub does not reveal secret values during preflight. A caller that is present and enabled can
+therefore still fail authentication at runtime; that result is `FAILED` and is reported with its
+Actions URL rather than being mislabeled as a timeout.
+
+The wait loop observes reviewer comments, reviews where applicable, reactions that prove a trigger
+was accepted, and relevant Actions runs. Each planned reviewer finishes as `CLEAN`, `FEEDBACK`,
+`FAILED`, or `TIMEOUT`; an unavailable channel is reported as `UNAVAILABLE` during preflight and is
+not waited on. Trigger rejection or workflow failure is `FAILED`, not `TIMEOUT`.
+
+The final issue summary contains the issue URL, requested and unavailable reviewers, response links,
+the highest actionable disposition, and timeout/failure diagnostics. A timeout never deletes the
+created issue.
+
+## 11. PR review waiting and merge behavior
+
+For effective `request`, `/jhw:pr` waits for the exact current head across:
+
+- Claude, Gemini, and OpenCode managed review results that were planned;
+- Codex and Gemini Code Assist responses that were requested;
+- required GitHub checks; and
+- the optional target command.
+
+Each reviewer is requested once and classified using existing `/jhw:ship` semantics: `CLEAN`,
+`FEEDBACK`, `FAILED`, or `TIMEOUT`. The command distinguishes a missing/failed trigger from an
+accepted request that exceeded the timeout. A later push invalidates the prior wait result and
+starts a new head-scoped round.
+
+Merge remains blocked while required CI fails, the target fails, a planned reviewer has not reached
+an allowed terminal state, or a finding at/above `--block-on` remains unresolved. Under explicit
+`--no-review --merge`, only the AI-review gate is waived; CI, target, current-head, and mergeability
+checks are unchanged.
+
+## 12. Repository ownership
+
+### 12.1 `jhw7500/automation`
+
+Owns:
+
+- label-to-`review_mode` workflow behavior;
+- draft and `ready_for_review` gates;
+- Claude/Gemini/OpenCode reusable and caller parity;
+- baseline workflow/config templates;
+- catalog, release inventory, immutable release verification, rollout checks, and contracts; and
+- deterministic tests for policy precedence, conflict handling, provider non-invocation, and
+  same-head authorization.
+
+### 12.2 `jhw7500/jhw-notion`
+
+Owns:
+
+- canonical `skills/claude/pr.md`;
+- deprecated `skills/claude/ship.md` alias;
+- canonical `skills/claude/issue.md`;
+- generated Codex skill synchronization;
+- command documentation and skill tests; and
+- the waiting, summary, idempotence, and mutation-order instructions used by the commands.
+
+Only skill files and their documentation/tests change in this repository. Notion database and
+Project Control records are excluded.
+
+## 13. Error handling and recovery
+
+- Invalid option combination: fail before mutation.
+- Missing permission or required label: fail before push/PR/issue creation, except reported creation
+  of an absent label during preflight.
+- Both labels: workflow policy failure, no model request.
+- Draft PR: no model request; ready transition retries policy normally.
+- Push succeeds but later request fails: keep the branch/PR, report exact failed channel, and allow
+  idempotent resume at the same head.
+- Issue creation succeeds but a reviewer fails or times out: keep the issue and return partial
+  results.
+- App trigger not acknowledged: classify `FAILED` after the trigger window rather than waiting the
+  full review timeout.
+- New commit during a wait: discard stale terminal results and resolve policy for the new head.
+- Missing deployed workflow capability: stop before using a review override; do not pretend an old
+  caller can honor `--no-review`.
+
+## 14. Verification
+
+Automation tests cover at least:
+
+1. `review.auto=true` and `review.auto=false` with no labels;
+2. `review:request` overriding false;
+3. `review:skip` overriding true;
+4. both labels failing without any provider step;
+5. draft `opened` producing zero reviews and `ready_for_review` producing exactly one;
+6. label verification preceding a review-triggering push;
+7. authorized same-head dispatch and per-reviewer/SHA deduplication;
+8. disabled or missing reviewers reported unavailable rather than successful;
+9. exact catalog, baseline, permission, release inventory, and local-action contracts; and
+10. complete pytest, YAML parsing, and actionlint suites.
+
+JHW skill tests cover at least:
+
+1. mutual exclusion before mutation;
+2. new-PR draft/label/ready order;
+3. existing-PR label-before-push order;
+4. no-option override removal and config fallback;
+5. external App command text and hidden-marker deduplication;
+6. `--no-review` issuing zero AI requests while retaining CI/target gates;
+7. explicit skip merge receipt;
+8. issue reviewer discovery, zero-reviewer preflight failure, waiting, and summary;
+9. timeout/failure preserving the created issue; and
+10. canonical-to-generated skill sync plus install-safety tests.
+
+## 15. Release and rollout
+
+1. Implement and review the automation contract on an isolated branch.
+2. Run repository-wide tests and dogfood the PR with explicit request/skip cases.
+3. Merge only a verified current head and create the next immutable automation release; never move a
+   release tag.
+4. Roll out to two bounded canary scenarios: `request` overriding an auto-off repository and `skip`
+   overriding an auto-on repository. Each canary verifies draft ordering, exact provider counts,
+   App mentions, same-head deduplication, and current-head results.
+5. Implement, test, review, and merge the jhw-notion skill changes against the verified canary
+   contract, then run the canonical-to-Codex sync.
+6. Confirm Codex Automatic reviews are off and apply the merge-preserving Gemini PR-open
+   configuration change before fleet activation.
+7. Use the existing fleet planner and publisher for managed callers/config, inspect every proposed
+   repository diff, and roll out in bounded batches.
+8. Stop rollout on duplicate App reviews, a label/push race, a non-terminal required check, a
+   provider invocation under skip/conflict/draft, or any release-verifier mismatch.
+
+Rollback uses a new automation release that restores the prior caller behavior and a normal skill
+revert PR. Immutable tags are not rewritten. Labels may remain harmlessly installed if the feature
+is rolled back.
+
+## 16. References
+
+- Codex documents separate repository Code review access, manual `@codex review`, and the Automatic
+  reviews setting: <https://developers.openai.com/codex/integrations/github>
+- Gemini documents repository `.gemini/config.yaml`, `pull_request_opened.code_review`, and
+  `code_review.disable`: <https://docs.cloud.google.com/gemini/docs/code-review/customize-repo-review>
+- Gemini documents manual `/gemini review` on PR issue comments:
+  <https://docs.cloud.google.com/gemini/docs/code-review/use-code-assist-github>

--- a/docs/superpowers/specs/2026-08-31-review-mode-command-control-design.md
+++ b/docs/superpowers/specs/2026-08-31-review-mode-command-control-design.md
@@ -1,7 +1,7 @@
 # Review-mode command control design
 
 Date: 2026-08-31
-Status: conversation design approved; internally reviewed; awaiting user review
+Status: approved; implementation plans written
 
 ## 1. Decision
 

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -156,10 +156,10 @@ for every common caller; enabling any of them is a later repository-owned PR.
 
 `review:request` and `review:skip` control only the managed Claude, Gemini, and OpenCode
 workflows. They do not control GitHub App reviews. The resolved managed-workflow mode is, in
-order: a `workflow_dispatch` `force_review` is `request`; both labels are `conflict`; only
-`review:request` is `request`; only `review:skip` is `skip`; and neither label is `auto`.
-`conflict` fails before a model is invoked. Draft PRs, `skip`, unsafe forks, and closed PRs
-succeed without invoking a model. `request` never overrides
+order: both labels are `conflict`; only `review:request` is `request`; only `review:skip` is
+`skip`; and neither label is `auto`. Only with neither label may a `workflow_dispatch`
+`force_review` change `auto` to `request`. `conflict` fails before a model is invoked. Draft
+PRs, `skip`, unsafe forks, and closed PRs succeed without invoking a model. `request` never overrides
 `workflows.<name>.enabled: false`, and `workflows.<name>.auto` still takes precedence over the
 baseline `review.auto: false`.
 

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -163,6 +163,20 @@ PRs, `skip`, unsafe forks, and closed PRs succeed without invoking a model. `req
 `workflows.<name>.enabled: false`, and `workflows.<name>.auto` still takes precedence over the
 baseline `review.auto: false`.
 
+Beginning with `v1.51`, the closed release inventory also contains exactly these regular,
+non-executable `100644` files:
+
+```text
+.github/actions/resolve-review-policy/action.yml
+.github/actions/resolve-review-policy/resolve_review_policy.py
+```
+
+Release verification authenticates that exact composite-action interface and helper, requires each
+of the Claude, Gemini, and OpenCode reusable workflows to call the resolver exactly once, and checks
+the exact ready-for-review, draft-guard, label, dispatch, and configuration-precedence wiring in
+their managed callers. These inventory and semantic checks apply only to `v1.51+`; `v1.50` and every
+earlier release retain their existing closed inventories and historical caller contracts.
+
 `/jhw:pr` posts `@codex review` and `/gemini review` after the final ready head, so manual
 App review remains available. Operators must keep Codex Code review enabled while disabling
 Automatic reviews in ChatGPT Codex settings. Gemini disables only PR-open automatic review:

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -152,6 +152,37 @@ Manual mention/comment and manual-dispatch behavior remains available when the a
 caller is enabled. The disabled bootstrap template uses `workflows.<name>.enabled: false`
 for every common caller; enabling any of them is a later repository-owned PR.
 
+## Review controls and external App operation
+
+`review:request` and `review:skip` control only the managed Claude, Gemini, and OpenCode
+workflows. They do not control GitHub App reviews. The resolved managed-workflow mode is, in
+order: a `workflow_dispatch` `force_review` is `request`; both labels are `conflict`; only
+`review:request` is `request`; only `review:skip` is `skip`; and neither label is `auto`.
+`conflict` fails before a model is invoked. Draft PRs, `skip`, unsafe forks, and closed PRs
+succeed without invoking a model. `request` never overrides
+`workflows.<name>.enabled: false`, and `workflows.<name>.auto` still takes precedence over the
+baseline `review.auto: false`.
+
+`/jhw:pr` posts `@codex review` and `/gemini review` after the final ready head, so manual
+App review remains available. Operators must keep Codex Code review enabled while disabling
+Automatic reviews in ChatGPT Codex settings. Gemini disables only PR-open automatic review:
+
+```yaml
+code_review:
+  pull_request_opened:
+    code_review: false
+```
+
+This uses only `pull_request_opened.code_review: false`; it does not set `code_review.disable`
+and preserves unrelated existing Gemini configuration keys. `review:skip` cannot cancel an App
+or managed-workflow review that has already started. Fleet activation stops unless an operator
+confirms the Codex setting and the Gemini configuration is mechanically verified.
+
+To roll back the external-App opt-in, restore only Gemini's
+`pull_request_opened.code_review` value to `true` and re-enable Automatic reviews in ChatGPT
+Codex settings; keep Codex Code review enabled. No label or managed-workflow policy changes are
+needed for this rollback.
+
 ## Deterministic automated-review input
 
 Claude, Gemini, and OpenCode call the same composite action:

--- a/examples/baseline-workflows/.github/workflows/claude-code-review.yml
+++ b/examples/baseline-workflows/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -20,7 +20,8 @@ jobs:
     if: >-
       (github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.fork == false &&
-      github.event.pull_request.head.repo.full_name == github.repository) ||
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false) ||
       (github.event_name == 'workflow_dispatch' && inputs.force_review)
     permissions:
       actions: read
@@ -32,5 +33,14 @@ jobs:
     with:
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       force_review: ${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}
+      review_mode: >-
+        ${{
+          github.event_name == 'workflow_dispatch' && inputs.force_review && 'request' ||
+          contains(github.event.pull_request.labels.*.name, 'review:request') &&
+          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'conflict' ||
+          contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||
+          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'skip' ||
+          'auto'
+        }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/examples/baseline-workflows/.github/workflows/gemini-auto-review.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-auto-review.yml
@@ -2,7 +2,7 @@ name: Gemini Auto PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -20,7 +20,8 @@ jobs:
     if: >-
       (github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.fork == false &&
-      github.event.pull_request.head.repo.full_name == github.repository) ||
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false) ||
       (github.event_name == 'workflow_dispatch' && inputs.force_review)
     permissions:
       actions: read
@@ -31,6 +32,15 @@ jobs:
     with:
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       force_review: ${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}
+      review_mode: >-
+        ${{
+          github.event_name == 'workflow_dispatch' && inputs.force_review && 'request' ||
+          contains(github.event.pull_request.labels.*.name, 'review:request') &&
+          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'conflict' ||
+          contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||
+          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'skip' ||
+          'auto'
+        }}
       repo_write_auth: github_app
       app_id: ${{ vars.APP_ID }}
       publisher_app_id: ${{ vars.APP_ID }}

--- a/examples/baseline-workflows/.github/workflows/opencode-auto-review.yml
+++ b/examples/baseline-workflows/.github/workflows/opencode-auto-review.yml
@@ -2,10 +2,27 @@ name: OpenCode Auto PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        type: number
+        required: true
+      force_review:
+        description: Perform one authorized same-HEAD review
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   opencode-review:
+    if: >-
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false) ||
+      (github.event_name == 'workflow_dispatch' && inputs.force_review)
     permissions:
       actions: read
       checks: write
@@ -14,6 +31,16 @@ jobs:
       pull-requests: write
     uses: jhw7500/automation/.github/workflows/opencode-auto-review.yml@__AUTOMATION_COMMIT__
     with:
-      pr_number: ${{ github.event.pull_request.number }}
+      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
+      force_review: ${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}
+      review_mode: >-
+        ${{
+          github.event_name == 'workflow_dispatch' && inputs.force_review && 'request' ||
+          contains(github.event.pull_request.labels.*.name, 'review:request') &&
+          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'conflict' ||
+          contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||
+          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'skip' ||
+          'auto'
+        }}
     secrets:
       ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -37,6 +37,8 @@ from scripts.workflow_release_inventory import (
     PREPARE_REVIEW_DIFF_ACTION_ROOT,
     REVIEW_INVOCATION_BUDGET_ACTION_ROOT,
     REVIEW_INVOCATION_BUDGET_HELPER_ROOT,
+    REVIEW_POLICY_ACTION_ROOT,
+    REVIEW_POLICY_HELPER_ROOT,
     REVIEW_SCOPE_HELPER_ROOT,
     SETUP_GEMINI_AUTH_ROOT,
     release_paths_for,
@@ -44,6 +46,7 @@ from scripts.workflow_release_inventory import (
     release_supports_canonicalize_review,
     release_supports_prepare_review_diff,
     release_supports_review_invocation_budget,
+    release_supports_review_policy,
     validate_release_listing,
 )
 
@@ -644,6 +647,9 @@ CANONICALIZE_REVIEW_ACTION = (
 REVIEW_INVOCATION_BUDGET_ACTION = (
     f"$/{REVIEW_INVOCATION_BUDGET_ACTION_ROOT.path.parent.as_posix()}"
 )
+REVIEW_POLICY_ACTION = (
+    f"$/{REVIEW_POLICY_ACTION_ROOT.path.parent.as_posix()}"
+)
 REVIEWER_WORKFLOWS = {
     "claude": "claude-code-review.yml",
     "gemini": "gemini-auto-review.yml",
@@ -660,6 +666,139 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
     "gemini": "cf3da7805be2f707f07eb2fa01e812083412d4dfb87d81ba3990f6222e616e9e",
     "opencode": "c249bd40a072d74179f5313f4e53d8ef9817f05bbdbc1f0c0e94bf513af1d2ba",
 }
+EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256 = {
+    "claude": "2950d9dbf0923dfc463a872e8602e4d73ba2457a0df90ca3cca228ffb661343a",
+    "gemini": "97065b368b6e50a2cff0149cdb472337ee36fb8cd102a2887c8a56c1bbdca8cc",
+    "opencode": "6a80a008783826618baed22c0675f354cdf7a1b845ef8f6aecd224f00f800249",
+}
+EXPECTED_REVIEW_POLICY_HELPER_SHA256 = (
+    "3e0fd3c86b1dc40dc35213ca41c3d63122c9ebf757042f5a2c86f4fc1e99ac8a"
+)
+EXPECTED_REVIEW_POLICY_RECORDS = {
+    "PolicyRequest": (
+        ("workflow_name", "str"),
+        ("review_mode", "str"),
+        ("force_run", "bool"),
+        ("force_review", "bool"),
+        ("event_name", "str"),
+        ("repository", "str"),
+        ("pr", "dict[str, object]"),
+        ("config", "dict[str, object]"),
+    ),
+    "PolicyDecision": (
+        ("run_review", "bool"),
+        ("effective_mode", "str"),
+        ("reason", "str"),
+        ("head_sha", "str"),
+    ),
+}
+EXPECTED_REVIEW_POLICY_LITERALS = frozenset(
+    {
+        "PolicyError",
+        "PolicyRequest",
+        "PolicyDecision",
+        "resolve_policy",
+        "review:request",
+        "review:skip",
+        "review_label_conflict",
+        "review_mode_label_mismatch",
+        "workflow_auto_false",
+        "review_auto_false",
+        "default_auto_true",
+    }
+)
+EXPECTED_REVIEW_POLICY_ACTION = yaml.load(
+    r"""name: Resolve Review Policy
+description: Resolve a deterministic review policy before model invocation.
+
+inputs:
+  workflow-name:
+    description: Workflow name in workflow-config.yml.
+    required: true
+  pr-number:
+    description: Pull request number.
+    required: true
+  review-mode:
+    description: Requested review mode.
+    required: true
+  force-run:
+    description: Run even when the workflow is disabled.
+    required: true
+  force-review:
+    description: Request a review for a manual dispatch.
+    required: true
+  github-token:
+    description: Token used to read the pull request.
+    required: true
+
+outputs:
+  run-review:
+    description: Whether a review may run.
+    value: ${{ steps.resolve.outputs.run-review }}
+  effective-mode:
+    description: The resolved review mode.
+    value: ${{ steps.resolve.outputs.effective-mode }}
+  reason:
+    description: Deterministic resolution reason.
+    value: ${{ steps.resolve.outputs.reason }}
+  head-sha:
+    description: Validated pull request head SHA.
+    value: ${{ steps.resolve.outputs.head-sha }}
+
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        REVIEW_MODE: ${{ inputs.review-mode }}
+        WORKFLOW_NAME: ${{ inputs.workflow-name }}
+        FORCE_RUN: ${{ inputs.force-run }}
+        FORCE_REVIEW: ${{ inputs.force-review }}
+      run: |
+        set -euo pipefail
+        policy_dir="$RUNNER_TEMP/review-policy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        install -d -m 0700 "$policy_dir"
+        gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > "$policy_dir/pr.json"
+        ruby -ryaml -rjson -e 'cfg = File.file?(ARGV[0]) ? (YAML.safe_load_file(ARGV[0], aliases: false) || {}) : {}; File.write(ARGV[1], JSON.generate(cfg))' \
+          .github/workflow-config.yml "$policy_dir/config.json"
+        python3 - "$policy_dir/pr.json" "$policy_dir/config.json" "$policy_dir/request.json" <<'PY'
+        import json
+        import os
+        import sys
+        from pathlib import Path
+
+        def boolean(name: str) -> bool:
+            value = os.environ[name]
+            if value not in {"true", "false"}:
+                raise SystemExit(f"{name.lower()}_invalid")
+            return value == "true"
+
+        pr_path, config_path, request_path = map(Path, sys.argv[1:])
+        payload = {
+            "workflow_name": os.environ["WORKFLOW_NAME"],
+            "review_mode": os.environ["REVIEW_MODE"],
+            "force_run": boolean("FORCE_RUN"),
+            "force_review": boolean("FORCE_REVIEW"),
+            "event_name": os.environ["GITHUB_EVENT_NAME"],
+            "repository": os.environ["GITHUB_REPOSITORY"],
+            "pr": json.loads(pr_path.read_text(encoding="utf-8")),
+            "config": json.loads(config_path.read_text(encoding="utf-8")),
+        }
+        request_path.write_text(
+            json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        PY
+        python3 "$GITHUB_ACTION_PATH/resolve_review_policy.py" \
+          --request-file "$policy_dir/request.json" \
+          --result-file "$policy_dir/result.json" \
+          --github-output "$GITHUB_OUTPUT"
+""",
+    Loader=yaml.BaseLoader,
+)
 EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION = yaml.load(
     r"""name: Review invocation budget
 description: Claim and finalize a durable fail-closed review invocation budget
@@ -2111,10 +2250,10 @@ def verify_opencode_runtime(
         "opencode run --model zai-coding-plan/glm-4.7 --format json "
         "--file review-full.diff --file review-scope.json"
     ) in run_script
-    current_diagnostics_contract = (
-        workflow_sha256
-        == EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256["opencode"]
-    )
+    current_diagnostics_contract = workflow_sha256 in {
+        EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256["opencode"],
+        EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256["opencode"],
+    }
     initial_validation_argument = " initial" if current_diagnostics_contract else ""
     repair_validation_argument = " repair" if current_diagnostics_contract else ""
     format_sequence = (
@@ -2144,6 +2283,7 @@ def verify_opencode_runtime(
         workflow_sha256 in {
             OPENCODE_AUTO_REVIEW_SHA256,
             EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256["opencode"],
+            EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256["opencode"],
         }
         and run_step.get("shell") == "bash"
         and run_env.get("CANDIDATE_NONCE")
@@ -2658,6 +2798,113 @@ def _class_function_headers(node: ast.ClassDef) -> dict[str, str]:
                 raise ValueError("duplicate method")
             functions[item.name] = _function_header(item)
     return functions
+
+
+def require_review_policy_helper_contract(source: str) -> None:
+    """Authenticate and statically validate the public policy-helper surface."""
+
+    try:
+        if (
+            hashlib.sha256(source.encode("utf-8")).hexdigest()
+            != EXPECTED_REVIEW_POLICY_HELPER_SHA256
+        ):
+            raise ValueError("helper source digest differs")
+        compile(
+            source,
+            REVIEW_POLICY_HELPER_ROOT.path.as_posix(),
+            "exec",
+            dont_inherit=True,
+        )
+        module = ast.parse(
+            source, filename=REVIEW_POLICY_HELPER_ROOT.path.as_posix()
+        )
+        _require_unique_module_bindings(
+            module,
+            frozenset(
+                {
+                    "PolicyError",
+                    *EXPECTED_REVIEW_POLICY_RECORDS,
+                    "resolve_policy",
+                }
+            ),
+        )
+        error = _class_node(module, "PolicyError")
+        if [ast.unparse(base) for base in error.bases] != ["ValueError"]:
+            raise ValueError("policy error base differs")
+        for name, expected in EXPECTED_REVIEW_POLICY_RECORDS.items():
+            if _record_fields(_class_node(module, name)) != expected:
+                raise ValueError("policy record differs")
+        functions = _module_function_headers(module)
+        if functions.get("resolve_policy") != (
+            "def resolve_policy(request: PolicyRequest) -> PolicyDecision"
+        ):
+            raise ValueError("policy function differs")
+        direct_literals = EXPECTED_REVIEW_POLICY_LITERALS - {
+            "workflow_auto_false",
+            "review_auto_false",
+        }
+        if any(literal not in source for literal in direct_literals):
+            raise ValueError("policy literal differs")
+        automatic = _function_node(module, "_automatic_decision")
+        automatic_source = ast.unparse(automatic)
+        if (
+            "workflow_auto_{str(automatic).lower()}"
+            not in automatic_source
+            or "review_auto_{str(automatic).lower()}"
+            not in automatic_source
+        ):
+            raise ValueError("automatic policy reasons differ")
+    except (SyntaxError, TypeError, UnicodeError, ValueError):
+        raise ReleaseVerificationError(
+            "review-policy helper contract is invalid"
+        ) from None
+
+
+def _verify_review_policy_action(
+    tree: VerifiedCommitTree, ref: str
+) -> None:
+    if not release_supports_review_policy(ref):
+        return
+    expected_files = {
+        (REVIEW_POLICY_ACTION_ROOT.path.as_posix(), "100644", "blob"),
+        (REVIEW_POLICY_HELPER_ROOT.path.as_posix(), "100644", "blob"),
+    }
+    actual_files = {
+        (entry.path.as_posix(), entry.mode, entry.object_type)
+        for entry in tree.files(REVIEW_POLICY_ACTION_ROOT.path.parent)
+    }
+    if actual_files != expected_files:
+        raise ReleaseVerificationError("review-policy inventory is not closed")
+    try:
+        action = yaml.load(
+            tree.read_file(REVIEW_POLICY_ACTION_ROOT.path),
+            Loader=yaml.BaseLoader,
+        )
+        if (
+            action != EXPECTED_REVIEW_POLICY_ACTION
+            or tuple(action["inputs"])
+            != tuple(EXPECTED_REVIEW_POLICY_ACTION["inputs"])
+            or tuple(action["outputs"])
+            != tuple(EXPECTED_REVIEW_POLICY_ACTION["outputs"])
+        ):
+            raise ValueError("action differs")
+    except (
+        AttributeError,
+        ReleaseVerificationError,
+        TypeError,
+        ValueError,
+        yaml.YAMLError,
+    ):
+        raise ReleaseVerificationError(
+            "review-policy action contract is invalid"
+        ) from None
+    try:
+        helper = tree.read_file(REVIEW_POLICY_HELPER_ROOT.path).decode("utf-8")
+    except (ReleaseVerificationError, UnicodeDecodeError):
+        raise ReleaseVerificationError(
+            "review-policy helper contract is invalid"
+        ) from None
+    require_review_policy_helper_contract(helper)
 
 
 def _verify_canonicalize_review_helpers(tree: VerifiedCommitTree) -> None:
@@ -4577,7 +4824,11 @@ def require_budget_helper_contract(source: str) -> None:
 
 
 def require_budget_workflow_contract(
-    tree: VerifiedCommitTree, workflow: str, reviewer: str
+    tree: VerifiedCommitTree,
+    workflow: str,
+    reviewer: str,
+    *,
+    review_policy: bool = False,
 ) -> None:
     """Require reviewer semantics from authenticated commit-tree workflow bytes."""
 
@@ -4855,10 +5106,16 @@ def require_budget_workflow_contract(
             if provider_job.get("needs") != ["check-enabled", "opencode-prepare"]:
                 raise ValueError("OpenCode provider dependencies differ")
             provider_job_if = " ".join(provider_job.get("if", "").split())
-            expected_job_if = (
-                "needs.check-enabled.outputs.enabled == 'true' && "
-                "needs.check-enabled.outputs.auto_enabled == 'true' && "
-                "needs.check-enabled.outputs.safe_pr == 'true' && "
+            expected_job_if = "needs.check-enabled.outputs.enabled == 'true' && "
+            expected_job_if += (
+                "needs.check-enabled.outputs.policy_run == 'true' && "
+                if review_policy
+                else (
+                    "needs.check-enabled.outputs.auto_enabled == 'true' && "
+                    "needs.check-enabled.outputs.safe_pr == 'true' && "
+                )
+            )
+            expected_job_if += (
                 "needs.opencode-prepare.result == 'success' && "
                 "needs.opencode-prepare.outputs.allow_invocation == 'true'"
             )
@@ -5212,7 +5469,12 @@ def _verify_review_invocation_budget(
         ) from None
     require_budget_helper_contract(helper)
     for reviewer, workflow in REVIEWER_WORKFLOWS.items():
-        require_budget_workflow_contract(tree, workflow, reviewer)
+        require_budget_workflow_contract(
+            tree,
+            workflow,
+            reviewer,
+            review_policy=release_supports_review_policy(ref),
+        )
     authenticated_digests = {
         action_path: (
             action_payload,
@@ -5223,11 +5485,16 @@ def _verify_review_invocation_budget(
             EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256,
         ),
     }
+    workflow_digests = (
+        EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256
+        if release_supports_review_policy(ref)
+        else EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256
+    )
     for reviewer, workflow in REVIEWER_WORKFLOWS.items():
         path = f".github/workflows/{workflow}"
         authenticated_digests[path] = (
             tree.read_file(path),
-            EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256[reviewer],
+            workflow_digests[reviewer],
         )
     if any(
         hashlib.sha256(payload).hexdigest() != expected
@@ -5242,6 +5509,8 @@ def expected_review_actions(ref: str, workflow: str) -> list[str]:
     """Return the exact ordered release-local action dependencies."""
 
     actions: list[str] = []
+    if release_supports_review_policy(ref):
+        actions.append(REVIEW_POLICY_ACTION)
     if _release_version(ref) >= (1, 46) and workflow == "gemini-auto-review.yml":
         actions.append(SETUP_GEMINI_AUTH_REVIEW)
     if release_supports_prepare_review_diff(ref):
@@ -5256,6 +5525,205 @@ def expected_review_actions(ref: str, workflow: str) -> list[str]:
     if release_supports_review_invocation_budget(ref):
         actions.append(REVIEW_INVOCATION_BUDGET_ACTION)
     return actions
+
+
+def _normalize_expression(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError("expression is not a string")
+    return " ".join(value.split())
+
+
+def _verify_review_policy_workflows(documents: dict[str, dict]) -> None:
+    contracts = {
+        "claude-code-review.yml": {
+            "workflow_name": "claude-code-review",
+            "provider_job": "claude-review",
+            "pr_number": "${{ inputs.pr_number || github.event.pull_request.number }}",
+            "outputs": {
+                "enabled": "${{ steps.check.outputs.enabled }}",
+                "policy_run": "${{ steps.review_policy.outputs.run-review }}",
+                "policy_reason": "${{ steps.review_policy.outputs.reason }}",
+                "policy_head": "${{ steps.review_policy.outputs.head-sha }}",
+                "model": "${{ steps.model.outputs.model }}",
+            },
+        },
+        "gemini-auto-review.yml": {
+            "workflow_name": "gemini-auto-review",
+            "provider_job": "gemini-review",
+            "pr_number": "${{ inputs.pr_number || github.event.pull_request.number }}",
+            "outputs": {
+                "enabled": "${{ steps.check.outputs.enabled }}",
+                "policy_run": "${{ steps.review_policy.outputs.run-review }}",
+                "policy_reason": "${{ steps.review_policy.outputs.reason }}",
+                "policy_head": "${{ steps.review_policy.outputs.head-sha }}",
+            },
+        },
+        "opencode-auto-review.yml": {
+            "workflow_name": "opencode-auto-review",
+            "provider_job": "opencode-review",
+            "pr_number": (
+                "${{ inputs.pr_number || github.event.pull_request.number || "
+                "github.event.issue.number }}"
+            ),
+            "outputs": {
+                "enabled": "${{ steps.check.outputs.enabled }}",
+                "policy_run": "${{ steps.review_policy.outputs.run-review }}",
+                "policy_reason": "${{ steps.review_policy.outputs.reason }}",
+                "policy_head": "${{ steps.review_policy.outputs.head-sha }}",
+            },
+        },
+    }
+    review_mode_input = {
+        "description": "Resolved PR review policy",
+        "type": "string",
+        "required": "false",
+        "default": "auto",
+    }
+    try:
+        for workflow, contract in contracts.items():
+            document = documents[workflow]
+            jobs = document["jobs"]
+            call_inputs = document["on"]["workflow_call"]["inputs"]
+            if call_inputs.get("review_mode") != review_mode_input:
+                raise ValueError("review mode input differs")
+            check = jobs["check-enabled"]
+            if check.get("outputs") != contract["outputs"]:
+                raise ValueError("policy outputs differ")
+            policy_steps = [
+                step
+                for step in check["steps"]
+                if step.get("uses") == REVIEW_POLICY_ACTION
+            ]
+            expected_step = {
+                "name": "Resolve PR review policy",
+                "id": "review_policy",
+                "uses": REVIEW_POLICY_ACTION,
+                "with": {
+                    "workflow-name": contract["workflow_name"],
+                    "pr-number": contract["pr_number"],
+                    "review-mode": "${{ inputs.review_mode }}",
+                    "force-run": "${{ inputs.force_run && 'true' || 'false' }}",
+                    "force-review": (
+                        "${{ inputs.force_review && 'true' || 'false' }}"
+                    ),
+                    "github-token": "${{ github.token }}",
+                },
+            }
+            if policy_steps != [expected_step]:
+                raise ValueError("policy call differs")
+            provider_job = jobs[contract["provider_job"]]
+            provider_if = _normalize_expression(provider_job.get("if"))
+            if workflow == "opencode-auto-review.yml":
+                expected_provider_if = (
+                    "needs.check-enabled.outputs.enabled == 'true' && "
+                    "needs.check-enabled.outputs.policy_run == 'true' && "
+                    "needs.opencode-prepare.result == 'success' && "
+                    "needs.opencode-prepare.outputs.allow_invocation == 'true'"
+                )
+                if provider_job.get("needs") != [
+                    "check-enabled",
+                    "opencode-prepare",
+                ]:
+                    raise ValueError("provider needs differ")
+                for job_name in ("opencode-prepare", "opencode-canonicalize"):
+                    if "needs.check-enabled.outputs.policy_run == 'true'" not in (
+                        _normalize_expression(jobs[job_name].get("if"))
+                    ):
+                        raise ValueError("pipeline policy predicate differs")
+            else:
+                expected_provider_if = (
+                    "needs.check-enabled.outputs.enabled == 'true' && "
+                    "needs.check-enabled.outputs.policy_run == 'true'"
+                )
+                if provider_job.get("needs") != "check-enabled":
+                    raise ValueError("provider needs differ")
+            if provider_if != expected_provider_if:
+                raise ValueError("provider policy predicate differs")
+            skipped = jobs["skipped"]
+            skipped_if = _normalize_expression(skipped.get("if"))
+            if "needs.check-enabled.outputs.policy_run != 'true'" not in skipped_if:
+                raise ValueError("skipped policy predicate differs")
+    except (KeyError, TypeError, ValueError):
+        raise ReleaseVerificationError(
+            "review-policy workflow contract is invalid"
+        ) from None
+
+
+def _verify_review_policy_callers(tree: VerifiedCommitTree) -> None:
+    trigger = {
+        "pull_request": {
+            "types": ["opened", "synchronize", "ready_for_review"]
+        },
+        "workflow_dispatch": {
+            "inputs": {
+                "pr_number": {
+                    "description": "Pull request number",
+                    "type": "number",
+                    "required": "true",
+                },
+                "force_review": {
+                    "description": "Perform one authorized same-HEAD review",
+                    "type": "boolean",
+                    "required": "false",
+                    "default": "false",
+                },
+            }
+        },
+    }
+    caller_if = (
+        "(github.event_name == 'pull_request' && "
+        "github.event.pull_request.head.repo.fork == false && "
+        "github.event.pull_request.head.repo.full_name == github.repository && "
+        "github.event.pull_request.draft == false) || "
+        "(github.event_name == 'workflow_dispatch' && inputs.force_review)"
+    )
+    review_mode = (
+        "${{\n"
+        "  github.event_name == 'workflow_dispatch' && inputs.force_review && 'request' ||\n"
+        "  contains(github.event.pull_request.labels.*.name, 'review:request') &&\n"
+        "  contains(github.event.pull_request.labels.*.name, 'review:skip') && 'conflict' ||\n"
+        "  contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||\n"
+        "  contains(github.event.pull_request.labels.*.name, 'review:skip') && 'skip' ||\n"
+        "  'auto'\n"
+        "}}"
+    )
+    callers = {
+        "claude-code-review.yml": "claude-review",
+        "gemini-auto-review.yml": "gemini-review",
+        "opencode-auto-review.yml": "opencode-review",
+    }
+    try:
+        for workflow, job_name in callers.items():
+            path = (
+                "examples/baseline-workflows/.github/workflows/" + workflow
+            )
+            document = yaml.load(
+                tree.read_file(path), Loader=yaml.BaseLoader
+            )
+            if not isinstance(document, dict) or document.get("on") != trigger:
+                raise ValueError("caller trigger differs")
+            job = document["jobs"][job_name]
+            if _normalize_expression(job.get("if")) != caller_if:
+                raise ValueError("caller draft/manual guard differs")
+            values = job["with"]
+            if (
+                values.get("pr_number")
+                != "${{ github.event.pull_request.number || inputs.pr_number }}"
+                or values.get("force_review")
+                != "${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}"
+                or values.get("review_mode") != review_mode
+            ):
+                raise ValueError("caller review mode differs")
+    except (
+        KeyError,
+        ReleaseVerificationError,
+        TypeError,
+        ValueError,
+        yaml.YAMLError,
+    ):
+        raise ReleaseVerificationError(
+            "review-policy caller contract is invalid"
+        ) from None
 
 
 def _verify_review_action_dependencies(
@@ -5830,6 +6298,8 @@ def _verify_gemini_workflow(name: str, document: dict, ref: str) -> None:
         }
     if release_supports_review_invocation_budget(ref):
         approved_actions |= {REVIEW_INVOCATION_BUDGET_ACTION}
+    if release_supports_review_policy(ref):
+        approved_actions |= {REVIEW_POLICY_ACTION}
     unapproved_actions = sorted(set(_action_references(document)) - approved_actions)
     if unapproved_actions:
         raise ReleaseVerificationError(
@@ -5898,10 +6368,17 @@ def _verify_gemini_workflow(name: str, document: dict, ref: str) -> None:
                 and step.get("uses") == REVIEW_INVOCATION_BUDGET_ACTION
                 and step_values.count("github.token") == 1
             )
+            policy_step = (
+                release_supports_review_policy(ref)
+                and name == "gemini-auto-review.yml"
+                and job_name == "check-enabled"
+                and step.get("uses") == REVIEW_POLICY_ACTION
+                and step_values.count("github.token") == 1
+            )
             if (
                 step_index not in candidates
                 and "github.token" in step_values
-                and not (provenance_step or budget_state_step)
+                and not (provenance_step or budget_state_step or policy_step)
             ):
                 raise ReleaseVerificationError(
                     f"{name}:{job_name} bypasses the resolved repository-write token"
@@ -5983,6 +6460,9 @@ def _verify_commit_content(
         _verify_prepare_review_diff_action(tree, ref)
     if release_supports_canonicalize_review(ref):
         _verify_canonicalize_review_action(tree)
+    if release_supports_review_policy(ref):
+        _verify_review_policy_action(tree, ref)
+        _verify_review_policy_callers(tree)
     _verify_approved_v140_policy(tree, ref)
     _verify_manual_gemini_output_contract(tree, ref)
     catalog = _verify_tag_catalog(tree, ref)
@@ -6022,6 +6502,8 @@ def _verify_commit_content(
 
     _verify_claude_code_action_pin(ref, documents)
     _verify_review_action_dependencies(ref, documents)
+    if release_supports_review_policy(ref):
+        _verify_review_policy_workflows(documents)
     if release_supports_canonicalize_review(ref):
         _verify_review_publication_contracts(documents, ref)
 
@@ -6454,12 +6936,21 @@ def _verify_commit_content(
         {},
     )
     condition = job.get("if", "")
-    if (
-        safe_output != "${{ steps.pr_scope.outputs.safe_pr }}"
-        or "gh api" not in scope_step.get("run", "")
-        or not isinstance(condition, str)
-        or "needs.check-enabled.outputs.safe_pr == 'true'" not in condition
-    ):
+    policy_guard = (
+        release_supports_review_policy(ref)
+        and check_job.get("outputs", {}).get("policy_run")
+        == "${{ steps.review_policy.outputs.run-review }}"
+        and isinstance(condition, str)
+        and "needs.check-enabled.outputs.policy_run == 'true'" in condition
+    )
+    historical_guard = (
+        not release_supports_review_policy(ref)
+        and safe_output == "${{ steps.pr_scope.outputs.safe_pr }}"
+        and "gh api" in scope_step.get("run", "")
+        and isinstance(condition, str)
+        and "needs.check-enabled.outputs.safe_pr == 'true'" in condition
+    )
+    if not (policy_guard or historical_guard):
         raise ReleaseVerificationError(
             "OpenCode auto review lacks a central same-repository PR guard"
         )

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -1238,6 +1238,49 @@ class ReleaseVerificationError(RuntimeError):
     """The requested release is absent, points elsewhere, or violates invariants."""
 
 
+class _DuplicateKeyRejectingLoader(yaml.BaseLoader):
+    """Preserve BaseLoader scalars while rejecting every duplicate mapping key."""
+
+    def construct_mapping(self, node: yaml.MappingNode, deep: bool = False) -> dict:
+        mapping: dict = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            try:
+                duplicate = key in mapping
+            except TypeError as exc:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found an unhashable key",
+                    key_node.start_mark,
+                ) from exc
+            if duplicate:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"found duplicate key {key!r}",
+                    key_node.start_mark,
+                )
+            mapping[key] = self.construct_object(value_node, deep=deep)
+        return mapping
+
+
+def _load_release_yaml(
+    payload: str | bytes, *, reject_duplicate_keys: bool
+) -> object:
+    loader = (
+        _DuplicateKeyRejectingLoader
+        if reject_duplicate_keys
+        else yaml.BaseLoader
+    )
+    try:
+        return yaml.load(payload, Loader=loader)
+    except yaml.YAMLError:
+        if not reject_duplicate_keys:
+            raise
+        raise ReleaseVerificationError("v1.51 release YAML is invalid") from None
+
+
 @dataclass(frozen=True)
 class AnnotatedTag:
     ref: str
@@ -2455,8 +2498,9 @@ def _release_version(ref: str) -> tuple[int, ...]:
 def _verify_setup_gemini_auth(tree: VerifiedCommitTree, ref: str) -> None:
     path = SETUP_GEMINI_AUTH_ROOT.path.as_posix()
     try:
-        document = yaml.load(
-            tree.read_text(path), Loader=yaml.BaseLoader
+        document = _load_release_yaml(
+            tree.read_text(path),
+            reject_duplicate_keys=release_supports_review_policy(ref),
         )
     except (ReleaseVerificationError, yaml.YAMLError):
         raise ReleaseVerificationError(
@@ -2474,7 +2518,10 @@ def _verify_setup_gemini_auth(tree: VerifiedCommitTree, ref: str) -> None:
 def _verify_prepare_review_diff_action(tree: VerifiedCommitTree, ref: str) -> None:
     path = PREPARE_REVIEW_DIFF_ACTION_ROOT.path.as_posix()
     try:
-        document = yaml.load(tree.read_text(path), Loader=yaml.BaseLoader)
+        document = _load_release_yaml(
+            tree.read_text(path),
+            reject_duplicate_keys=release_supports_review_policy(ref),
+        )
     except (ReleaseVerificationError, yaml.YAMLError):
         raise ReleaseVerificationError(
             "prepare-review-diff action contract is invalid"
@@ -2876,9 +2923,9 @@ def _verify_review_policy_action(
     if actual_files != expected_files:
         raise ReleaseVerificationError("review-policy inventory is not closed")
     try:
-        action = yaml.load(
+        action = _load_release_yaml(
             tree.read_file(REVIEW_POLICY_ACTION_ROOT.path),
-            Loader=yaml.BaseLoader,
+            reject_duplicate_keys=True,
         )
         if (
             action != EXPECTED_REVIEW_POLICY_ACTION
@@ -3022,7 +3069,9 @@ def _verify_canonicalize_review_helpers(tree: VerifiedCommitTree) -> None:
         ) from None
 
 
-def _verify_canonicalize_review_action(tree: VerifiedCommitTree) -> None:
+def _verify_canonicalize_review_action(
+    tree: VerifiedCommitTree, ref: str
+) -> None:
     expected_files = {
         (root.path.as_posix(), "100644", "blob")
         for root in (
@@ -3041,7 +3090,10 @@ def _verify_canonicalize_review_action(tree: VerifiedCommitTree) -> None:
         )
     path = CANONICALIZE_REVIEW_ACTION_ROOT.path.as_posix()
     try:
-        document = yaml.load(tree.read_text(path), Loader=yaml.BaseLoader)
+        document = _load_release_yaml(
+            tree.read_text(path),
+            reject_duplicate_keys=release_supports_review_policy(ref),
+        )
     except (ReleaseVerificationError, yaml.YAMLError):
         raise ReleaseVerificationError(
             "canonicalize-review action contract is invalid"
@@ -3151,7 +3203,10 @@ def _verify_tag_catalog(
             name = f"{config.canonical_dir}/{relative}"
             text = tree.read_text(name)
             try:
-                document = yaml.load(text, Loader=yaml.BaseLoader)
+                document = _load_release_yaml(
+                    text,
+                    reject_duplicate_keys=release_supports_review_policy(ref),
+                )
             except yaml.YAMLError as exc:
                 raise ReleaseVerificationError(f"{name} is invalid YAML") from exc
             if not isinstance(document, dict):
@@ -3294,7 +3349,10 @@ def _verify_manual_gemini_output_contract(
     for filename, contract in MANUAL_GEMINI_FETCH_CONTRACTS.items():
         path = f"{root}/{filename}"
         try:
-            document = yaml.load(tree.read_text(path), Loader=yaml.BaseLoader)
+            document = _load_release_yaml(
+                tree.read_text(path),
+                reject_duplicate_keys=release_supports_review_policy(ref),
+            )
             prepare = document["jobs"]["prepare"]
             downstream = document["jobs"][contract.downstream_job]
             downstream_with = downstream["with"]
@@ -4836,7 +4894,10 @@ def require_budget_workflow_contract(
         if REVIEWER_WORKFLOWS.get(reviewer) != workflow:
             raise ValueError("reviewer workflow mismatch")
         payload = tree.read_file(f".github/workflows/{workflow}")
-        document = yaml.load(payload, Loader=yaml.BaseLoader)
+        document = _load_release_yaml(
+            payload,
+            reject_duplicate_keys=review_policy,
+        )
         if not isinstance(document, dict) or not isinstance(document.get("jobs"), dict):
             raise ValueError("workflow document differs")
         jobs = document["jobs"]
@@ -5453,7 +5514,10 @@ def _verify_review_invocation_budget(
     action_path = REVIEW_INVOCATION_BUDGET_ACTION_ROOT.path.as_posix()
     try:
         action_payload = tree.read_file(action_path)
-        action = yaml.load(action_payload, Loader=yaml.BaseLoader)
+        action = _load_release_yaml(
+            action_payload,
+            reject_duplicate_keys=release_supports_review_policy(ref),
+        )
         if action != EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION:
             raise ValueError("action differs")
     except (AttributeError, ReleaseVerificationError, TypeError, ValueError, yaml.YAMLError):
@@ -5697,8 +5761,9 @@ def _verify_review_policy_callers(tree: VerifiedCommitTree) -> None:
             path = (
                 "examples/baseline-workflows/.github/workflows/" + workflow
             )
-            document = yaml.load(
-                tree.read_file(path), Loader=yaml.BaseLoader
+            document = _load_release_yaml(
+                tree.read_file(path),
+                reject_duplicate_keys=True,
             )
             if not isinstance(document, dict) or document.get("on") != trigger:
                 raise ValueError("caller trigger differs")
@@ -6459,7 +6524,7 @@ def _verify_commit_content(
     if release_supports_prepare_review_diff(ref):
         _verify_prepare_review_diff_action(tree, ref)
     if release_supports_canonicalize_review(ref):
-        _verify_canonicalize_review_action(tree)
+        _verify_canonicalize_review_action(tree, ref)
     if release_supports_review_policy(ref):
         _verify_review_policy_action(tree, ref)
         _verify_review_policy_callers(tree)
@@ -6490,7 +6555,10 @@ def _verify_commit_content(
                 raise ReleaseVerificationError(
                     f"{name} checkout reference is not the approved immutable commit"
                 )
-        data = yaml.load(text, Loader=yaml.BaseLoader)
+        data = _load_release_yaml(
+            text,
+            reject_duplicate_keys=release_supports_review_policy(ref),
+        )
         relative = PurePosixPath(name).relative_to(workflow_root)
         if len(relative.parts) != 1:
             if relative.name in central_workflows:

--- a/scripts/workflow-catalog.json
+++ b/scripts/workflow-catalog.json
@@ -52,7 +52,8 @@
         "pull_request": {
           "types": [
             "opened",
-            "synchronize"
+            "synchronize",
+            "ready_for_review"
           ]
         },
         "workflow_dispatch": {
@@ -83,7 +84,8 @@
           },
           "with": [
             "force_review",
-            "pr_number"
+            "pr_number",
+            "review_mode"
           ],
           "secrets": [
             "CLAUDE_CODE_OAUTH_TOKEN"
@@ -101,7 +103,8 @@
         "pull_request": {
           "types": [
             "opened",
-            "synchronize"
+            "synchronize",
+            "ready_for_review"
           ]
         },
         "workflow_dispatch": {
@@ -134,7 +137,8 @@
             "force_review",
             "pr_number",
             "publisher_app_id",
-            "repo_write_auth"
+            "repo_write_auth",
+            "review_mode"
           ],
           "secrets": [
             "APP_PRIVATE_KEY",
@@ -607,8 +611,24 @@
         "pull_request": {
           "types": [
             "opened",
-            "synchronize"
+            "synchronize",
+            "ready_for_review"
           ]
+        },
+        "workflow_dispatch": {
+          "inputs": {
+            "pr_number": {
+              "description": "Pull request number",
+              "type": "number",
+              "required": "true"
+            },
+            "force_review": {
+              "description": "Perform one authorized same-HEAD review",
+              "type": "boolean",
+              "required": "false",
+              "default": "false"
+            }
+          }
         }
       },
       "caller_jobs": [
@@ -622,7 +642,9 @@
             "pull-requests": "write"
           },
           "with": [
-            "pr_number"
+            "force_review",
+            "pr_number",
+            "review_mode"
           ],
           "secrets": [
             "ZHIPU_API_KEY"

--- a/scripts/workflow_release_bundle.py
+++ b/scripts/workflow_release_bundle.py
@@ -61,7 +61,7 @@ def _build_git_archive(
     automation: Path,
     revision: str,
     *,
-    ref: str = "v1.46",
+    ref: str = "v1.51",
     tree: VerifiedCommitTree | None = None,
 ) -> bytes:
     verified = tree if tree is not None else VerifiedCommitTree.open(automation, revision)
@@ -94,7 +94,7 @@ def _git_archive(
     automation: Path,
     revision: str,
     *,
-    ref: str = "v1.46",
+    ref: str = "v1.51",
     tree: VerifiedCommitTree | None = None,
 ) -> bytes:
     archive: bytes | None = None
@@ -108,7 +108,7 @@ def _git_archive(
 
 
 def _safe_member(
-    member: tarfile.TarInfo, roots: tuple[ReleaseRoot, ...] = release_roots_for("v1.46")
+    member: tarfile.TarInfo, roots: tuple[ReleaseRoot, ...] = release_roots_for("v1.51")
 ) -> PurePosixPath:
     path = PurePosixPath(member.name)
     allowed_modes = release_file_modes(path, roots)
@@ -131,7 +131,7 @@ def _extract_archive(
     archive_bytes: bytes,
     destination: Path,
     *,
-    roots: tuple[ReleaseRoot, ...] = release_roots_for("v1.46"),
+    roots: tuple[ReleaseRoot, ...] = release_roots_for("v1.51"),
 ) -> None:
     try:
         with tarfile.open(fileobj=BytesIO(archive_bytes), mode="r:") as archive:

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -92,6 +92,18 @@ REVIEW_INVOCATION_BUDGET_HELPER_ROOT = ReleaseRoot(
     "file",
     "100644",
 )
+REVIEW_POLICY_ACTION_ROOT = ReleaseRoot(
+    PurePosixPath(".github/actions/resolve-review-policy/action.yml"),
+    "file",
+    "100644",
+)
+REVIEW_POLICY_HELPER_ROOT = ReleaseRoot(
+    PurePosixPath(
+        ".github/actions/resolve-review-policy/resolve_review_policy.py"
+    ),
+    "file",
+    "100644",
+)
 
 HISTORICAL_RELEASE_ROOTS = (
     CENTRAL_WORKFLOW_ROOT,
@@ -113,11 +125,16 @@ REVIEW_INVOCATION_BUDGET_ROOTS = (
     REVIEW_INVOCATION_BUDGET_ACTION_ROOT,
     REVIEW_INVOCATION_BUDGET_HELPER_ROOT,
 )
+REVIEW_POLICY_ROOTS = (
+    REVIEW_POLICY_ACTION_ROOT,
+    REVIEW_POLICY_HELPER_ROOT,
+)
 RELEASE_ROOTS = (
     HISTORICAL_RELEASE_ROOTS
     + PREPARE_REVIEW_DIFF_ROOTS
     + CANONICALIZE_REVIEW_ROOTS
     + REVIEW_INVOCATION_BUDGET_ROOTS
+    + REVIEW_POLICY_ROOTS
 )
 RELEASE_PATHS = tuple(root.path.as_posix() for root in RELEASE_ROOTS)
 EXACT_RELEASE_ROOTS = tuple(root for root in RELEASE_ROOTS if root.kind == "file")
@@ -129,6 +146,7 @@ _RELEASE_REF = re.compile(r"v[0-9]+(?:\.[0-9]+)+")
 PREPARE_REVIEW_DIFF_RELEASE = (1, 45)
 CANONICALIZE_REVIEW_RELEASE = (1, 46)
 REVIEW_INVOCATION_BUDGET_RELEASE = (1, 47)
+REVIEW_POLICY_RELEASE = (1, 51)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -155,6 +173,12 @@ def release_supports_review_invocation_budget(ref: str) -> bool:
     return _release_version(ref) >= REVIEW_INVOCATION_BUDGET_RELEASE
 
 
+def release_supports_review_policy(ref: str) -> bool:
+    """Return whether ``ref`` owns the deterministic review-policy action."""
+
+    return _release_version(ref) >= REVIEW_POLICY_RELEASE
+
+
 def release_roots_for(ref: str) -> tuple[ReleaseRoot, ...]:
     """Select the authenticated inventory that existed at ``ref``'s release line."""
     roots = HISTORICAL_RELEASE_ROOTS
@@ -164,6 +188,8 @@ def release_roots_for(ref: str) -> tuple[ReleaseRoot, ...]:
         roots += CANONICALIZE_REVIEW_ROOTS
     if release_supports_review_invocation_budget(ref):
         roots += REVIEW_INVOCATION_BUDGET_ROOTS
+    if release_supports_review_policy(ref):
+        roots += REVIEW_POLICY_ROOTS
     return roots
 
 

--- a/tests/release_fixture_helpers.py
+++ b/tests/release_fixture_helpers.py
@@ -34,8 +34,343 @@ V145_PREPARE_DIFF_FIXTURE = (
 )
 
 
+def restore_pre_v151_review_policy_callers(repo: Path) -> None:
+    """Remove only the v1.51 caller policy surface from historical fixtures."""
+
+    baseline_root = repo / "examples/baseline-workflows/.github/workflows"
+    review_mode = (
+        "      review_mode: >-\n"
+        "        ${{\n"
+        "          github.event_name == 'workflow_dispatch' && inputs.force_review && 'request' ||\n"
+        "          contains(github.event.pull_request.labels.*.name, 'review:request') &&\n"
+        "          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'conflict' ||\n"
+        "          contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||\n"
+        "          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'skip' ||\n"
+        "          'auto'\n"
+        "        }}\n"
+    )
+    draft_guard = (
+        "      github.event.pull_request.head.repo.full_name == github.repository &&\n"
+        "      github.event.pull_request.draft == false) ||\n"
+    )
+    historical_head_guard = (
+        "      github.event.pull_request.head.repo.full_name == github.repository) ||\n"
+    )
+    dispatch = (
+        "  workflow_dispatch:\n"
+        "    inputs:\n"
+        "      pr_number:\n"
+        "        description: Pull request number\n"
+        "        type: number\n"
+        "        required: true\n"
+        "      force_review:\n"
+        "        description: Perform one authorized same-HEAD review\n"
+        "        type: boolean\n"
+        "        required: false\n"
+        "        default: false\n"
+    )
+    forced_if = (
+        "    if: >-\n"
+        "      (github.event_name == 'pull_request' &&\n"
+        "      github.event.pull_request.head.repo.fork == false &&\n"
+        "      github.event.pull_request.head.repo.full_name == github.repository) ||\n"
+        "      (github.event_name == 'workflow_dispatch' && inputs.force_review)\n"
+    )
+    for filename in (
+        "claude-code-review.yml",
+        "gemini-auto-review.yml",
+        "opencode-auto-review.yml",
+    ):
+        path = baseline_root / filename
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        live_trigger_count = text.count(
+            "    types: [opened, synchronize, ready_for_review]\n"
+        )
+        if live_trigger_count == 0:
+            assert text.count("    types: [opened, synchronize]\n") == 1
+            assert review_mode not in text
+            assert draft_guard not in text
+            continue
+        assert live_trigger_count == 1
+        assert text.count(draft_guard) == 1
+        assert text.count(review_mode) == 1
+        text = text.replace(
+            "    types: [opened, synchronize, ready_for_review]\n",
+            "    types: [opened, synchronize]\n",
+            1,
+        ).replace(draft_guard, historical_head_guard, 1).replace(
+            review_mode, "", 1
+        )
+        if filename == "opencode-auto-review.yml":
+            assert text.count(dispatch) == 1
+            assert text.count(forced_if) == 1
+            assert text.count(
+                "      force_review: ${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}\n"
+            ) == 1
+            text = text.replace(dispatch, "", 1).replace(forced_if, "", 1).replace(
+                "      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}\n",
+                "      pr_number: ${{ github.event.pull_request.number }}\n",
+                1,
+            ).replace(
+                "      force_review: ${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}\n",
+                "",
+                1,
+            )
+        path.write_text(text, encoding="utf-8")
+
+    catalog = repo / "scripts/workflow-catalog.json"
+    if catalog.exists():
+        text = catalog.read_text(encoding="utf-8")
+        ready = '            "synchronize",\n            "ready_for_review"\n'
+        review_mode_entry = ',\n            "review_mode"\n'
+        ready_count = text.count(ready)
+        review_mode_count = text.count(review_mode_entry)
+        if ready_count == 0 and review_mode_count == 0:
+            return
+        assert ready_count == 3
+        assert review_mode_count == 3
+        text = text.replace(ready, '            "synchronize"\n', 3).replace(
+            review_mode_entry, "\n", 3
+        )
+        opencode_start = text.index(
+            '      "path": ".github/workflows/opencode-auto-review.yml"'
+        )
+        opencode_end = text.index(
+            '      "path": ".github/workflow-config.yml"', opencode_start
+        )
+        opencode = text[opencode_start:opencode_end]
+        dispatch_entry = (
+            '        },\n'
+            '        "workflow_dispatch": {\n'
+            '          "inputs": {\n'
+            '            "pr_number": {\n'
+            '              "description": "Pull request number",\n'
+            '              "type": "number",\n'
+            '              "required": "true"\n'
+            '            },\n'
+            '            "force_review": {\n'
+            '              "description": "Perform one authorized same-HEAD review",\n'
+            '              "type": "boolean",\n'
+            '              "required": "false",\n'
+            '              "default": "false"\n'
+            '            }\n'
+            '          }\n'
+            '        }\n'
+        )
+        assert opencode.count(dispatch_entry) == 1
+        assert opencode.count('            "force_review",\n') == 1
+        opencode = opencode.replace(dispatch_entry, "        }\n", 1).replace(
+            '            "force_review",\n', "", 1
+        )
+        catalog.write_text(
+            text[:opencode_start] + opencode + text[opencode_end:],
+            encoding="utf-8",
+        )
+
+
+def restore_pre_v151_review_policy(repo: Path) -> None:
+    """Restore live reusable workflows and callers to their pre-v1.51 policy."""
+
+    restore_pre_v151_review_policy_callers(repo)
+    workflow_root = repo / ".github/workflows"
+    review_mode_input = (
+        "      review_mode:\n"
+        "        description: Resolved PR review policy\n"
+        "        type: string\n"
+        "        required: false\n"
+        "        default: auto\n"
+    )
+    policy_outputs = (
+        "      policy_run: ${{ steps.review_policy.outputs.run-review }}\n"
+        "      policy_reason: ${{ steps.review_policy.outputs.reason }}\n"
+        "      policy_head: ${{ steps.review_policy.outputs.head-sha }}\n"
+    )
+
+    for filename, workflow_name in (
+        ("claude-code-review.yml", "claude-code-review"),
+        ("gemini-auto-review.yml", "gemini-auto-review"),
+    ):
+        path = workflow_root / filename
+        text = path.read_text(encoding="utf-8")
+        pr_number = "${{ inputs.pr_number || github.event.pull_request.number }}"
+        policy_step = (
+            "      - name: Resolve PR review policy\n"
+            "        id: review_policy\n"
+            "        uses: $/.github/actions/resolve-review-policy\n"
+            "        with:\n"
+            f"          workflow-name: {workflow_name}\n"
+            f"          pr-number: {pr_number}\n"
+            "          review-mode: ${{ inputs.review_mode }}\n"
+            "          force-run: ${{ inputs.force_run && 'true' || 'false' }}\n"
+            "          force-review: ${{ inputs.force_review && 'true' || 'false' }}\n"
+            "          github-token: ${{ github.token }}\n"
+        )
+        auto_step = (
+            "      - name: Check auto review mode\n"
+            "        id: auto_mode\n"
+            "        env:\n"
+            "          FORCE_RUN: ${{ (inputs.force_run || inputs.force_review) && 'true' || 'false' }}\n"
+            "        run: |-\n"
+            "          CONFIG_FILE=\".github/workflow-config.yml\"\n"
+            "          if [[ \"$FORCE_RUN\" == 'true' ]]; then\n"
+            "            echo \"auto_enabled=true\" >> \"$GITHUB_OUTPUT\"\n"
+            "            exit 0\n"
+            "          fi\n"
+            "\n"
+            "          auto_enabled=\"true\"\n"
+            "          if [[ -f \"$CONFIG_FILE\" ]]; then\n"
+            "            # Per-workflow auto field: workflows.<name>.auto (default: true)\n"
+            "            # Falls back to global review.auto for backward compatibility\n"
+            "            auto_enabled=\"$(ruby -ryaml -e '\n"
+            "              cfg = (YAML.load_file(ARGV[0]) rescue {}) || {}\n"
+            f"              v = cfg.dig(\"workflows\", \"{workflow_name}\", \"auto\")\n"
+            "              v = cfg.dig(\"review\", \"auto\") if v.nil?\n"
+            "              v = true if v.nil?\n"
+            "              puts(v ? \"true\" : \"false\")\n"
+            "            ' \"$CONFIG_FILE\" 2>/dev/null || echo true)\"\n"
+            "          fi\n"
+            "          echo \"auto_enabled=${auto_enabled}\" >> \"$GITHUB_OUTPUT\"\n"
+        )
+        assert text.count(review_mode_input) == 1
+        assert text.count(policy_outputs) == 1
+        assert text.count(policy_step) == 1
+        assert text.count(
+            "          force-run: ${{ inputs.force_run && 'true' || 'false' }}\n"
+        ) == 2
+        assert text.count("needs.check-enabled.outputs.policy_run") == 2
+        text = text.replace(review_mode_input, "", 1).replace(
+            policy_outputs,
+            "      auto_enabled: ${{ steps.auto_mode.outputs.auto_enabled }}\n",
+            1,
+        ).replace(
+            "          force-run: ${{ inputs.force_run && 'true' || 'false' }}\n",
+            "          force-run: ${{ (inputs.force_run || inputs.force_review) && 'true' || 'false' }}\n",
+            1,
+        ).replace(policy_step, auto_step, 1).replace(
+            "needs.check-enabled.outputs.policy_run",
+            "needs.check-enabled.outputs.auto_enabled",
+            2,
+        )
+        if filename == "gemini-auto-review.yml":
+            permission_block = (
+                "    permissions:\n"
+                "      contents: read\n"
+                "      pull-requests: read\n"
+                "    name: Check if enabled\n"
+            )
+            assert text.count(permission_block) == 1
+            text = text.replace(
+                permission_block,
+                "    permissions:\n      contents: read\n    name: Check if enabled\n",
+                1,
+            )
+        path.write_text(text, encoding="utf-8")
+
+    path = workflow_root / "opencode-auto-review.yml"
+    text = path.read_text(encoding="utf-8")
+    force_review_input = (
+        "      force_review:\n"
+        "        description: Perform one explicitly authorized review even when HEAD is unchanged\n"
+        "        type: boolean\n"
+        "        required: false\n"
+        "        default: false\n"
+    )
+    policy_step = (
+        "      - name: Resolve PR review policy\n"
+        "        id: review_policy\n"
+        "        uses: $/.github/actions/resolve-review-policy\n"
+        "        with:\n"
+        "          workflow-name: opencode-auto-review\n"
+        "          pr-number: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}\n"
+        "          review-mode: ${{ inputs.review_mode }}\n"
+        "          force-run: ${{ inputs.force_run && 'true' || 'false' }}\n"
+        "          force-review: ${{ inputs.force_review && 'true' || 'false' }}\n"
+        "          github-token: ${{ github.token }}\n"
+    )
+    historical_steps = (
+        "      - name: Check auto review mode\n"
+        "        id: auto_mode\n"
+        "        env:\n"
+        "          FORCE_RUN: ${{ inputs.force_run && 'true' || 'false' }}\n"
+        "        run: |-\n"
+        "          CONFIG_FILE=\".github/workflow-config.yml\"\n"
+        "          if [[ \"$FORCE_RUN\" == 'true' ]]; then\n"
+        "            echo \"auto_enabled=true\" >> \"$GITHUB_OUTPUT\"\n"
+        "            exit 0\n"
+        "          fi\n"
+        "\n"
+        "          auto_enabled=\"true\"\n"
+        "          if [[ -f \"$CONFIG_FILE\" ]]; then\n"
+        "            # Precedence (matches claude/gemini): workflows.opencode-auto-review.auto → review.auto → default true\n"
+        "            auto_enabled=\"$(ruby -ryaml -e 'cfg = (YAML.load_file(ARGV[0]) rescue {}) || {}; v = cfg.dig(\"workflows\", \"opencode-auto-review\", \"auto\"); v = cfg.dig(\"review\", \"auto\") if v.nil?; v = true if v.nil?; puts(v ? \"true\" : \"false\")' \"$CONFIG_FILE\" 2>/dev/null || echo true)\"\n"
+        "          fi\n"
+        "          echo \"auto_enabled=${auto_enabled}\" >> \"$GITHUB_OUTPUT\"\n"
+        "\n"
+        "      - name: Verify same-repository PR\n"
+        "        id: pr_scope\n"
+        "        env:\n"
+        "          GH_TOKEN: ${{ github.token }}\n"
+        "          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}\n"
+        "        run: |\n"
+        "          echo \"safe_pr=false\" >> \"$GITHUB_OUTPUT\"\n"
+        "          if [[ ! \"$PR_NUMBER\" =~ ^[0-9]+$ ]]; then\n"
+        "            exit 0\n"
+        "          fi\n"
+        "          metadata=\"$(gh api \"repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}\" \\\n"
+        "            --jq '[.head.repo.full_name, .head.repo.fork] | @tsv' 2>/dev/null)\" || exit 0\n"
+        "          IFS=$'\\t' read -r head_repo head_fork <<< \"$metadata\"\n"
+        "          if [[ \"$head_repo\" == \"$GITHUB_REPOSITORY\" && \"$head_fork\" == \"false\" ]]; then\n"
+        "            echo \"safe_pr=true\" >> \"$GITHUB_OUTPUT\"\n"
+        "          fi\n"
+    )
+    assert text.count(review_mode_input) == 1
+    assert text.count(force_review_input) == 1
+    assert text.count(policy_outputs) == 1
+    assert text.count(policy_step) == 1
+    assert text.count("needs.check-enabled.outputs.policy_run == 'true'") == 3
+    assert text.count("needs.check-enabled.outputs.policy_run != 'true'") == 1
+    text = text.replace(review_mode_input, "", 1).replace(
+        force_review_input, "", 1
+    ).replace(
+        policy_outputs,
+        "      auto_enabled: ${{ steps.auto_mode.outputs.auto_enabled }}\n"
+        "      safe_pr: ${{ steps.pr_scope.outputs.safe_pr }}\n",
+        1,
+    ).replace(policy_step, historical_steps, 1).replace(
+        "needs.check-enabled.outputs.policy_run == 'true'",
+        "needs.check-enabled.outputs.auto_enabled == 'true' &&\n"
+        "      needs.check-enabled.outputs.safe_pr == 'true'",
+        3,
+    ).replace(
+        "needs.check-enabled.outputs.policy_run != 'true'",
+        "needs.check-enabled.outputs.auto_enabled != 'true' ||\n"
+        "      needs.check-enabled.outputs.safe_pr != 'true'",
+        1,
+    )
+    for line in (
+        "          force-full: ${{ inputs.force_review && 'true' || 'false' }}\n",
+        "          force-review: ${{ inputs.force_review && 'true' || 'false' }}\n",
+    ):
+        assert text.count(line) == 1
+        text = text.replace(line, "", 1)
+    force_claim = (
+        "      - name: Enforce force-review claim\n"
+        "        if: ${{ always() && !cancelled() && inputs.force_review && steps.review-budget-claim.outputs.allow-invocation != 'true' }}\n"
+        "        run: |\n"
+        "          echo '::error::force-review was not authorized by the bounded review budget'\n"
+        "          exit 1\n"
+        "\n"
+    )
+    assert text.count(force_claim) == 1
+    path.write_text(text.replace(force_claim, "", 1), encoding="utf-8")
+
+
 def restore_pre_force_review_callers(repo: Path) -> None:
     """Remove the force-review caller surface from historical fixtures."""
+
+    restore_pre_v151_review_policy_callers(repo)
 
     baseline_root = repo / "examples/baseline-workflows/.github/workflows"
     for filename in ("claude-code-review.yml", "gemini-auto-review.yml"):

--- a/tests/test_canonical_workflow_tree.py
+++ b/tests/test_canonical_workflow_tree.py
@@ -402,6 +402,13 @@ def test_automation_config_has_an_explicit_disabled_review_default() -> None:
     assert config["review"] == {"auto": "false"}
 
 
+def test_automation_gemini_app_is_manual_review_only() -> None:
+    config = yaml.safe_load((ROOT / ".gemini/config.yaml").read_text())
+
+    assert config == {"code_review": {"pull_request_opened": {"code_review": False}}}
+    assert config["code_review"].get("disable") is None
+
+
 def test_triggers_and_permissions_match_the_approved_policy() -> None:
     workflow_root = CANONICAL / "workflows"
     actual_names = {path.name for path in workflow_root.glob("*.yml")}

--- a/tests/test_canonical_workflow_tree.py
+++ b/tests/test_canonical_workflow_tree.py
@@ -20,6 +20,26 @@ from scripts.workflow_catalog import (  # noqa: E402
 )
 
 
+REVIEW_MODE_EXPRESSION = " ".join(
+    """
+    ${{
+      github.event_name == 'workflow_dispatch' && inputs.force_review && 'request' ||
+      contains(github.event.pull_request.labels.*.name, 'review:request') &&
+      contains(github.event.pull_request.labels.*.name, 'review:skip') && 'conflict' ||
+      contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||
+      contains(github.event.pull_request.labels.*.name, 'review:skip') && 'skip' ||
+      'auto'
+    }}
+    """.split()
+)
+SELF_REVIEW_MODE_EXPRESSION = " ".join(
+    REVIEW_MODE_EXPRESSION.replace(
+        "github.event_name == 'workflow_dispatch' && inputs.force_review && 'request' || ",
+        "",
+    ).split()
+)
+
+
 EXPECTED_WORKFLOW_NAMES = {
     "auto-rereview-request",
     "claude",
@@ -61,7 +81,7 @@ EXPECTED_TRIGGERS: dict[str, object] = {
         "issues": {"types": ["opened", "assigned"]},
     },
     "claude-code-review.yml": {
-        "pull_request": {"types": ["opened", "synchronize"]},
+        "pull_request": {"types": ["opened", "synchronize", "ready_for_review"]},
         "workflow_dispatch": {
             "inputs": {
                 "pr_number": {
@@ -79,7 +99,7 @@ EXPECTED_TRIGGERS: dict[str, object] = {
         },
     },
     "gemini-auto-review.yml": {
-        "pull_request": {"types": ["opened", "synchronize"]},
+        "pull_request": {"types": ["opened", "synchronize", "ready_for_review"]},
         "workflow_dispatch": {
             "inputs": {
                 "pr_number": {
@@ -230,7 +250,22 @@ EXPECTED_TRIGGERS: dict[str, object] = {
         "pull_request_review_comment": {"types": ["created"]},
     },
     "opencode-auto-review.yml": {
-        "pull_request": {"types": ["opened", "synchronize"]}
+        "pull_request": {"types": ["opened", "synchronize", "ready_for_review"]},
+        "workflow_dispatch": {
+            "inputs": {
+                "pr_number": {
+                    "description": "Pull request number",
+                    "type": "number",
+                    "required": "true",
+                },
+                "force_review": {
+                    "description": "Perform one authorized same-HEAD review",
+                    "type": "boolean",
+                    "required": "false",
+                    "default": "false",
+                },
+            }
+        },
     },
 }
 
@@ -361,6 +396,12 @@ def test_bootstrap_config_matches_the_approved_disabled_policy() -> None:
     )
 
 
+def test_automation_config_has_an_explicit_disabled_review_default() -> None:
+    config = load_yaml(ROOT / ".github/workflow-config.yml")
+
+    assert config["review"] == {"auto": "false"}
+
+
 def test_triggers_and_permissions_match_the_approved_policy() -> None:
     workflow_root = CANONICAL / "workflows"
     actual_names = {path.name for path in workflow_root.glob("*.yml")}
@@ -434,3 +475,38 @@ def test_canonical_callers_use_only_the_selected_auth_contract() -> None:
                 }
             else:
                 assert "secrets" not in job
+
+
+def test_auto_review_callers_forward_the_resolved_review_mode() -> None:
+    callers = {
+        "claude-code-review.yml": "claude-review",
+        "gemini-auto-review.yml": "gemini-review",
+        "opencode-auto-review.yml": "opencode-review",
+    }
+    for filename, job_name in callers.items():
+        caller = load_yaml(CANONICAL / "workflows" / filename)
+        job = caller["jobs"][job_name]
+
+        assert caller["on"]["pull_request"]["types"] == [
+            "opened", "synchronize", "ready_for_review",
+        ]
+        assert " ".join(job["with"]["review_mode"].split()) == REVIEW_MODE_EXPRESSION
+        assert "github.event.pull_request.draft == false" in job["if"]
+
+
+def test_self_auto_review_callers_forward_label_review_mode() -> None:
+    callers = {
+        "_self-claude-review.yml": "claude-review",
+        "_self-gemini-auto-review.yml": "gemini-review",
+        "_self-opencode-auto-review.yml": "opencode-review",
+    }
+    for filename, job_name in callers.items():
+        caller = load_yaml(ROOT / ".github/workflows" / filename)
+        job = caller["jobs"][job_name]
+
+        assert caller["on"]["pull_request"]["types"] == [
+            "opened", "synchronize", "ready_for_review",
+        ]
+        assert " ".join(job["with"]["review_mode"].split()) == SELF_REVIEW_MODE_EXPRESSION
+        assert "github.event.pull_request.draft == false" in job["if"]
+        assert job["with"]["force_review"] == "false"

--- a/tests/test_review_policy_action.py
+++ b/tests/test_review_policy_action.py
@@ -92,6 +92,18 @@ def test_manual_force_review_allows_request_without_label():
     assert decision.reason == "request"
 
 
+def test_manual_force_review_rejects_skip_label_mismatch():
+    with pytest.raises(PolicyError, match="review_mode_label_mismatch"):
+        resolve_policy(
+            request(
+                labels=["review:skip"],
+                mode="request",
+                event="workflow_dispatch",
+                force_review=True,
+            )
+        )
+
+
 def test_request_does_not_override_disabled_workflow():
     decision = resolve_policy(
         request(

--- a/tests/test_review_policy_action.py
+++ b/tests/test_review_policy_action.py
@@ -1,0 +1,191 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / ".github/actions/resolve-review-policy/resolve_review_policy.py"
+ACTION = HELPER.with_name("action.yml")
+SPEC = importlib.util.spec_from_file_location("resolve_review_policy", HELPER)
+assert SPEC is not None and SPEC.loader is not None
+review_policy = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = review_policy
+SPEC.loader.exec_module(review_policy)
+
+PolicyError = review_policy.PolicyError
+PolicyRequest = review_policy.PolicyRequest
+resolve_policy = review_policy.resolve_policy
+
+
+def base_pr() -> dict[str, object]:
+    return {
+        "state": "open",
+        "draft": False,
+        "head": {
+            "sha": "a" * 40,
+            "repo": {"full_name": "jhw7500/example", "fork": False},
+        },
+        "labels": [],
+    }
+
+
+def request(*, labels=None, mode="auto", config=None, pr=None, event="pull_request", force_review=False):
+    payload = base_pr() if pr is None else pr
+    payload["labels"] = [{"name": name} for name in (labels or [])]
+    return PolicyRequest(
+        workflow_name="claude-code-review",
+        review_mode=mode,
+        force_run=False,
+        force_review=force_review,
+        event_name=event,
+        repository="jhw7500/example",
+        pr=payload,
+        config={} if config is None else config,
+    )
+
+
+@pytest.mark.parametrize(
+    ("labels", "mode", "config", "expected"),
+    [
+        ([], "auto", {"review": {"auto": True}}, (True, "review_auto_true")),
+        ([], "auto", {"review": {"auto": False}}, (False, "review_auto_false")),
+        ([], "auto", {"workflows": {"claude-code-review": {"auto": False}}, "review": {"auto": True}}, (False, "workflow_auto_false")),
+        (["review:request"], "request", {"review": {"auto": False}}, (True, "request")),
+        (["review:skip"], "skip", {"review": {"auto": True}}, (False, "skip")),
+    ],
+)
+def test_policy_precedence(labels, mode, config, expected):
+    decision = resolve_policy(request(labels=labels, mode=mode, config=config))
+    assert (decision.run_review, decision.reason) == expected
+
+
+def test_both_labels_fail_closed():
+    with pytest.raises(PolicyError, match="review_label_conflict"):
+        resolve_policy(request(labels=["review:request", "review:skip"], mode="conflict"))
+
+
+@pytest.mark.parametrize(("change", "reason"), [
+    ({"draft": True}, "draft"),
+    ({"state": "closed"}, "closed"),
+    ({"head": {"repo": {"full_name": "fork/repo", "fork": True}}}, "unsafe_pr"),
+])
+def test_noneligible_pr_never_runs(change, reason):
+    pr = base_pr() | change
+    decision = resolve_policy(request(pr=pr))
+    assert decision.run_review is False
+    assert decision.reason == reason
+
+
+def test_pull_request_mode_must_match_labels():
+    with pytest.raises(PolicyError, match="review_mode_label_mismatch"):
+        resolve_policy(request(labels=["review:skip"], mode="request"))
+
+
+def test_manual_force_review_allows_request_without_label():
+    decision = resolve_policy(request(mode="request", event="workflow_dispatch", force_review=True))
+    assert decision.run_review is True
+    assert decision.reason == "request"
+
+
+def test_request_does_not_override_disabled_workflow():
+    decision = resolve_policy(
+        request(
+            labels=["review:request"],
+            mode="request",
+            config={"workflows": {"claude-code-review": {"enabled": False}}},
+        )
+    )
+    assert (decision.run_review, decision.reason) == (False, "workflow_disabled")
+
+
+def test_automatic_mode_defaults_to_true_when_not_configured():
+    decision = resolve_policy(request())
+    assert (decision.run_review, decision.reason) == (True, "default_auto_true")
+
+
+def test_action_uses_file_transport_with_expected_interface():
+    document = yaml.load(ACTION.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+    assert set(document["inputs"]) == {
+        "workflow-name",
+        "pr-number",
+        "review-mode",
+        "force-run",
+        "force-review",
+        "github-token",
+    }
+    assert set(document["outputs"]) == {
+        "run-review",
+        "effective-mode",
+        "reason",
+        "head-sha",
+    }
+    assert document["runs"]["using"] == "composite"
+
+    script = document["runs"]["steps"][0]["run"]
+    assert "set -euo pipefail" in script
+    assert 'gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"' in script
+    assert ".github/workflow-config.yml \"$policy_dir/config.json\"" in script
+    assert "eval" not in script
+
+
+def _cli_payload() -> dict[str, object]:
+    return {
+        "workflow_name": "claude-code-review",
+        "review_mode": "auto",
+        "force_run": False,
+        "force_review": False,
+        "event_name": "pull_request",
+        "repository": "jhw7500/example",
+        "pr": base_pr(),
+        "config": {},
+    }
+
+
+def _run_cli(tmp_path: Path, payload: str) -> subprocess.CompletedProcess[str]:
+    request_path = tmp_path / "request.json"
+    result_path = tmp_path / "result.json"
+    output_path = tmp_path / "github-output"
+    request_path.write_text(payload, encoding="utf-8")
+    output_path.write_text("", encoding="utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(HELPER),
+            "--request-file",
+            str(request_path),
+            "--result-file",
+            str(result_path),
+            "--github-output",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert output_path.read_text(encoding="utf-8") == ""
+    return result
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{",
+        json.dumps({**_cli_payload(), "config": []}),
+        json.dumps({**_cli_payload(), "config": {"review": {"auto": "true"}}}),
+        json.dumps(
+            {
+                **_cli_payload(),
+                "pr": {**base_pr(), "head": {"sha": "invalid", "repo": {"full_name": "jhw7500/example", "fork": False}}},
+            }
+        ),
+        json.dumps({**_cli_payload(), "repository": "invalid-repository"}),
+    ],
+)
+def test_cli_rejects_malformed_input_without_writing_github_output(tmp_path, payload):
+    assert _run_cli(tmp_path, payload).returncode != 0

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -428,6 +428,18 @@ def test_every_provider_job_is_review_policy_gated():
         assert "needs.check-enabled.outputs.policy_run == 'true'" in condition
 
 
+def test_review_policy_jobs_do_not_drop_pull_request_read_permission():
+    for workflow in REVIEW_WORKFLOWS.values():
+        check_job = workflow["jobs"]["check-enabled"]
+        assert _step(workflow, "check-enabled", "Resolve PR review policy")
+
+        permissions = check_job.get("permissions")
+        pull_request_permission = (
+            "inherited" if permissions is None else permissions.get("pull-requests")
+        )
+        assert pull_request_permission in {"inherited", "read"}
+
+
 def _job_needs(job: dict) -> set[str]:
     needs = job.get("needs", [])
     return {needs} if isinstance(needs, str) else set(needs)

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -368,6 +368,113 @@ def _step_id(job: dict, name: str) -> str:
     return next(step["id"] for step in job["steps"] if step.get("name") == name)
 
 
+REVIEW_WORKFLOWS = {
+    name: _load(f"{name}.yml")
+    for name in (
+        "claude-code-review",
+        "gemini-auto-review",
+        "opencode-auto-review",
+    )
+}
+
+
+@pytest.mark.parametrize("workflow_name", REVIEW_WORKFLOWS)
+def test_review_policy_wiring_is_exact_for_every_provider(workflow_name):
+    workflow = REVIEW_WORKFLOWS[workflow_name]
+    mode = workflow["on"]["workflow_call"]["inputs"]["review_mode"]
+    policy = _step(workflow, "check-enabled", "Resolve PR review policy")
+
+    assert mode == {
+        "description": "Resolved PR review policy",
+        "type": "string",
+        "required": "false",
+        "default": "auto",
+    }
+    assert policy["id"] == "review_policy"
+    assert policy["uses"] == "$/.github/actions/resolve-review-policy"
+    assert policy["with"] == {
+        "workflow-name": workflow_name,
+        "pr-number": (
+            "${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}"
+            if workflow_name == "opencode-auto-review"
+            else "${{ inputs.pr_number || github.event.pull_request.number }}"
+        ),
+        "review-mode": "${{ inputs.review_mode }}",
+        "force-run": "${{ inputs.force_run && 'true' || 'false' }}",
+        "force-review": "${{ inputs.force_review && 'true' || 'false' }}",
+        "github-token": "${{ github.token }}",
+    }
+    assert "if" not in policy
+    assert workflow["jobs"]["check-enabled"]["outputs"] | {
+        "policy_run": "${{ steps.review_policy.outputs.run-review }}",
+        "policy_reason": "${{ steps.review_policy.outputs.reason }}",
+        "policy_head": "${{ steps.review_policy.outputs.head-sha }}",
+    } == workflow["jobs"]["check-enabled"]["outputs"]
+    assert all(
+        step.get("name") != "Check auto review mode"
+        for step in workflow["jobs"]["check-enabled"]["steps"]
+    )
+
+
+def test_every_provider_job_is_review_policy_gated():
+    cases = (
+        ("claude-code-review", "claude-review"),
+        ("gemini-auto-review", "gemini-review"),
+        ("opencode-auto-review", "opencode-prepare"),
+    )
+    for workflow_name, job_name in cases:
+        condition = REVIEW_WORKFLOWS[workflow_name]["jobs"][job_name]["if"]
+        assert "needs.check-enabled.outputs.enabled == 'true'" in condition
+        assert "needs.check-enabled.outputs.policy_run == 'true'" in condition
+
+
+def _job_needs(job: dict) -> set[str]:
+    needs = job.get("needs", [])
+    return {needs} if isinstance(needs, str) else set(needs)
+
+
+def _transitive_job_needs(jobs: dict, job_name: str) -> set[str]:
+    pending = list(_job_needs(jobs[job_name]))
+    result: set[str] = set()
+    while pending:
+        dependency = pending.pop()
+        if dependency in result:
+            continue
+        result.add(dependency)
+        pending.extend(_job_needs(jobs[dependency]))
+    return result
+
+
+def test_review_policy_precedes_diff_and_every_model_path_depends_on_its_gate():
+    cases = (
+        ("claude-code-review", "claude-review", "Run Claude Code Review"),
+        ("gemini-auto-review", "gemini-review", "Run Gemini Code Review"),
+        ("opencode-auto-review", "opencode-review", "Run OpenCode PR review"),
+    )
+    for workflow_name, provider_job_name, provider_step_name in cases:
+        workflow = REVIEW_WORKFLOWS[workflow_name]
+        jobs = workflow["jobs"]
+        first_job_name = (
+            "opencode-prepare" if workflow_name == "opencode-auto-review" else provider_job_name
+        )
+        first_job = jobs[first_job_name]
+        policy = _step(workflow, "check-enabled", "Resolve PR review policy")
+
+        assert sum(
+            step.get("uses") == "$/.github/actions/resolve-review-policy"
+            for job in jobs.values()
+            for step in job.get("steps", [])
+        ) == 1
+        assert "if" not in policy
+        assert "check-enabled" in _job_needs(first_job)
+        assert "needs.check-enabled.outputs.policy_run == 'true'" in first_job["if"]
+        assert _step(workflow, provider_job_name, provider_step_name)
+
+        dependencies = _transitive_job_needs(jobs, provider_job_name)
+        assert first_job_name == provider_job_name or first_job_name in dependencies
+        assert "check-enabled" in dependencies
+
+
 def _github_outputs(path: Path) -> dict[str, str]:
     return dict(
         line.split("=", 1)
@@ -2986,7 +3093,7 @@ def test_shared_diff_models_use_one_selected_artifact_and_scope_prompt():
     )
 
 
-def test_force_review_is_opt_in_and_forces_a_full_diff_for_both_reviewers():
+def test_force_review_is_opt_in_and_forces_a_full_diff_for_every_provider():
     for workflow_name, job_name, prepare_name, claim_name in (
         (
             "claude-code-review.yml",
@@ -2999,6 +3106,12 @@ def test_force_review_is_opt_in_and_forces_a_full_diff_for_both_reviewers():
             "gemini-review",
             "Prepare review diff",
             "Claim Gemini review budget",
+        ),
+        (
+            "opencode-auto-review.yml",
+            "opencode-prepare",
+            "Prepare review diff",
+            "Claim OpenCode review budget",
         ),
     ):
         workflow = _load(workflow_name)
@@ -8095,6 +8208,7 @@ def test_opencode_shared_diff_wiring_and_model_gates_are_exact():
         "pr-number": "${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}",
         "previous-sha": "${{ steps.ctx.outputs.previous_sha }}",
         "previous-full-hash": "${{ steps.ctx.outputs.previous_full_hash }}",
+        "force-full": "${{ inputs.force_review && 'true' || 'false' }}",
         "context-lines": "3",
         "output-directory": "${{ github.workspace }}",
     }
@@ -8150,6 +8264,7 @@ def test_opencode_budget_claim_is_sealed_before_tokenless_model_job():
         "expected-head-sha": "${{ steps.prepare-diff.outputs.head-sha }}",
         "full-diff-sha256": "${{ steps.prepare-diff.outputs.full-diff-sha256 }}",
         "diff-mode": "${{ steps.prepare-diff.outputs.diff-mode }}",
+        "force-review": "${{ inputs.force_review && 'true' || 'false' }}",
         "input-files-json": "${{ format('[\"{0}/review-full.diff\",\"{0}/review-scope.json\"]', github.workspace) }}",
         "authenticated-review-json": "${{ steps.ctx.outputs.authenticated_review_json }}",
         "model-route-json": '["zai-coding-plan/glm-4.7"]',

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -1770,6 +1770,71 @@ def test_v151_rejects_review_policy_action_transport_mutations(
         release_verifier.verify_commit_content(repo, "v1.51", bad_commit)
 
 
+def test_v151_rejects_duplicate_top_level_review_policy_action_key(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    prepare_v151(repo)
+    path = repo / REVIEW_POLICY_RELEASE_FILES[0]
+    replace(
+        path,
+        "\nruns:\n",
+        "\nruns:\n  using: docker\n\nruns:\n",
+        count=1,
+    )
+    bad_commit = commit(repo, "duplicate top-level review-policy action key")
+
+    with pytest.raises(ReleaseVerificationError, match="review-policy action"):
+        release_verifier.verify_commit_content(repo, "v1.51", bad_commit)
+
+
+def test_v151_rejects_duplicate_nested_reusable_workflow_key(
+    current_release_repo: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _ = current_release_repo
+    prepare_v151(repo)
+    path = repo / ".github/workflows/claude-code-review.yml"
+    replace(
+        path,
+        "      review_mode:\n",
+        "      review_mode:\n"
+        "        description: ignored duplicate\n"
+        "      review_mode:\n",
+        count=1,
+    )
+    monkeypatch.setitem(
+        release_verifier.EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256,
+        "claude",
+        hashlib.sha256(path.read_bytes()).hexdigest(),
+    )
+    bad_commit = commit(repo, "duplicate nested reusable-workflow key")
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.51", bad_commit)
+
+
+def test_v151_rejects_duplicate_nested_review_policy_caller_key(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    prepare_v151(repo)
+    path = (
+        repo
+        / "examples/baseline-workflows/.github/workflows/opencode-auto-review.yml"
+    )
+    replace(
+        path,
+        "      review_mode: >-\n",
+        "      review_mode: skip\n      review_mode: >-\n",
+        count=1,
+    )
+    bad_commit = commit(repo, "duplicate nested review-policy caller key")
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.51", bad_commit)
+
+
 @pytest.mark.parametrize(
     ("old", "new"),
     (

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -26,6 +26,7 @@ from release_fixture_helpers import (
     V145_REVIEW_FIXTURE_ROOT,
     restore_historical_review_workflows,
     restore_pre_force_review_callers,
+    restore_pre_v151_review_policy,
     restore_v145_review_workflows,
 )
 
@@ -87,6 +88,10 @@ CANONICALIZER_RELEASE_FILES = (
 REVIEW_INVOCATION_BUDGET_RELEASE_FILES = (
     ".github/actions/review-invocation-budget/action.yml",
     ".github/actions/review-invocation-budget/review_invocation_budget.py",
+)
+REVIEW_POLICY_RELEASE_FILES = (
+    ".github/actions/resolve-review-policy/action.yml",
+    ".github/actions/resolve-review-policy/resolve_review_policy.py",
 )
 V1462_WORKFLOW_FIXTURE_COMMIT = "d42c28ddd827554e6e46a2ab49dfe34c838c0425"
 V1462_WORKFLOW_FIXTURE_SHA256 = {
@@ -206,6 +211,7 @@ def current_release_repo(tmp_path: Path) -> tuple[Path, str]:
             shutil.copytree(source, target)
         else:
             shutil.copy2(source, target)
+    restore_pre_v151_review_policy(repo)
     git(repo, "init", "-q")
     git(repo, "config", "user.name", "Test")
     git(repo, "config", "user.email", "test@example.com")
@@ -269,6 +275,32 @@ def prepare_v147(repo: Path) -> str:
         if git(repo, "status", "--porcelain")
         else git(repo, "rev-parse", "HEAD")
     )
+
+
+def prepare_v151(repo: Path) -> str:
+    for relative in (
+        ".github/actions/resolve-review-policy/action.yml",
+        ".github/actions/resolve-review-policy/resolve_review_policy.py",
+        ".github/workflows/claude-code-review.yml",
+        ".github/workflows/gemini-auto-review.yml",
+        ".github/workflows/opencode-auto-review.yml",
+        "examples/baseline-workflows/.github/workflows/claude-code-review.yml",
+        "examples/baseline-workflows/.github/workflows/gemini-auto-review.yml",
+        "examples/baseline-workflows/.github/workflows/opencode-auto-review.yml",
+        "scripts/workflow-catalog.json",
+    ):
+        source = ROOT / relative
+        target = repo / relative
+        if target.is_dir():
+            shutil.rmtree(target)
+        elif target.exists() or target.is_symlink():
+            target.unlink()
+        if source.is_dir():
+            shutil.copytree(source, target)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+    return commit(repo, "v1.51 candidate")
 
 
 def verify_v147(repo: Path, message: str) -> str:
@@ -1630,6 +1662,272 @@ def test_v147_accepts_current_budget_release_contract(
     candidate = prepare_v147(repo)
 
     assert release_verifier.verify_commit_content(repo, "v1.47", candidate) == candidate
+
+
+def test_v151_accepts_current_review_policy_release_contract(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v151(repo)
+
+    assert release_verifier.verify_commit_content(repo, "v1.51", candidate) == candidate
+
+
+@pytest.mark.parametrize("relative", REVIEW_POLICY_RELEASE_FILES)
+@pytest.mark.parametrize("mutation", ("missing", "executable", "symlink"))
+def test_v151_requires_each_review_policy_file_as_one_regular_0644_blob(
+    current_release_repo: tuple[Path, str], relative: str, mutation: str
+) -> None:
+    repo, _ = current_release_repo
+    prepare_v151(repo)
+    target = repo / relative
+    if mutation == "missing":
+        target.unlink()
+    elif mutation == "executable":
+        target.chmod(0o755)
+    else:
+        target.unlink()
+        target.symlink_to("untrusted-policy")
+    bad_commit = commit(repo, f"mutate v1.51 policy file {relative}: {mutation}")
+
+    with pytest.raises(ReleaseVerificationError, match="release inventory"):
+        release_verifier.verify_commit_content(repo, "v1.51", bad_commit)
+
+
+def test_v151_rejects_files_outside_closed_review_policy_action_inventory(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    prepare_v151(repo)
+    extra = repo / ".github/actions/resolve-review-policy/unowned.py"
+    extra.write_text("raise RuntimeError('unowned')\n", encoding="utf-8")
+    bad_commit = commit(repo, "add unowned review-policy helper")
+
+    with pytest.raises(ReleaseVerificationError, match="review-policy inventory"):
+        release_verifier.verify_commit_content(repo, "v1.51", bad_commit)
+
+
+@pytest.mark.parametrize(
+    ("section", "mutation"),
+    (
+        ("inputs", "missing"),
+        ("inputs", "extra"),
+        ("inputs", "reordered"),
+        ("outputs", "missing"),
+        ("outputs", "extra"),
+        ("outputs", "reordered"),
+    ),
+)
+def test_v151_rejects_review_policy_action_interface_mutations(
+    current_release_repo: tuple[Path, str], section: str, mutation: str
+) -> None:
+    repo, _ = current_release_repo
+    prepare_v151(repo)
+    path = repo / REVIEW_POLICY_RELEASE_FILES[0]
+
+    def mutate(document: dict) -> None:
+        values = document[section]
+        first = next(iter(values))
+        if mutation == "missing":
+            values.pop(first)
+        elif mutation == "extra":
+            values["unowned"] = {"required": "false"}
+        else:
+            value = values.pop(first)
+            values[first] = value
+
+    mutate_yaml(path, mutate)
+    bad_commit = commit(repo, f"mutate review-policy {section}: {mutation}")
+
+    with pytest.raises(ReleaseVerificationError, match="review-policy action"):
+        release_verifier.verify_commit_content(repo, "v1.51", bad_commit)
+
+
+@pytest.mark.parametrize(
+    ("old", "new"),
+    (
+        ("set -euo pipefail", "set -eu"),
+        (
+            'gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"',
+            'gh pr view "$PR_NUMBER"',
+        ),
+        (
+            '--request-file "$policy_dir/request.json"',
+            '--request-json "$(cat "$policy_dir/request.json")"',
+        ),
+    ),
+)
+def test_v151_rejects_review_policy_action_transport_mutations(
+    current_release_repo: tuple[Path, str], old: str, new: str
+) -> None:
+    repo, _ = current_release_repo
+    prepare_v151(repo)
+    path = repo / REVIEW_POLICY_RELEASE_FILES[0]
+    replace(path, old, new, count=1)
+    bad_commit = commit(repo, "weaken review-policy action transport")
+
+    with pytest.raises(ReleaseVerificationError, match="review-policy action"):
+        release_verifier.verify_commit_content(repo, "v1.51", bad_commit)
+
+
+@pytest.mark.parametrize(
+    ("old", "new"),
+    (
+        ("review:request", "review:ask"),
+        ("workflow_auto_", "workflow_default_"),
+        ("    workflow_name: str\n", "    workflow_name: int\n"),
+        (
+            '    if workflow is not None and "auto" in workflow:\n',
+            '    if False and workflow is not None and "auto" in workflow:\n',
+        ),
+    ),
+)
+def test_v151_rejects_review_policy_helper_mutations(
+    current_release_repo: tuple[Path, str], old: str, new: str
+) -> None:
+    repo, _ = current_release_repo
+    prepare_v151(repo)
+    path = repo / REVIEW_POLICY_RELEASE_FILES[1]
+    replace(path, old, new, count=1)
+    bad_commit = commit(repo, "weaken review-policy helper")
+
+    with pytest.raises(ReleaseVerificationError, match="review-policy helper"):
+        release_verifier.verify_commit_content(repo, "v1.51", bad_commit)
+
+
+@pytest.mark.parametrize(
+    ("workflow", "mutation"),
+    (
+        ("claude-code-review.yml", "missing"),
+        ("gemini-auto-review.yml", "duplicate"),
+        ("opencode-auto-review.yml", "missing"),
+    ),
+)
+def test_v151_requires_each_reusable_to_call_review_policy_exactly_once(
+    current_release_repo: tuple[Path, str], workflow: str, mutation: str
+) -> None:
+    repo, _ = current_release_repo
+    prepare_v151(repo)
+    path = repo / ".github/workflows" / workflow
+
+    def mutate(document: dict) -> None:
+        job = document["jobs"]["check-enabled"]
+        step = next(
+            item
+            for item in job["steps"]
+            if item.get("uses") == "$/.github/actions/resolve-review-policy"
+        )
+        if mutation == "missing":
+            job["steps"].remove(step)
+        else:
+            job["steps"].append(dict(step))
+
+    mutate_yaml(path, mutate)
+    bad_commit = commit(repo, f"{mutation} review-policy action in {workflow}")
+
+    with pytest.raises(ReleaseVerificationError, match="review action dependency"):
+        release_verifier.verify_commit_content(repo, "v1.51", bad_commit)
+
+
+@pytest.mark.parametrize(
+    ("reviewer", "workflow", "job"),
+    (
+        ("claude", "claude-code-review.yml", "claude-review"),
+        ("gemini", "gemini-auto-review.yml", "gemini-review"),
+        ("opencode", "opencode-auto-review.yml", "opencode-review"),
+    ),
+)
+def test_v151_rejects_provider_job_without_policy_run_dependency(
+    current_release_repo: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    reviewer: str,
+    workflow: str,
+    job: str,
+) -> None:
+    repo, _ = current_release_repo
+    prepare_v151(repo)
+    path = repo / ".github/workflows" / workflow
+
+    def mutate(document: dict) -> None:
+        condition = document["jobs"][job]["if"]
+        document["jobs"][job]["if"] = condition.replace(
+            "needs.check-enabled.outputs.policy_run == 'true'", "true", 1
+        )
+
+    mutate_yaml(path, mutate)
+    monkeypatch.setitem(
+        release_verifier.EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256,
+        reviewer,
+        hashlib.sha256(path.read_bytes()).hexdigest(),
+    )
+    bad_commit = commit(repo, f"remove {reviewer} policy_run dependency")
+
+    with pytest.raises(ReleaseVerificationError, match="review-policy workflow"):
+        release_verifier.verify_commit_content(repo, "v1.51", bad_commit)
+
+
+@pytest.mark.parametrize(
+    ("workflow", "mutation"),
+    (
+        ("claude-code-review.yml", "ready-trigger"),
+        ("gemini-auto-review.yml", "draft-guard"),
+        ("opencode-auto-review.yml", "review-mode"),
+        ("claude-code-review.yml", "label-spelling"),
+        ("gemini-auto-review.yml", "precedence"),
+        ("opencode-auto-review.yml", "dispatch-shape"),
+    ),
+)
+def test_v151_rejects_review_policy_caller_mutations(
+    current_release_repo: tuple[Path, str], workflow: str, mutation: str
+) -> None:
+    repo, _ = current_release_repo
+    prepare_v151(repo)
+    path = (
+        repo
+        / "examples/baseline-workflows/.github/workflows"
+        / workflow
+    )
+    if mutation == "ready-trigger":
+        replace(path, ", ready_for_review", "", count=1)
+    elif mutation == "draft-guard":
+        replace(
+            path,
+            "      github.event.pull_request.head.repo.full_name == github.repository &&\n"
+            "      github.event.pull_request.draft == false) ||\n",
+            "      github.event.pull_request.head.repo.full_name == github.repository) ||\n",
+            count=1,
+        )
+    elif mutation == "review-mode":
+        mutate_yaml(
+            path,
+            lambda document: document["jobs"]["opencode-review"]["with"].pop(
+                "review_mode"
+            ),
+        )
+    elif mutation == "label-spelling":
+        replace(path, "review:request", "review:ask")
+    elif mutation == "precedence":
+        text = path.read_text(encoding="utf-8")
+        request = "          contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||\n"
+        skip = "          contains(github.event.pull_request.labels.*.name, 'review:skip') && 'skip' ||\n"
+        assert text.count(request) == 1 and text.count(skip) == 1
+        path.write_text(
+            text.replace(request, "__REQUEST_BRANCH__\n", 1)
+            .replace(skip, request, 1)
+            .replace("__REQUEST_BRANCH__\n", skip, 1),
+            encoding="utf-8",
+        )
+    else:
+        replace(
+            path,
+            "      (github.event_name == 'workflow_dispatch' && inputs.force_review)\n",
+            "      github.event_name == 'workflow_dispatch'\n",
+            count=1,
+        )
+    bad_commit = commit(repo, f"mutate {workflow} policy caller: {mutation}")
+
+    with pytest.raises(ReleaseVerificationError, match="review-policy caller"):
+        release_verifier.verify_commit_content(repo, "v1.51", bad_commit)
 
 
 @pytest.mark.parametrize("relative", REVIEW_INVOCATION_BUDGET_RELEASE_FILES)

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -58,6 +58,26 @@ def test_catalog_and_profiles_are_closed() -> None:
     assert by_kind["config"] == {"workflow-config.yml"}
     assert by_kind["retired"] == {"bump-automation-ref.yml"}
 
+    callers = {
+        entry.path.name: entry
+        for entry in catalog.callers
+        if entry.path.name in {
+            "claude-code-review.yml",
+            "gemini-auto-review.yml",
+            "opencode-auto-review.yml",
+        }
+    }
+    assert set(callers) == {
+        "claude-code-review.yml",
+        "gemini-auto-review.yml",
+        "opencode-auto-review.yml",
+    }
+    for entry in callers.values():
+        assert entry.trigger["pull_request"]["types"] == [
+            "opened", "synchronize", "ready_for_review",
+        ]
+        assert "review_mode" in entry.caller_jobs[0].with_keys
+
 
 def _write(root: Path, catalog: list[dict], repos: dict[str, dict]) -> None:
     (root / "scripts").mkdir()

--- a/tests/test_workflow_release_bundle.py
+++ b/tests/test_workflow_release_bundle.py
@@ -52,6 +52,10 @@ REVIEW_INVOCATION_BUDGET_RELEASE_FILES = {
     ".github/actions/review-invocation-budget/action.yml",
     ".github/actions/review-invocation-budget/review_invocation_budget.py",
 }
+REVIEW_POLICY_RELEASE_FILES = {
+    ".github/actions/resolve-review-policy/action.yml",
+    ".github/actions/resolve-review-policy/resolve_review_policy.py",
+}
 
 
 def test_canonicalize_review_composite_action_has_exact_safe_shell_contract() -> None:
@@ -389,6 +393,31 @@ def test_review_invocation_budget_capability_boundary_is_closed() -> None:
     assert {root.kind for root in budget_roots} == {"file"}
 
 
+def test_review_policy_release_boundary() -> None:
+    capability = getattr(
+        release_inventory, "release_supports_review_policy", None
+    )
+    assert callable(capability)
+    assert capability("v1.50") is False
+    assert capability("v1.51") is True
+    paths = {
+        root.path.as_posix()
+        for root in release_inventory.release_roots_for("v1.51")
+    }
+    assert REVIEW_POLICY_RELEASE_FILES <= paths
+    assert REVIEW_POLICY_RELEASE_FILES.isdisjoint(
+        root.path.as_posix()
+        for root in release_inventory.release_roots_for("v1.50")
+    )
+    policy_roots = tuple(
+        root
+        for root in release_inventory.release_roots_for("v1.51")
+        if root.path.as_posix() in REVIEW_POLICY_RELEASE_FILES
+    )
+    assert {root.mode for root in policy_roots} == {"100644"}
+    assert {root.kind for root in policy_roots} == {"file"}
+
+
 def test_review_invocation_budget_action_has_exact_safe_contract() -> None:
     payload = REVIEW_INVOCATION_BUDGET_ACTION.read_bytes()
     document = yaml.load(payload, Loader=yaml.BaseLoader)
@@ -543,7 +572,7 @@ def test_release_archive_uses_only_authenticated_tree_and_blob_reads(
     assert release_bundle._git_archive(repo, release_commit)
 
 
-def test_latest_release_archive_default_includes_v146_canonicalizer_files(
+def test_latest_release_archive_default_includes_v151_release_files(
     release_repo: tuple[Path, str],
 ) -> None:
     repo, release_commit = release_repo
@@ -556,7 +585,57 @@ def test_latest_release_archive_default_includes_v146_canonicalizer_files(
         ".github/actions/canonicalize-review/action.yml",
         ".github/actions/canonicalize-review/canonicalize_review.py",
         ".github/actions/canonicalize-review/review_scope.py",
-    } <= names
+    } | REVIEW_POLICY_RELEASE_FILES <= names
+
+
+def test_v150_archive_preserves_historical_inventory_without_review_policy(
+    release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = release_repo
+    for relative in REVIEW_POLICY_RELEASE_FILES:
+        (repo / relative).unlink()
+    historical_commit = commit(repo, "historical v1.50 without review policy")
+
+    archive = release_bundle._git_archive(
+        repo, historical_commit, ref="v1.50"
+    )
+
+    with tarfile.open(fileobj=BytesIO(archive), mode="r:") as stream:
+        names = set(stream.getnames())
+    assert REVIEW_POLICY_RELEASE_FILES.isdisjoint(names)
+
+
+@pytest.mark.parametrize("mutation", ("missing", "executable"))
+def test_v151_archive_requires_closed_review_policy_inventory(
+    release_repo: tuple[Path, str], mutation: str
+) -> None:
+    repo, _ = release_repo
+    action = repo / ".github/actions/resolve-review-policy/action.yml"
+    if mutation == "missing":
+        action.unlink()
+    elif mutation == "executable":
+        action.chmod(0o755)
+    candidate = commit(repo, f"v1.51 review policy {mutation}")
+
+    with pytest.raises(ReleaseVerificationError, match="archive verified release"):
+        release_bundle._git_archive(repo, candidate, ref="v1.51")
+
+
+def test_v151_release_listing_rejects_extra_review_policy_descendant(
+    release_repo: tuple[Path, str],
+) -> None:
+    repo, release_commit = release_repo
+    roots = release_inventory.release_roots_for("v1.51")
+    tree = release_verifier.VerifiedCommitTree.open(repo, release_commit)
+    listing = tree.listing(release_inventory.release_paths_for("v1.51"))
+    listing += (
+        b"100644 blob "
+        + b"f" * 40
+        + b"\t.github/actions/resolve-review-policy/unowned.py\0"
+    )
+
+    with pytest.raises(ValueError, match="invalid release tree listing"):
+        release_inventory.validate_release_listing(listing, roots)
 
 
 def test_release_archive_rejects_semantically_valid_blob_at_wrong_object_name(

--- a/tests/test_workflow_secret_contracts.py
+++ b/tests/test_workflow_secret_contracts.py
@@ -124,11 +124,23 @@ class WorkflowSecretContractsTest(unittest.TestCase):
     def test_opencode_auto_review_enforces_same_repository_prs_centrally(self) -> None:
         workflow = load_workflow(WORKFLOWS / "opencode-auto-review.yml")
         check = workflow["jobs"]["check-enabled"]
-        self.assertEqual("${{ steps.pr_scope.outputs.safe_pr }}", check["outputs"]["safe_pr"])
-        scope_step = next(step for step in check["steps"] if step.get("id") == "pr_scope")
-        self.assertIn("gh api", scope_step["run"])
-        condition = workflow["jobs"]["opencode-review"]["if"]
-        self.assertIn("needs.check-enabled.outputs.safe_pr == 'true'", condition)
+        self.assertEqual(
+            "${{ steps.review_policy.outputs.run-review }}",
+            check["outputs"]["policy_run"],
+        )
+        policy_step = next(
+            step for step in check["steps"] if step.get("id") == "review_policy"
+        )
+        self.assertEqual(
+            "$/.github/actions/resolve-review-policy", policy_step["uses"]
+        )
+        self.assertNotIn("if", policy_step)
+        self.assertEqual(
+            "${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}",
+            policy_step["with"]["pr-number"],
+        )
+        condition = workflow["jobs"]["opencode-prepare"]["if"]
+        self.assertIn("needs.check-enabled.outputs.policy_run == 'true'", condition)
 
     def test_opencode_command_keeps_read_only_checkout_auth_for_private_repos(self) -> None:
         workflow = load_workflow(WORKFLOWS / "opencode.yml")

--- a/tests/test_workflow_secret_contracts.py
+++ b/tests/test_workflow_secret_contracts.py
@@ -57,7 +57,13 @@ class WorkflowSecretContractsTest(unittest.TestCase):
                     self.assertIn("permissions", job)
                     self.assertIsInstance(job["permissions"], dict)
                     if job_name == "check-enabled":
-                        self.assertEqual({"contents": "read"}, job["permissions"])
+                        expected = {"contents": "read"}
+                        if filename == "gemini-auto-review.yml":
+                            expected["pull-requests"] = "read"
+                        self.assertEqual(
+                            expected,
+                            job["permissions"],
+                        )
                     elif job_name == "skipped":
                         self.assertEqual({}, job["permissions"])
 


### PR DESCRIPTION
Adds the review label policy, draft-safe callers, external App opt-in configuration, and the immutable v1.51 release boundary.

Spec: docs/superpowers/specs/2026-08-31-review-mode-command-control-design.md