### PR TITLE
test(workflows): prove review skip policy

### DIFF
--- a/.github/workflow-config.yml
+++ b/.github/workflow-config.yml
@@ -64,7 +64,7 @@ workflows:
 
 # === Shared Settings ===
 review:
-  auto: false
+  auto: true
 
 claude:
   # Optional. If empty/omitted, claude-code-action default is used.


### PR DESCRIPTION
Disposable v1.51 skip-policy canary. Sets automatic review on for this PR head, then relies on the review:skip control label to prove policy-only successful termination with zero AI provider or App invocation. This PR must not be merged.