### PR TITLE
feat(fleet): support multi-branch workflow rollout

### DIFF
--- a/docs/superpowers/plans/2026-09-01-multi-branch-workflow-rollout.md
+++ b/docs/superpowers/plans/2026-09-01-multi-branch-workflow-rollout.md
@@ -1,0 +1,262 @@
+# Multi-Branch Workflow Rollout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make fleet rollout and audit cover every configured active branch while preserving default-branch behavior and fail-closed publication.
+
+**Architecture:** Fleet schema v2 adds per-repository `additional_branches`; schema v1 remains readable as default-only. The restricted Git adapter returns snapshots containing both repository default and selected base branches. Rollout and audit expand repositories into branch targets, isolate each target in a fresh clone, and bind all branch/PR/manifest identities to the selected base.
+
+**Tech Stack:** Python 3.12, dataclasses, Git/GitHub CLI adapter, pytest, JSON, SHA-256, actionlint.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-multi-branch-workflow-rollout-design.md`
+
+## Global Constraints
+
+- Keep the current deterministic default rollout head unchanged.
+- Preserve immutable automation SHA pinning and the restricted Git Data API boundary.
+- Prevalidate every selected repository/branch target before the first remote mutation.
+- Bootstrap only the repository default branch.
+- Do not create a release tag or consumer pull request in this issue PR.
+- Do not modify issue #52 or Notion.
+
+---
+
+### Task 1: Versioned Fleet Configuration
+
+**Files:**
+- Modify: `scripts/workflow_catalog.py`
+- Modify: `scripts/workflow-config.json`
+- Test: `tests/test_workflow_catalog.py`
+
+**Interfaces:**
+- Consumes: schema-1 and schema-2 `scripts/workflow-config.json` bytes.
+- Produces: `RepoProfile.additional_branches: tuple[str, ...]` with schema-1 default `()`, plus
+  `configured_branch_targets(profile) -> tuple[str | None, ...]` returning default sentinel `None`
+  followed by configured additional branches.
+
+- [ ] **Step 1: Write failing schema tests**
+
+Add behavior tests proving the live `wlan-driver-v2` profile yields `("ported",)`, all other live
+profiles yield `()`, a copied schema-1 config remains readable as default-only, and duplicate,
+non-string, empty, or invalid Git branch names are rejected. Assert the shared target helper returns
+`(None, "ported")` for `wlan-driver-v2` and `(None,)` for a default-only profile.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run: `python3 -m pytest -q tests/test_workflow_catalog.py`
+
+Expected: failures because `RepoProfile` has no `additional_branches` and schema 2 is unsupported.
+
+- [ ] **Step 3: Implement the minimal versioned parser**
+
+Extend the profile record:
+
+```python
+@dataclass(frozen=True)
+class RepoProfile:
+    name: str
+    profile: str
+    optional_workflows: frozenset[str]
+    repo_write_auth: Literal["github_app", "github_token"]
+    bootstrap_allowed: bool
+    additional_branches: tuple[str, ...]
+```
+
+Accept schema versions 1 and 2. Schema 1 requires the historical four profile keys and supplies an
+empty tuple. Schema 2 requires those keys plus `additional_branches`, validates a unique ordered list
+of valid non-empty Git branch names, and preserves that order. Add the pure shared target helper so
+rollout and audit cannot diverge in expansion order. Change the live config to schema 2, set
+`wlan-driver-v2.additional_branches` to `["ported"]`, and set every other repository to `[]`.
+
+- [ ] **Step 4: Run the tests and verify GREEN**
+
+Run: `python3 -m pytest -q tests/test_workflow_catalog.py tests/test_prepare_workflow_rollout.py`
+
+- [ ] **Step 5: Commit the configuration unit**
+
+```bash
+git add scripts/workflow_catalog.py scripts/workflow-config.json tests/test_workflow_catalog.py
+git commit -m "feat(fleet): configure additional rollout branches"
+```
+
+### Task 2: Branch-Aware Restricted Git Adapter
+
+**Files:**
+- Modify: `scripts/workflow_fleet_git.py`
+- Test: `tests/test_workflow_fleet_git.py`
+
+**Interfaces:**
+- Consumes: optional requested base branch and the configured repository identity.
+- Produces: `RepositorySnapshot.base_branch`, `clone_branch(...)`, and `refetch_branch(...)` while retaining default-only wrappers.
+
+- [ ] **Step 1: Write failing adapter tests**
+
+Add tests that clone `ported` with `git clone --single-branch --branch ported`, retain the reported
+repository default `main`, refetch `ported`, reject malformed or missing branch metadata, and accept
+only the expected SHA-256-suffixed rollout ref/commit identity for an additional base.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run: `python3 -m pytest -q tests/test_workflow_fleet_git.py`
+
+Expected: failures because snapshots and adapter entry points are default-only.
+
+- [ ] **Step 3: Implement the minimal adapter surface**
+
+Add `base_branch` to `RepositorySnapshot`. Implement:
+
+```python
+def clone_branch(owner: str, repo: str, workspace: Path, branch: str | None) -> RepositorySnapshot:
+    ...
+
+def clone_default_branch(owner: str, repo: str, workspace: Path) -> RepositorySnapshot:
+    return clone_branch(owner, repo, workspace, None)
+
+def refetch_branch(snapshot: RepositorySnapshot) -> str:
+    ...
+```
+
+Keep `refetch_default` as the compatibility wrapper for default snapshots. Extend the closed rollout
+ref validator with an optional 64-hex digest suffix and validate that suffix against
+`sha256(snapshot.base_branch.encode("utf-8"))` whenever the selected base differs from the default.
+Bind the expected rollout commit message to the selected base branch.
+
+- [ ] **Step 4: Run the tests and verify GREEN**
+
+Run: `python3 -m pytest -q tests/test_workflow_fleet_git.py`
+
+- [ ] **Step 5: Commit the adapter unit**
+
+```bash
+git add scripts/workflow_fleet_git.py tests/test_workflow_fleet_git.py
+git commit -m "feat(fleet): inspect explicit base branches"
+```
+
+### Task 3: Multi-Branch Rollout Planning and Publication
+
+**Files:**
+- Modify: `scripts/rollout_workflow_fleet.py`
+- Test: `tests/test_rollout_workflow_fleet.py`
+
+**Interfaces:**
+- Consumes: `RepoProfile.additional_branches`, branch-aware snapshots, and existing release bundles.
+- Produces: branch-bound `RepoOutcome`, `PreparedRepo`, rollout head/title/body, exact PR reuse, publication, and manifest records.
+
+- [ ] **Step 1: Write failing identity and expansion tests**
+
+Add tests proving default identity text is byte-for-byte unchanged; `ported` receives a literal
+hand-derived digest-suffixed head, base-bound title/body, and exact PR base; `--repo wlan-driver-v2`
+prevalidates and publishes both targets; and a blocked `ported` prevalidation prevents publication
+of `main` and every other selected target.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run: `python3 -m pytest -q tests/test_rollout_workflow_fleet.py`
+
+Expected: failures because result models and loops contain one target per repository.
+
+- [ ] **Step 3: Implement branch-bound identities**
+
+Add `base_branch` to public outcomes and prepared records. Make `rollout_branch`, `pr_title`, and
+`pr_body` accept selected/default branch identity while preserving their current output for the
+default branch. Pass the exact identity through commit construction, inspection, reuse, creation,
+and attestation.
+
+- [ ] **Step 4: Implement target expansion and isolation**
+
+Expand each selected profile through `configured_branch_targets(profile)`, where `None` means the
+discovered default. Give each target its own marked temporary clone, prevalidate the full expanded
+batch before mutation, publish the exact prepared targets only after the gate passes, and reject
+bootstrap on additional targets.
+
+- [x] **Step 5: Run the tests and verify GREEN**
+
+Run: `python3 -m pytest -q tests/test_rollout_workflow_fleet.py tests/test_workflow_fleet_git.py`
+
+- [ ] **Step 6: Commit the rollout unit**
+
+```bash
+git add scripts/rollout_workflow_fleet.py tests/test_rollout_workflow_fleet.py
+git commit -m "feat(fleet): publish per active branch"
+```
+
+### Task 4: Multi-Branch Audit and Operator Contract
+
+**Files:**
+- Modify: `scripts/audit_workflow_fleet.py`
+- Modify: `docs/workflow-fleet-rollout.md`
+- Test: `tests/test_audit_workflow_fleet.py`
+
+**Interfaces:**
+- Consumes: the same branch target expansion as rollout.
+- Produces: one branch-identified `AuditResult` per target and summary totals over targets.
+
+- [x] **Step 1: Write failing audit tests**
+
+Add tests proving the live 16-repository config audits 17 branch targets, output distinguishes
+`wlan-driver-v2[main]` and `wlan-driver-v2[ported]`, `ported` drift prevents an all-current result,
+and clone/fetch failures block only their exact target while remaining visible in the summary.
+
+- [x] **Step 2: Run the tests and verify RED**
+
+Run: `python3 -m pytest -q tests/test_audit_workflow_fleet.py`
+
+Expected: failures because audit currently clones and reports only repository defaults.
+
+- [x] **Step 3: Implement branch-aware audit**
+
+Add `base_branch` to `AuditResult`, expand selected repositories exactly as rollout does, use a fresh
+marked clone workspace for each target, and print target-qualified results. Count branch targets in
+the final summary.
+
+- [x] **Step 4: Update the operator contract**
+
+Document schema v2, default-plus-additional expansion, target-qualified manifest/output, unique head
+identity, all-target prevalidation, default-only bootstrap, and a 17-target completion condition for
+the current fleet.
+
+- [ ] **Step 5: Run the tests and verify GREEN**
+
+Run: `python3 -m pytest -q tests/test_audit_workflow_fleet.py tests/test_rollout_workflow_fleet.py`
+
+- [x] **Step 6: Commit the audit/documentation unit**
+
+```bash
+git add scripts/audit_workflow_fleet.py docs/workflow-fleet-rollout.md tests/test_audit_workflow_fleet.py docs/superpowers/specs/2026-09-01-multi-branch-workflow-rollout-design.md docs/superpowers/plans/2026-09-01-multi-branch-workflow-rollout.md
+git commit -m "docs(fleet): define multi-branch rollout contract"
+```
+
+### Task 5: Release Contract and Final Verification
+
+**Files:**
+- Modify if required by authenticated bytes: `scripts/verify_workflow_release.py`
+- Test: `tests/test_verify_workflow_release.py`
+- Test: `tests/test_workflow_release_bundle.py`
+
+**Interfaces:**
+- Consumes: completed schema/adapter/rollout/audit implementation.
+- Produces: a release-verifiable, review-ready branch without creating a release.
+
+- [ ] **Step 1: Run release-focused verification**
+
+Run: `python3 -m pytest -q tests/test_verify_workflow_release.py tests/test_workflow_release_bundle.py`
+
+If authenticated byte checks fail, recalculate only the exact live/historical transformed digests
+required by those failures, update the verifier, and rerun the failing tests.
+
+- [ ] **Step 2: Run workflow validation**
+
+Run CI's YAML parser over `.github/workflows` and `examples/baseline-workflows/.github/workflows`,
+then run digest-verified actionlint 1.7.12 with `-shellcheck= -pyflakes=` over both directories.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `python3 -m pytest -q`
+
+Expected: every test and subtest passes with zero failures.
+
+- [ ] **Step 4: Review and integrate**
+
+Run an independent read-only review over `origin/main..HEAD`, address every Critical or Important
+finding with a new RED→GREEN cycle, push `feat/76-multi-branch-rollout`, open a PR containing
+`Fixes #76`, wait for required CI, and merge with the repository's merge-commit convention.

--- a/docs/superpowers/specs/2026-09-01-multi-branch-workflow-rollout-design.md
+++ b/docs/superpowers/specs/2026-09-01-multi-branch-workflow-rollout-design.md
@@ -1,0 +1,58 @@
+# Multi-Branch Workflow Rollout Design
+
+## Problem
+
+The fleet rollout and audit commands currently inspect only each repository's default branch.
+`wlan-driver-v2` also maintains the active `ported` branch. Because common workflow callers were
+updated only on `main`, `ported` drifted until Claude's identical-default-workflow validation
+prevented reviews on pull requests targeting that branch.
+
+## Decision
+
+Keep the default branch implicit and add a closed `additional_branches` list to each repository
+profile. The live schema becomes version 2; historical schema-1 release bundles remain readable
+and behave as default-branch-only bundles. Initially only `wlan-driver-v2` declares `ported`.
+
+Both rollout and audit expand each selected repository into one default target plus its configured
+additional targets. `--repo wlan-driver-v2` therefore covers both `main` and `ported` without a new
+operator flag. `AuditResult`, CLI output, and manifests identify the exact resolved base branch;
+summary totals count branch targets rather than repositories. Each audit target uses a fresh marked
+single-branch clone, so a clone or fetch failure remains visible for that target without suppressing
+the rest of the audit batch.
+
+The existing default rollout head remains `automation/common-workflows-<ref>`. An additional target
+uses `automation/common-workflows-<ref>-<sha256(base-branch)>`. The full digest avoids Git ref prefix
+conflicts, preserves every valid Git branch name without lossy escaping, and gives each base branch
+a deterministic one-to-one rollout identity. Pull-request title, body, commit identity, exact-PR
+reuse checks, and attestation all bind the additional target's base branch.
+
+The restricted Git adapter records both the repository default branch and the selected base branch.
+Default-only wrapper functions remain for compatibility; branch-aware clone/refetch functions power
+the new paths. Each branch target receives a fresh single-branch clone so switching or rendering one
+target cannot contaminate another.
+
+All branch targets complete read-only prevalidation before the first remote mutation. One blocked
+target blocks publication for the entire selected batch, preserving the existing all-prevalidate
+gate. Bootstrap remains default-branch-only; a missing configuration on an additional branch is a
+normal blocked target.
+
+## Rejected Alternatives
+
+- An operator-only `--base-branch` flag is not durable and allows audits to silently omit an active
+  branch.
+- Making caller wrappers reference mutable tags weakens immutable release pinning and changes the
+  security model far beyond this incident.
+- Embedding raw base names in rollout heads creates ref-prefix and escaping collisions for valid Git
+  branch names.
+
+## Completion Conditions
+
+- Schema-1 bundles remain default-only and schema-2 profiles validate `additional_branches`.
+- `wlan-driver-v2` expands to default plus `ported`; all other repositories remain default-only.
+- Plan, publish, reuse, and attestation bind the exact base branch and unique rollout head.
+- A blocked additional target prevents every remote mutation in that batch.
+- Audit reports every configured branch target and cannot call the fleet current while one is drifted.
+- The current 16-repository fleet completes only at `current=17`, `drift=0`, and `blocked=0`.
+- Existing default-branch behavior, immutable release verification, and restricted Git/GitHub
+  boundaries remain green.
+- No release tag or consumer rollout is created in this issue PR.

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -24,11 +24,9 @@ by `scripts/workflow-config.json`. Consumer-repository Git and `gh` operations u
 operator's normal GitHub authentication, but provider credentials are removed from child
 environments. Supply the locally installed, reviewed `actionlint` executable explicitly.
 
-Fleet configuration schema v2 treats the repository default branch as an implicit target
-and adds any active branches through a profile's ordered `additional_branches` list. A
-selected repository expands to all of its configured targets: `--repo wlan-driver-v2`
-therefore covers both `main` and `ported` without another flag. Schema-1 release bundles
-remain default-only.
+The historical `v1.40.1` release bundle uses schema v1 and is default-branch-only across
+its 19 configured repositories. Its commands below must not be used to claim schema-v2
+or multi-branch coverage.
 
 Automation release verification has a narrower boundary. It discovers a normal repository
 or linked worktree by reading the `.git` pointer and `commondir` itself, reads tag refs
@@ -423,7 +421,7 @@ inspection, safe `drift` and an explicitly requested safe `bootstrap_required` b
 as an implicit bootstrap opportunity. Audit reports `current`, `drift`, or `blocked` for
 each configured target.
 
-The manifest and operator output qualify every result with its exact base branch and include
+The manifest and operator output identify the default target and include
 the observed base SHA, release commit, required secret and variable **names**, and managed
 diff paths. The manifest is a convenience report, not an approval token; publish always
 refetches and recomputes.
@@ -444,8 +442,7 @@ python3 "$AUTOMATION_RELEASE_ROOT/scripts/rollout_workflow_fleet.py" \
 ```
 
 For `v1.40.1`, the default target keeps the deterministic branch
-`automation/common-workflows-v1.40.1`; each configured non-default target adds the complete
-SHA-256 digest of its base-branch name. Publish computes exact blob, tree, and commit SHA-1
+`automation/common-workflows-v1.40.1`. Publish computes exact blob, tree, and commit SHA-1
 identities locally with fixed author, committer, timestamp, and message fields. JSON sent
 through stdin creates those detached objects only at the literal GitHub Git Data API
 endpoints `repos/jhw7500/<catalog-repo>/git/blobs`, `trees`, and `commits`; the final
@@ -465,7 +462,7 @@ cleanup ref is created. There is no ordinary Git
 branch push, force option, merge, auto-merge, update-branch, default-branch write,
 secret-write, variable-write, or revert operation.
 
-All selected repository/branch targets pass read-only prevalidation before the first remote effect.
+All selected repositories pass read-only prevalidation before the first remote effect.
 Publication then refetches and recomputes each repository immediately before its branch
 is created or reused. The reuse rules are fail-closed:
 
@@ -485,7 +482,7 @@ repository is blocked. It does not roll back successful repositories. Correct th
 and rerun the same command; exact branches and PRs are safely reused.
 
 Bootstrap is deliberately separate and accepts exactly one matching, bootstrap-allowed
-repository's default target; additional targets cannot bootstrap. Its new config disables
+repository's default target. Its new config disables
 every common workflow:
 
 ```bash
@@ -532,7 +529,7 @@ python3 "$AUTOMATION_RELEASE_ROOT/scripts/rollout_workflow_fleet.py" \
 
 ### 4. Read-only audit
 
-Audit current content on every configured target after reviewed merges:
+Audit current content on every configured repository default after reviewed merges:
 
 ```bash
 python3 "$AUTOMATION_RELEASE_ROOT/scripts/audit_workflow_fleet.py" \
@@ -541,20 +538,42 @@ python3 "$AUTOMATION_RELEASE_ROOT/scripts/audit_workflow_fleet.py" \
   --ref v1.40.1
 ```
 
-Repeated `--repo NAME` arguments narrow the audit but still expand each selected profile's
-default and additional targets. Output is target-qualified (for example,
-`wlan-driver-v2[main]` and `wlan-driver-v2[ported]`). Audit reports `current`, `drift`, or
+Repeated `--repo NAME` arguments narrow the audit. Output identifies the repository default.
+Audit reports `current`, `drift`, or
 `blocked` from managed bytes, tracked Git entry metadata, and contracts; it ignores
 project-owned workflow differences. A mode-only drift is `drift`, appears in
 `changed_paths`, and is repaired to an exact `100644 blob`. Commit construction and final
 attestation cover the complete managed set: every required or selected optional/config
 file that is present has canonical bytes and mode/type, unselected optional and retired
 paths are absent, and no project-owned path is changed. During rollout, an unmerged
-target legitimately remains `drift`. The current fleet completion condition is `current=17`,
-`drift=0`, and `blocked=0`.
+repository legitimately remains `drift`. The historical fleet completion condition is
+`current=19`, `drift=0`, and `blocked=0`.
 
 If the implicit default target cannot be cloned far enough to discover its remote name,
 its blocked result is labeled `default:unresolved`; the colon makes it invalid as a Git branch.
+
+## Post-merge multi-branch contract
+
+Use this section only with the first immutable automation release containing #76 after it
+is merged; no release tag is assigned here. That release carries schema v2. It treats the
+repository default as an implicit target and expands each profile's ordered
+`additional_branches`. The current 16-repository configuration therefore has 17 targets:
+`wlan-driver-v2` expands to its discovered default plus `ported`; every other profile has
+only its default target.
+
+For that post-merge release, `--repo wlan-driver-v2` plans, publishes, and audits both
+targets without another flag. The default rollout head remains
+`automation/common-workflows-<ref>`; an additional target uses the full lower-case
+SHA-256 digest suffix of its resolved base branch. PR title/body, commit identity, reuse,
+attestation, manifest, and output bind the exact base branch.
+
+All expanded targets must complete read-only prevalidation before the first remote
+publication. Metadata must resolve to one repository default, unique base branches, and
+unique rollout heads; an additional target cannot equal that default. Any inconsistency
+blocks that repository's targets and prevents publication for the selected batch. Audit
+keeps every configured target visible and blocked on the same inconsistency, rather than
+reporting duplicate targets as current. Bootstrap remains default-only. Completion for the
+current schema-v2 fleet is `current=17`, `drift=0`, and `blocked=0`.
 
 ### Review, merge, and recovery
 

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -554,7 +554,7 @@ target legitimately remains `drift`. The current fleet completion condition is `
 `drift=0`, and `blocked=0`.
 
 If the implicit default target cannot be cloned far enough to discover its remote name,
-its blocked result is labeled `<default-unresolved>`; this cannot collide with a valid branch.
+its blocked result is labeled `default:unresolved`; the colon makes it invalid as a Git branch.
 
 ### Review, merge, and recovery
 

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -553,6 +553,9 @@ paths are absent, and no project-owned path is changed. During rollout, an unmer
 target legitimately remains `drift`. The current fleet completion condition is `current=17`,
 `drift=0`, and `blocked=0`.
 
+If the implicit default target cannot be cloned far enough to discover its remote name,
+its blocked result is labeled `<default-unresolved>`; this cannot collide with a valid branch.
+
 ### Review, merge, and recovery
 
 Repository owners inspect each diff, run project-specific CI, obtain their normal reviews,

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -549,9 +549,6 @@ paths are absent, and no project-owned path is changed. During rollout, an unmer
 repository legitimately remains `drift`. The historical fleet completion condition is
 `current=19`, `drift=0`, and `blocked=0`.
 
-If the implicit default target cannot be cloned far enough to discover its remote name,
-its blocked result is labeled `default:unresolved`; the colon makes it invalid as a Git branch.
-
 ## Post-merge multi-branch contract
 
 Use this section only with the first immutable automation release containing #76 after it
@@ -560,6 +557,9 @@ repository default as an implicit target and expands each profile's ordered
 `additional_branches`. The current 16-repository configuration therefore has 17 targets:
 `wlan-driver-v2` expands to its discovered default plus `ported`; every other profile has
 only its default target.
+
+If the implicit default target cannot be cloned far enough to discover its remote name,
+its blocked result is labeled `default:unresolved`; the colon makes it invalid as a Git branch.
 
 For that post-merge release, `--repo wlan-driver-v2` plans, publishes, and audits both
 targets without another flag. The default rollout head remains

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -24,6 +24,12 @@ by `scripts/workflow-config.json`. Consumer-repository Git and `gh` operations u
 operator's normal GitHub authentication, but provider credentials are removed from child
 environments. Supply the locally installed, reviewed `actionlint` executable explicitly.
 
+Fleet configuration schema v2 treats the repository default branch as an implicit target
+and adds any active branches through a profile's ordered `additional_branches` list. A
+selected repository expands to all of its configured targets: `--repo wlan-driver-v2`
+therefore covers both `main` and `ported` without another flag. Schema-1 release bundles
+remain default-only.
+
 Automation release verification has a narrower boundary. It discovers a normal repository
 or linked worktree by reading the `.git` pointer and `commondir` itself, reads tag refs
 directly, rejects alternates and promisor/shallow object stores, and creates an isolated
@@ -415,11 +421,12 @@ The pure renderer's renderer-only content classifications are `current`, `drift`
 inspection, safe `drift` and an explicitly requested safe `bootstrap_required` become
 `planned`. A missing config without explicit bootstrap is `blocked`; it is never presented
 as an implicit bootstrap opportunity. Audit reports `current`, `drift`, or `blocked` for
-default-branch content.
+each configured target.
 
-The manifest includes the observed base SHA, release commit, required secret and variable
-**names**, and managed diff paths. It is a convenience report, not an approval token;
-publish always refetches and recomputes.
+The manifest and operator output qualify every result with its exact base branch and include
+the observed base SHA, release commit, required secret and variable **names**, and managed
+diff paths. The manifest is a convenience report, not an approval token; publish always
+refetches and recomputes.
 
 ### 2. Publish independent PRs
 
@@ -436,8 +443,9 @@ python3 "$AUTOMATION_RELEASE_ROOT/scripts/rollout_workflow_fleet.py" \
   --actionlint "$ACTIONLINT"
 ```
 
-For `v1.40.1`, every repository uses the deterministic branch
-`automation/common-workflows-v1.40.1`. Publish computes exact blob, tree, and commit SHA-1
+For `v1.40.1`, the default target keeps the deterministic branch
+`automation/common-workflows-v1.40.1`; each configured non-default target adds the complete
+SHA-256 digest of its base-branch name. Publish computes exact blob, tree, and commit SHA-1
 identities locally with fixed author, committer, timestamp, and message fields. JSON sent
 through stdin creates those detached objects only at the literal GitHub Git Data API
 endpoints `repos/jhw7500/<catalog-repo>/git/blobs`, `trees`, and `commits`; the final
@@ -457,11 +465,11 @@ cleanup ref is created. There is no ordinary Git
 branch push, force option, merge, auto-merge, update-branch, default-branch write,
 secret-write, variable-write, or revert operation.
 
-All selected repositories pass read-only prevalidation before the first remote effect.
+All selected repository/branch targets pass read-only prevalidation before the first remote effect.
 Publication then refetches and recomputes each repository immediately before its branch
 is created or reused. The reuse rules are fail-closed:
 
-- an absent rollout branch may be created from the freshly fetched default branch;
+- an absent rollout branch may be created from the freshly fetched selected base branch;
 - a matching branch may receive its missing PR only when its base, release commit, and
   managed path/mode/blob diff exactly match the fresh render;
 - one exact open PR is reusable only when its base branch, head repository, head branch,
@@ -477,7 +485,8 @@ repository is blocked. It does not roll back successful repositories. Correct th
 and rerun the same command; exact branches and PRs are safely reused.
 
 Bootstrap is deliberately separate and accepts exactly one matching, bootstrap-allowed
-repository. Its new config disables every common workflow:
+repository's default target; additional targets cannot bootstrap. Its new config disables
+every common workflow:
 
 ```bash
 python3 "$AUTOMATION_RELEASE_ROOT/scripts/rollout_workflow_fleet.py" \
@@ -523,7 +532,7 @@ python3 "$AUTOMATION_RELEASE_ROOT/scripts/rollout_workflow_fleet.py" \
 
 ### 4. Read-only audit
 
-Audit current default-branch content after reviewed merges:
+Audit current content on every configured target after reviewed merges:
 
 ```bash
 python3 "$AUTOMATION_RELEASE_ROOT/scripts/audit_workflow_fleet.py" \
@@ -532,14 +541,16 @@ python3 "$AUTOMATION_RELEASE_ROOT/scripts/audit_workflow_fleet.py" \
   --ref v1.40.1
 ```
 
-Repeated `--repo NAME` arguments narrow the audit. Audit reports `current`, `drift`, or
+Repeated `--repo NAME` arguments narrow the audit but still expand each selected profile's
+default and additional targets. Output is target-qualified (for example,
+`wlan-driver-v2[main]` and `wlan-driver-v2[ported]`). Audit reports `current`, `drift`, or
 `blocked` from managed bytes, tracked Git entry metadata, and contracts; it ignores
 project-owned workflow differences. A mode-only drift is `drift`, appears in
 `changed_paths`, and is repaired to an exact `100644 blob`. Commit construction and final
 attestation cover the complete managed set: every required or selected optional/config
 file that is present has canonical bytes and mode/type, unselected optional and retired
 paths are absent, and no project-owned path is changed. During rollout, an unmerged
-repository legitimately remains `drift`. The completion condition is `current=19`,
+target legitimately remains `drift`. The current fleet completion condition is `current=17`,
 `drift=0`, and `blocked=0`.
 
 ### Review, merge, and recovery

--- a/scripts/audit_workflow_fleet.py
+++ b/scripts/audit_workflow_fleet.py
@@ -36,6 +36,7 @@ from scripts.workflow_release_bundle import (  # noqa: E402
 
 VERSION_REF = re.compile(r"v[0-9]+(?:\.[0-9]+)+")
 WORKSPACE_MARKER = ".automation-fleet-workspace"
+UNRESOLVED_DEFAULT_BRANCH = "<default-unresolved>"
 GIT_PREFIX = (
     "git",
     "-c",
@@ -161,7 +162,7 @@ def main(argv: list[str] | None = None) -> int:
         for repo in repos:
             profile = bundle.config.profiles[repo]
             for target_branch in configured_branch_targets(profile):
-                selected_base = target_branch or "default"
+                selected_base = target_branch or UNRESOLVED_DEFAULT_BRANCH
                 with tempfile.TemporaryDirectory(
                     prefix=f".audit-{repo}-", dir=workspace
                 ) as temporary:

--- a/scripts/audit_workflow_fleet.py
+++ b/scripts/audit_workflow_fleet.py
@@ -24,7 +24,10 @@ from scripts.prepare_workflow_rollout import (  # noqa: E402
     render_repository,
 )
 from scripts.workflow_fleet_git import FleetGitError  # noqa: E402
-from scripts.workflow_catalog import RepoProfile  # noqa: E402
+from scripts.workflow_catalog import (  # noqa: E402
+    RepoProfile,
+    configured_branch_targets,
+)
 from scripts.workflow_release_bundle import (  # noqa: E402
     ReleaseBundle,
     materialize_release_bundle,
@@ -45,6 +48,7 @@ GIT_PREFIX = (
 @dataclass(frozen=True)
 class AuditResult:
     repo: str
+    base_branch: str
     status: Literal["current", "drift", "blocked"]
     detail: str
     changed_paths: tuple[str, ...]
@@ -58,6 +62,7 @@ def audit_repository(
     variable_names: set[str],
     *,
     observed_revision: str | None = None,
+    base_branch: str = "",
 ) -> AuditResult:
     """Return a renderer-derived content classification without writing."""
 
@@ -75,14 +80,14 @@ def audit_repository(
             observed_revision=observed_revision,
         )
     except RolloutError as exc:
-        return AuditResult(repo.name, "blocked", str(exc), ())
+        return AuditResult(repo.name, base_branch, "blocked", str(exc), ())
 
     if plan.status == "blocked":
-        return AuditResult(repo.name, "blocked", plan.reason, ())
+        return AuditResult(repo.name, base_branch, "blocked", plan.reason, ())
     changed_paths = tuple(sorted(change.path.as_posix() for change in plan.changes))
     if plan.status in {"drift", "bootstrap_required"}:
-        return AuditResult(repo.name, "drift", plan.reason, changed_paths)
-    return AuditResult(repo.name, "current", plan.reason, ())
+        return AuditResult(repo.name, base_branch, "drift", plan.reason, changed_paths)
+    return AuditResult(repo.name, base_branch, "current", plan.reason, ())
 
 
 def git(args: list[str], *, cwd: Path | None = None) -> str:
@@ -153,39 +158,61 @@ def main(argv: list[str] | None = None) -> int:
             parser.error(f"repositories not in release bundle: {', '.join(unknown)}")
 
         outcomes: list[AuditResult] = []
-        with tempfile.TemporaryDirectory(prefix=".audit-", dir=workspace) as temporary:
-            clone_workspace = Path(temporary)
-            (clone_workspace / WORKSPACE_MARKER).write_text(
-                "managed disposable clones only\n", encoding="utf-8"
-            )
-            for repo in repos:
-                try:
-                    snapshot = fleet_git.clone_default_branch(
-                        bundle.config.owner, repo, clone_workspace
+        for repo in repos:
+            profile = bundle.config.profiles[repo]
+            for target_branch in configured_branch_targets(profile):
+                selected_base = target_branch or "default"
+                with tempfile.TemporaryDirectory(
+                    prefix=f".audit-{repo}-", dir=workspace
+                ) as temporary:
+                    clone_workspace = Path(temporary)
+                    (clone_workspace / WORKSPACE_MARKER).write_text(
+                        "managed disposable clones only\n", encoding="utf-8"
                     )
-                    base_sha = fleet_git.refetch_default(snapshot)
-                    git(["switch", "--detach", base_sha], cwd=snapshot.path)
-                    outcomes.append(
-                        audit_repository(
-                            snapshot.path,
-                            bundle,
-                            bundle.config.profiles[repo],
-                            set(snapshot.secret_names),
-                            set(snapshot.variable_names),
-                            observed_revision=base_sha,
+                    try:
+                        snapshot = fleet_git.clone_branch(
+                            bundle.config.owner, repo, clone_workspace, target_branch
                         )
-                    )
-                except (FleetGitError, RolloutError):
-                    outcomes.append(
-                        AuditResult(repo, "blocked", "repository audit failed", ())
-                    )
-                except (OSError, KeyError, ValueError):
-                    outcomes.append(
-                        AuditResult(repo, "blocked", "local audit failed", ())
-                    )
+                        selected_base = snapshot.base_branch or snapshot.default_branch
+                        base_sha = fleet_git.refetch_branch(snapshot)
+                        git(["switch", "--detach", base_sha], cwd=snapshot.path)
+                        outcomes.append(
+                            audit_repository(
+                                snapshot.path,
+                                bundle,
+                                profile,
+                                set(snapshot.secret_names),
+                                set(snapshot.variable_names),
+                                observed_revision=base_sha,
+                                base_branch=selected_base,
+                            )
+                        )
+                    except (FleetGitError, RolloutError):
+                        outcomes.append(
+                            AuditResult(
+                                repo,
+                                selected_base,
+                                "blocked",
+                                "repository audit failed",
+                                (),
+                            )
+                        )
+                    except (OSError, KeyError, ValueError):
+                        outcomes.append(
+                            AuditResult(
+                                repo,
+                                selected_base,
+                                "blocked",
+                                "local audit failed",
+                                (),
+                            )
+                        )
 
         for outcome in outcomes:
-            print(f"{outcome.status.upper():7} {outcome.repo}: {outcome.detail}")
+            print(
+                f"{outcome.status.upper():7} "
+                f"{outcome.repo}[{outcome.base_branch}]: {outcome.detail}"
+            )
         counts = {
             status: sum(item.status == status for item in outcomes)
             for status in ("current", "drift", "blocked")

--- a/scripts/audit_workflow_fleet.py
+++ b/scripts/audit_workflow_fleet.py
@@ -25,8 +25,10 @@ from scripts.prepare_workflow_rollout import (  # noqa: E402
 )
 from scripts.workflow_fleet_git import FleetGitError  # noqa: E402
 from scripts.workflow_catalog import (  # noqa: E402
+    CatalogError,
     RepoProfile,
     configured_branch_targets,
+    validate_resolved_branch_targets,
 )
 from scripts.workflow_release_bundle import (  # noqa: E402
     ReleaseBundle,
@@ -89,6 +91,38 @@ def audit_repository(
     if plan.status in {"drift", "bootstrap_required"}:
         return AuditResult(repo.name, base_branch, "drift", plan.reason, changed_paths)
     return AuditResult(repo.name, base_branch, "current", plan.reason, ())
+
+
+def _block_inconsistent_audit_targets(
+    profile: RepoProfile,
+    targets: list[tuple[str | None, AuditResult, tuple[str, str] | None]],
+) -> list[AuditResult]:
+    """Keep every configured target visible when metadata makes them ambiguous."""
+
+    if any(resolution is None for _, _, resolution in targets):
+        return [outcome for _, outcome, _ in targets]
+    resolved = tuple(
+        (target, resolution[0], resolution[1])
+        for target, _, resolution in targets
+        if resolution is not None
+    )
+    try:
+        validate_resolved_branch_targets(profile, resolved)
+    except CatalogError as exc:
+        detail = f"branch target consistency failed: {exc}"
+        return [
+            AuditResult(
+                outcome.repo,
+                f"default:{outcome.base_branch}"
+                if target is None
+                else outcome.base_branch,
+                "blocked",
+                detail,
+                (),
+            )
+            for target, outcome, _ in targets
+        ]
+    return [outcome for _, outcome, _ in targets]
 
 
 def git(args: list[str], *, cwd: Path | None = None) -> str:
@@ -161,8 +195,12 @@ def main(argv: list[str] | None = None) -> int:
         outcomes: list[AuditResult] = []
         for repo in repos:
             profile = bundle.config.profiles[repo]
+            target_outcomes: list[
+                tuple[str | None, AuditResult, tuple[str, str] | None]
+            ] = []
             for target_branch in configured_branch_targets(profile):
                 selected_base = target_branch or UNRESOLVED_DEFAULT_BRANCH
+                resolution: tuple[str, str] | None = None
                 with tempfile.TemporaryDirectory(
                     prefix=f".audit-{repo}-", dir=workspace
                 ) as temporary:
@@ -175,10 +213,13 @@ def main(argv: list[str] | None = None) -> int:
                             bundle.config.owner, repo, clone_workspace, target_branch
                         )
                         selected_base = snapshot.base_branch or snapshot.default_branch
+                        resolution = (snapshot.default_branch, selected_base)
                         base_sha = fleet_git.refetch_branch(snapshot)
                         git(["switch", "--detach", base_sha], cwd=snapshot.path)
-                        outcomes.append(
-                            audit_repository(
+                        target_outcomes.append(
+                            (
+                                target_branch,
+                                audit_repository(
                                 snapshot.path,
                                 bundle,
                                 profile,
@@ -186,28 +227,39 @@ def main(argv: list[str] | None = None) -> int:
                                 set(snapshot.variable_names),
                                 observed_revision=base_sha,
                                 base_branch=selected_base,
+                                ),
+                                resolution,
                             )
                         )
                     except (FleetGitError, RolloutError):
-                        outcomes.append(
-                            AuditResult(
-                                repo,
-                                selected_base,
-                                "blocked",
-                                "repository audit failed",
-                                (),
+                        target_outcomes.append(
+                            (
+                                target_branch,
+                                AuditResult(
+                                    repo,
+                                    selected_base,
+                                    "blocked",
+                                    "repository audit failed",
+                                    (),
+                                ),
+                                resolution,
                             )
                         )
                     except (OSError, KeyError, ValueError):
-                        outcomes.append(
-                            AuditResult(
-                                repo,
-                                selected_base,
-                                "blocked",
-                                "local audit failed",
-                                (),
+                        target_outcomes.append(
+                            (
+                                target_branch,
+                                AuditResult(
+                                    repo,
+                                    selected_base,
+                                    "blocked",
+                                    "local audit failed",
+                                    (),
+                                ),
+                                resolution,
                             )
                         )
+            outcomes.extend(_block_inconsistent_audit_targets(profile, target_outcomes))
 
         for outcome in outcomes:
             print(

--- a/scripts/audit_workflow_fleet.py
+++ b/scripts/audit_workflow_fleet.py
@@ -36,7 +36,7 @@ from scripts.workflow_release_bundle import (  # noqa: E402
 
 VERSION_REF = re.compile(r"v[0-9]+(?:\.[0-9]+)+")
 WORKSPACE_MARKER = ".automation-fleet-workspace"
-UNRESOLVED_DEFAULT_BRANCH = "<default-unresolved>"
+UNRESOLVED_DEFAULT_BRANCH = "default:unresolved"
 GIT_PREFIX = (
     "git",
     "-c",

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -124,6 +124,7 @@ class PreparedRepo:
     plan: RenderPlan | None
     base_branch: str = ""
     target_branch: str | None = None
+    default_branch: str = ""
 
 
 @dataclass
@@ -1124,6 +1125,7 @@ def prevalidate_repository(
 
     base_sha = ""
     selected_base = base_branch or ""
+    observed_default = ""
     plan: RenderPlan | None = None
     try:
         if base_branch is None:
@@ -1137,6 +1139,7 @@ def prevalidate_repository(
             )
             base_sha = fleet_git.refetch_branch(snapshot)
         selected_base = _selected_base_branch(snapshot)
+        observed_default = snapshot.default_branch
         snapshot = replace(snapshot, base_sha=base_sha)
         if bootstrap and selected_base != snapshot.default_branch:
             return PreparedRepo(
@@ -1152,6 +1155,7 @@ def prevalidate_repository(
                 None,
                 selected_base,
                 base_branch,
+                observed_default,
             )
         git(["switch", "--detach", base_sha], cwd=snapshot.path)
         plan = _render(snapshot, bundle, repo, bootstrap=bootstrap)
@@ -1163,6 +1167,7 @@ def prevalidate_repository(
                 plan,
                 selected_base,
                 base_branch,
+                observed_default,
             )
         if plan.status == "current":
             require_no_current_rollout_branch(snapshot, bundle.ref)
@@ -1173,6 +1178,7 @@ def prevalidate_repository(
                 plan,
                 selected_base,
                 base_branch,
+                observed_default,
             )
         validate_managed_result(
             snapshot.path, bundle, plan, actionlint, bootstrap=bootstrap
@@ -1187,6 +1193,7 @@ def prevalidate_repository(
             plan,
             selected_base,
             base_branch,
+            observed_default,
         )
     except (CommandError, FleetGitError, RolloutError) as exc:
         return PreparedRepo(
@@ -1196,6 +1203,7 @@ def prevalidate_repository(
             plan,
             selected_base,
             base_branch,
+            observed_default,
         )
     except (OSError, KeyError, ValueError):
         return PreparedRepo(
@@ -1208,6 +1216,7 @@ def prevalidate_repository(
             plan,
             selected_base,
             base_branch,
+            observed_default,
         )
 
 
@@ -1262,6 +1271,7 @@ def _publish_repository_fresh(
     *,
     repo: str,
     base_branch: str | None,
+    prevalidated_default_branch: str | None,
     bootstrap: bool,
     actionlint: Path | None,
     progress: PublicationProgress,
@@ -1279,6 +1289,16 @@ def _publish_repository_fresh(
             )
         selected_base = _selected_base_branch(snapshot)
         progress.base_branch = selected_base
+        if (
+            (base_branch is not None and selected_base != base_branch)
+            or (
+                prevalidated_default_branch is not None
+                and snapshot.default_branch != prevalidated_default_branch
+            )
+        ):
+            raise CommandError(
+                "prevalidated base/default branch identity no longer matches"
+            )
         branch = rollout_branch(bundle.ref, selected_base, snapshot.default_branch)
         progress.stage = "refetch"
         base_sha = (
@@ -1418,6 +1438,7 @@ def publish_repository(
     *,
     repo: str,
     base_branch: str | None = None,
+    prevalidated_default_branch: str | None = None,
     bootstrap: bool,
     actionlint: Path | None,
 ) -> RepoOutcome:
@@ -1430,6 +1451,7 @@ def publish_repository(
             workspace,
             repo=repo,
             base_branch=base_branch,
+            prevalidated_default_branch=prevalidated_default_branch,
             bootstrap=bootstrap,
             actionlint=actionlint,
             progress=progress,
@@ -1610,7 +1632,8 @@ def main(argv: list[str] | None = None) -> int:
                             bundle,
                             workspace,
                             repo=item.repo,
-                            base_branch=item.target_branch,
+                            base_branch=item.base_branch or None,
+                            prevalidated_default_branch=item.default_branch or None,
                             bootstrap=(
                                 args.bootstrap_repo == item.repo
                                 and item.target_branch is None

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import asdict, dataclass, replace
+import hashlib
 import json
 import os
 from pathlib import Path, PurePosixPath
@@ -30,7 +31,10 @@ from scripts.prepare_workflow_rollout import (  # noqa: E402
     RolloutError,
     render_repository,
 )
-from scripts.workflow_catalog import WorkflowCatalog  # noqa: E402
+from scripts.workflow_catalog import (  # noqa: E402
+    WorkflowCatalog,
+    configured_branch_targets,
+)
 from scripts.workflow_fleet_git import (  # noqa: E402
     FleetGitError,
     PullRequest,
@@ -102,6 +106,7 @@ class RepoOutcome:
     pr_url: str = ""
     changed_paths: tuple[str, ...] = ()
     stage: str = ""
+    base_branch: str = ""
 
 
 @dataclass(frozen=True)
@@ -117,6 +122,8 @@ class PreparedRepo:
     action: str
     outcome: RepoOutcome
     plan: RenderPlan | None
+    base_branch: str = ""
+    target_branch: str | None = None
 
 
 @dataclass
@@ -125,6 +132,7 @@ class PublicationProgress:
     base_sha: str = ""
     head_sha: str = ""
     changed_paths: tuple[str, ...] = ()
+    base_branch: str = ""
 
 
 def _publication_blocked(
@@ -143,6 +151,7 @@ def _publication_blocked(
         pr_url,
         progress.changed_paths,
         progress.stage,
+        progress.base_branch,
     )
 
 
@@ -159,22 +168,55 @@ def git(
     return fleet_git.run([*GIT_PREFIX, *args], cwd=cwd, stdin=stdin)
 
 
-def rollout_branch(ref: str) -> str:
+def _selected_base_branch(snapshot: RepositorySnapshot) -> str:
+    return snapshot.base_branch or snapshot.default_branch
+
+
+def _is_additional_branch(base_branch: str | None, default_branch: str | None) -> bool:
+    return base_branch is not None and default_branch is not None and base_branch != default_branch
+
+
+def rollout_branch(
+    ref: str,
+    base_branch: str | None = None,
+    default_branch: str | None = None,
+) -> str:
     if VERSION_REF.fullmatch(ref) is None:
         raise CommandError(f"invalid release ref: {ref}")
-    return f"automation/common-workflows-{ref}"
+    branch = f"automation/common-workflows-{ref}"
+    if _is_additional_branch(base_branch, default_branch):
+        assert base_branch is not None
+        return f"{branch}-{hashlib.sha256(base_branch.encode('utf-8')).hexdigest()}"
+    return branch
 
 
-def pr_title(ref: str) -> str:
+def pr_title(
+    ref: str,
+    base_branch: str | None = None,
+    default_branch: str | None = None,
+) -> str:
+    if _is_additional_branch(base_branch, default_branch):
+        return f"ci: adopt common automation workflows ({ref}; base={base_branch})"
     return f"ci: adopt common automation workflows ({ref})"
 
 
-def pr_body(ref: str, commit: str, changed_paths: Sequence[str]) -> str:
+def pr_body(
+    ref: str,
+    commit: str,
+    changed_paths: Sequence[str],
+    base_branch: str | None = None,
+    default_branch: str | None = None,
+) -> str:
     paths = "\n".join(f"- `{path}`" for path in sorted(changed_paths))
+    base = (
+        f"- base branch: `{base_branch}`\n"
+        if _is_additional_branch(base_branch, default_branch)
+        else ""
+    )
     return (
         "Standardize only the catalogued common AI workflow callers.\n\n"
         f"- automation tag: `{ref}`\n- automation commit: `{commit}`\n"
-        f"- managed paths:\n{paths}\n\n"
+        f"{base}- managed paths:\n{paths}\n\n"
         "Project-specific workflows are unchanged. This PR does not modify secrets. "
         "Merge and recovery use this repository's normal GitHub controls.\n"
     )
@@ -809,7 +851,8 @@ def construct_rollout_commit(
             )
         ):
             raise RolloutError("render change does not match the managed result")
-    branch = rollout_branch(ref)
+    selected_base = _selected_base_branch(snapshot)
+    branch = rollout_branch(ref, selected_base, snapshot.default_branch)
     with tempfile.TemporaryDirectory(prefix="workflow-fleet-index-") as temporary:
         root = Path(temporary)
         environment = _hermetic_environment(root, root / "index")
@@ -876,7 +919,7 @@ def construct_rollout_commit(
                 ["commit-tree", tree, "-p", base_sha],
                 cwd=snapshot.path,
                 environment=environment,
-                stdin=(pr_title(ref) + "\n").encode("utf-8"),
+                stdin=(pr_title(ref, selected_base, snapshot.default_branch) + "\n").encode("utf-8"),
             ).decode("ascii"),
             "rollout commit",
         )
@@ -899,7 +942,7 @@ def construct_rollout_commit(
         tree_sha=tree,
         base_tree_sha=base_tree,
         base_sha=base_sha,
-        message=pr_title(ref),
+        message=pr_title(ref, selected_base, snapshot.default_branch),
         blobs=tuple(blobs),
         deletions=tuple(
             change.path.as_posix()
@@ -939,10 +982,11 @@ def inspect_rollout(
 ) -> RolloutInspection:
     """Classify the exact release branch and pull-request identity."""
 
-    branch = rollout_branch(ref)
+    selected_base = _selected_base_branch(snapshot)
+    branch = rollout_branch(ref, selected_base, snapshot.default_branch)
     changed = _changed_paths(plan)
-    title = pr_title(ref)
-    body = pr_body(ref, commit, changed)
+    title = pr_title(ref, selected_base, snapshot.default_branch)
+    body = pr_body(ref, commit, changed, selected_base, snapshot.default_branch)
     branch_sha = fleet_git.remote_branch_sha(snapshot, branch)
     if branch_sha is None:
         requests = fleet_git.list_rollout_prs(
@@ -960,7 +1004,7 @@ def inspect_rollout(
         return RolloutInspection("create_pr", branch_sha)
     if len(requests) != 1 or not _exact_pr(
         requests[0],
-        base=snapshot.default_branch,
+        base=selected_base,
         branch=branch,
         head_repo=f"{fleet_git.OWNER}/{snapshot.path.name}",
         head_sha=branch_sha,
@@ -974,7 +1018,10 @@ def inspect_rollout(
 def require_no_current_rollout_branch(snapshot: RepositorySnapshot, ref: str) -> None:
     """Refuse a stale exact release branch when the default is already current."""
 
-    if fleet_git.remote_branch_sha(snapshot, rollout_branch(ref)) is not None:
+    selected_base = _selected_base_branch(snapshot)
+    if fleet_git.remote_branch_sha(
+        snapshot, rollout_branch(ref, selected_base, snapshot.default_branch)
+    ) is not None:
         raise CommandError(
             "rollout branch exists although the observed default is already current"
         )
@@ -990,7 +1037,8 @@ def attest_pull_request(
 ) -> None:
     """Re-read the release branch and exact PR before reporting publication."""
 
-    branch = rollout_branch(ref)
+    selected_base = _selected_base_branch(snapshot)
+    branch = rollout_branch(ref, selected_base, snapshot.default_branch)
     if fleet_git.remote_branch_sha(snapshot, branch) != head_sha:
         raise CommandError("rollout branch changed after pull request creation")
     requests = fleet_git.list_rollout_prs(fleet_git.OWNER, snapshot.path.name, branch)
@@ -1000,12 +1048,14 @@ def attest_pull_request(
         or requests[0].url != request.url
         or not _exact_pr(
             requests[0],
-            base=snapshot.default_branch,
+            base=selected_base,
             branch=branch,
             head_repo=f"{fleet_git.OWNER}/{snapshot.path.name}",
             head_sha=head_sha,
-            title=pr_title(ref),
-            body=pr_body(ref, commit, changed_paths),
+            title=pr_title(ref, selected_base, snapshot.default_branch),
+            body=pr_body(
+                ref, commit, changed_paths, selected_base, snapshot.default_branch
+            ),
         )
     ):
         raise CommandError("pull request attestation failed")
@@ -1035,12 +1085,13 @@ def _render(
 def _prepared_outcome(
     repo: str,
     base_sha: str,
+    base_branch: str,
     plan: RenderPlan,
     inspection: RolloutInspection | None,
 ) -> RepoOutcome:
     changed = _changed_paths(plan)
     if plan.status == "current":
-        return RepoOutcome(repo, "current", plan.reason, base_sha)
+        return RepoOutcome(repo, "current", plan.reason, base_sha, base_branch=base_branch)
     assert inspection is not None
     details = {
         "create_branch": "would create an exact branch, commit, and pull request",
@@ -1056,6 +1107,7 @@ def _prepared_outcome(
         inspection.branch_sha,
         inspection.pr_url,
         changed,
+        base_branch=base_branch,
     )
 
 
@@ -1064,30 +1116,63 @@ def prevalidate_repository(
     workspace: Path,
     *,
     repo: str,
+    base_branch: str | None = None,
     bootstrap: bool,
     actionlint: Path | None,
 ) -> PreparedRepo:
     """Perform every read/render/validation gate without remote mutation."""
 
     base_sha = ""
+    selected_base = base_branch or ""
     plan: RenderPlan | None = None
     try:
-        snapshot = fleet_git.clone_default_branch(bundle.config.owner, repo, workspace)
-        base_sha = fleet_git.refetch_default(snapshot)
+        if base_branch is None:
+            snapshot = fleet_git.clone_default_branch(
+                bundle.config.owner, repo, workspace
+            )
+            base_sha = fleet_git.refetch_default(snapshot)
+        else:
+            snapshot = fleet_git.clone_branch(
+                bundle.config.owner, repo, workspace, base_branch
+            )
+            base_sha = fleet_git.refetch_branch(snapshot)
+        selected_base = _selected_base_branch(snapshot)
         snapshot = replace(snapshot, base_sha=base_sha)
+        if bootstrap and selected_base != snapshot.default_branch:
+            return PreparedRepo(
+                repo,
+                "blocked",
+                RepoOutcome(
+                    repo,
+                    "blocked",
+                    "bootstrap is permitted only on the default branch",
+                    base_sha,
+                    base_branch=selected_base,
+                ),
+                None,
+                selected_base,
+                base_branch,
+            )
         git(["switch", "--detach", base_sha], cwd=snapshot.path)
         plan = _render(snapshot, bundle, repo, bootstrap=bootstrap)
         if plan.status == "blocked":
             return PreparedRepo(
                 repo,
                 "blocked",
-                RepoOutcome(repo, "blocked", plan.reason, base_sha),
+                RepoOutcome(repo, "blocked", plan.reason, base_sha, base_branch=selected_base),
                 plan,
+                selected_base,
+                base_branch,
             )
         if plan.status == "current":
             require_no_current_rollout_branch(snapshot, bundle.ref)
             return PreparedRepo(
-                repo, "current", _prepared_outcome(repo, base_sha, plan, None), plan
+                repo,
+                "current",
+                _prepared_outcome(repo, base_sha, selected_base, plan, None),
+                plan,
+                selected_base,
+                base_branch,
             )
         validate_managed_result(
             snapshot.path, bundle, plan, actionlint, bootstrap=bootstrap
@@ -1098,22 +1183,31 @@ def prevalidate_repository(
         return PreparedRepo(
             repo,
             inspection.action,
-            _prepared_outcome(repo, base_sha, plan, inspection),
+            _prepared_outcome(repo, base_sha, selected_base, plan, inspection),
             plan,
+            selected_base,
+            base_branch,
         )
     except (CommandError, FleetGitError, RolloutError) as exc:
         return PreparedRepo(
             repo,
             "blocked",
-            RepoOutcome(repo, "blocked", str(exc), base_sha),
+            RepoOutcome(repo, "blocked", str(exc), base_sha, base_branch=selected_base),
             plan,
+            selected_base,
+            base_branch,
         )
     except (OSError, KeyError, ValueError):
         return PreparedRepo(
             repo,
             "blocked",
-            RepoOutcome(repo, "blocked", "local prevalidation failed", base_sha),
+            RepoOutcome(
+                repo, "blocked", "local prevalidation failed", base_sha,
+                base_branch=selected_base,
+            ),
             plan,
+            selected_base,
+            base_branch,
         )
 
 
@@ -1129,7 +1223,8 @@ def publish_new_branch(
 ) -> str:
     """Create one local commit and publish one previously absent exact branch."""
 
-    branch = rollout_branch(ref)
+    selected_base = _selected_base_branch(snapshot)
+    branch = rollout_branch(ref, selected_base, snapshot.default_branch)
     if bundle is not None:
         validate_managed_result(
             snapshot.path,
@@ -1166,19 +1261,31 @@ def _publish_repository_fresh(
     workspace: Path,
     *,
     repo: str,
+    base_branch: str | None,
     bootstrap: bool,
     actionlint: Path | None,
     progress: PublicationProgress,
 ) -> RepoOutcome:
     """Refetch/recompute one repository and create or reuse only its exact PR."""
 
-    branch = rollout_branch(bundle.ref)
     with _make_clone_workspace(workspace, f".publish-{repo}-") as temporary:
-        snapshot = fleet_git.clone_default_branch(
-            bundle.config.owner, repo, Path(temporary)
-        )
+        if base_branch is None:
+            snapshot = fleet_git.clone_default_branch(
+                bundle.config.owner, repo, Path(temporary)
+            )
+        else:
+            snapshot = fleet_git.clone_branch(
+                bundle.config.owner, repo, Path(temporary), base_branch
+            )
+        selected_base = _selected_base_branch(snapshot)
+        progress.base_branch = selected_base
+        branch = rollout_branch(bundle.ref, selected_base, snapshot.default_branch)
         progress.stage = "refetch"
-        base_sha = fleet_git.refetch_default(snapshot)
+        base_sha = (
+            fleet_git.refetch_default(snapshot)
+            if base_branch is None
+            else fleet_git.refetch_branch(snapshot)
+        )
         snapshot = replace(snapshot, base_sha=base_sha)
         progress.base_sha = base_sha
         git(["switch", "--detach", base_sha], cwd=snapshot.path)
@@ -1191,7 +1298,10 @@ def _publish_repository_fresh(
         if plan.status == "current":
             progress.stage = "branch"
             require_no_current_rollout_branch(snapshot, bundle.ref)
-            return RepoOutcome(repo, "current", plan.reason, base_sha, stage="complete")
+            return RepoOutcome(
+                repo, "current", plan.reason, base_sha, stage="complete",
+                base_branch=selected_base,
+            )
         progress.stage = "validation"
         validate_managed_result(
             snapshot.path, bundle, plan, actionlint, bootstrap=bootstrap
@@ -1200,8 +1310,10 @@ def _publish_repository_fresh(
         inspection = inspect_rollout(
             snapshot, base_sha, bundle.ref, bundle.commit, plan
         )
-        body = pr_body(bundle.ref, bundle.commit, changed)
-        title = pr_title(bundle.ref)
+        body = pr_body(
+            bundle.ref, bundle.commit, changed, selected_base, snapshot.default_branch
+        )
+        title = pr_title(bundle.ref, selected_base, snapshot.default_branch)
         if inspection.action == "reuse":
             return RepoOutcome(
                 repo,
@@ -1212,6 +1324,7 @@ def _publish_repository_fresh(
                 inspection.pr_url,
                 changed,
                 "complete",
+                selected_base,
             )
         if inspection.action == "create_branch":
             try:
@@ -1235,7 +1348,7 @@ def _publish_repository_fresh(
             request = fleet_git.create_pull_request(
                 bundle.config.owner,
                 repo,
-                snapshot.default_branch,
+                selected_base,
                 branch,
                 head_sha,
                 title,
@@ -1249,7 +1362,7 @@ def _publish_repository_fresh(
                     for item in requests
                     if _exact_pr(
                         item,
-                        base=snapshot.default_branch,
+                        base=selected_base,
                         branch=branch,
                         head_repo=f"{bundle.config.owner}/{repo}",
                         head_sha=head_sha,
@@ -1295,6 +1408,7 @@ def _publish_repository_fresh(
             request.url,
             changed,
             "complete",
+            selected_base,
         )
 
 
@@ -1303,6 +1417,7 @@ def publish_repository(
     workspace: Path,
     *,
     repo: str,
+    base_branch: str | None = None,
     bootstrap: bool,
     actionlint: Path | None,
 ) -> RepoOutcome:
@@ -1314,6 +1429,7 @@ def publish_repository(
             bundle,
             workspace,
             repo=repo,
+            base_branch=base_branch,
             bootstrap=bootstrap,
             actionlint=actionlint,
             progress=progress,
@@ -1452,21 +1568,27 @@ def main(argv: list[str] | None = None) -> int:
             and not bundle.config.profiles[args.bootstrap_repo].bootstrap_allowed
         ):
             parser.error("release profile does not allow bootstrap")
-        branch = rollout_branch(bundle.ref)
-        del branch  # parsing the exact branch is an early fail-closed gate
+        rollout_branch(bundle.ref)  # parse the default identity before prevalidation
 
         prepared: list[PreparedRepo] = []
-        with _make_clone_workspace(workspace, ".prevalidate-") as temporary:
-            for repo in repos:
-                prepared.append(
-                    prevalidate_repository(
-                        bundle,
-                        Path(temporary),
-                        repo=repo,
-                        bootstrap=args.bootstrap_repo == repo,
-                        actionlint=actionlint,
+        for repo in repos:
+            profile = bundle.config.profiles[repo]
+            for target_branch in configured_branch_targets(profile):
+                with _make_clone_workspace(
+                    workspace, f".prevalidate-{repo}-"
+                ) as temporary:
+                    prepared.append(
+                        prevalidate_repository(
+                            bundle,
+                            Path(temporary),
+                            repo=repo,
+                            base_branch=target_branch,
+                            bootstrap=(
+                                args.bootstrap_repo == repo and target_branch is None
+                            ),
+                            actionlint=actionlint,
+                        )
                     )
-                )
 
         if args.mode == "plan" or any(
             item.outcome.status == "blocked" for item in prepared
@@ -1488,7 +1610,11 @@ def main(argv: list[str] | None = None) -> int:
                             bundle,
                             workspace,
                             repo=item.repo,
-                            bootstrap=args.bootstrap_repo == item.repo,
+                            base_branch=item.target_branch,
+                            bootstrap=(
+                                args.bootstrap_repo == item.repo
+                                and item.target_branch is None
+                            ),
                             actionlint=actionlint,
                         )
                     )
@@ -1527,7 +1653,11 @@ def main(argv: list[str] | None = None) -> int:
         )
         for item in outcomes:
             suffix = f" {item.pr_url}" if item.pr_url else ""
-            print(f"{item.status.upper():9} {item.repo}: {item.detail}{suffix}")
+            target = item.base_branch or "unknown"
+            print(
+                f"{item.status.upper():9} {item.repo}[{target}]: "
+                f"{item.detail}{suffix}"
+            )
         blocked = sum(item.status == "blocked" for item in outcomes)
         print(
             f"SUMMARY mode={args.mode} ref={bundle.ref} commit={bundle.commit} "

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -32,8 +32,11 @@ from scripts.prepare_workflow_rollout import (  # noqa: E402
     render_repository,
 )
 from scripts.workflow_catalog import (  # noqa: E402
+    CatalogError,
+    RepoProfile,
     WorkflowCatalog,
     configured_branch_targets,
+    validate_resolved_branch_targets,
 )
 from scripts.workflow_fleet_git import (  # noqa: E402
     FleetGitError,
@@ -1112,6 +1115,45 @@ def _prepared_outcome(
     )
 
 
+def _block_inconsistent_prepared_targets(
+    profile: RepoProfile,
+    ref: str,
+    prepared: Sequence[PreparedRepo],
+) -> tuple[PreparedRepo, ...]:
+    """Fail closed when configured targets no longer have unique identities."""
+
+    if any(item.outcome.status == "blocked" for item in prepared):
+        return tuple(prepared)
+    resolved = tuple(
+        (item.target_branch, item.default_branch, item.base_branch)
+        for item in prepared
+    )
+    try:
+        validate_resolved_branch_targets(profile, resolved)
+        heads = tuple(
+            rollout_branch(ref, base_branch, default_branch)
+            for _, default_branch, base_branch in resolved
+        )
+        if len(set(heads)) != len(heads):
+            raise CatalogError("branch target rollout heads are not unique")
+    except CatalogError as exc:
+        detail = f"branch target consistency failed: {exc}"
+        return tuple(
+            replace(
+                item,
+                action="blocked",
+                outcome=replace(
+                    item.outcome,
+                    status="blocked",
+                    detail=detail,
+                    stage="consistency",
+                ),
+            )
+            for item in prepared
+        )
+    return tuple(prepared)
+
+
 def prevalidate_repository(
     bundle: ReleaseBundle,
     workspace: Path,
@@ -1611,6 +1653,18 @@ def main(argv: list[str] | None = None) -> int:
                             actionlint=actionlint,
                         )
                     )
+
+        for repo in repos:
+            indexes = [
+                index for index, item in enumerate(prepared) if item.repo == repo
+            ]
+            checked = _block_inconsistent_prepared_targets(
+                bundle.config.profiles[repo],
+                bundle.ref,
+                tuple(prepared[index] for index in indexes),
+            )
+            for index, item in zip(indexes, checked):
+                prepared[index] = item
 
         if args.mode == "plan" or any(
             item.outcome.status == "blocked" for item in prepared

--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "gh_owner": "jhw7500",
   "automation_ref": "v1.51",
   "canonical_dir": "examples/baseline-workflows/.github",
@@ -14,7 +14,8 @@
         "opencode-auto-review.yml"
       ],
       "repo_write_auth": "github_app",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     },
     "max9296": {
       "profile": "common-ai-v1",
@@ -25,7 +26,8 @@
         "opencode-auto-review.yml"
       ],
       "repo_write_auth": "github_app",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     },
     "imx-vpu": {
       "profile": "common-ai-v1",
@@ -36,7 +38,8 @@
         "opencode-auto-review.yml"
       ],
       "repo_write_auth": "github_token",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     },
     "wlan-driver-v2": {
       "profile": "common-ai-v1",
@@ -46,7 +49,10 @@
         "opencode-auto-review.yml"
       ],
       "repo_write_auth": "github_app",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": [
+        "ported"
+      ]
     },
     "wlan-bridge": {
       "profile": "common-ai-v1",
@@ -56,7 +62,8 @@
         "opencode-auto-review.yml"
       ],
       "repo_write_auth": "github_app",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     },
     "wlan-package": {
       "profile": "common-ai-v1",
@@ -65,7 +72,8 @@
         "opencode-auto-review.yml"
       ],
       "repo_write_auth": "github_app",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     },
     "pim-package-jhw": {
       "profile": "common-ai-v1",
@@ -73,7 +81,8 @@
         "opencode-auto-review.yml"
       ],
       "repo_write_auth": "github_app",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     },
     "wlan-opc": {
       "profile": "common-ai-v1",
@@ -81,55 +90,64 @@
         "opencode.yml"
       ],
       "repo_write_auth": "github_token",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     },
     "pcap-analyzer": {
       "profile": "common-ai-v1",
       "optional_workflows": [],
       "repo_write_auth": "github_app",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     },
     "wpa-supplicant": {
       "profile": "common-ai-v1",
       "optional_workflows": [],
       "repo_write_auth": "github_token",
-      "bootstrap_allowed": true
+      "bootstrap_allowed": true,
+      "additional_branches": []
     },
     "sc16is7xx": {
       "profile": "common-ai-v1",
       "optional_workflows": [],
       "repo_write_auth": "github_app",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     },
     "pim-check": {
       "profile": "common-ai-v1",
       "optional_workflows": [],
       "repo_write_auth": "github_token",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     },
     "redmine": {
       "profile": "common-ai-v1",
       "optional_workflows": [],
       "repo_write_auth": "github_app",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     },
     "jhw-notion": {
       "profile": "common-ai-v1",
       "optional_workflows": [],
       "repo_write_auth": "github_app",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     },
     "personal-ops": {
       "profile": "common-ai-v1",
       "optional_workflows": [],
       "repo_write_auth": "github_app",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     },
     "claude-config": {
       "profile": "common-ai-v1",
       "optional_workflows": [],
       "repo_write_auth": "github_token",
-      "bootstrap_allowed": false
+      "bootstrap_allowed": false,
+      "additional_branches": []
     }
   }
 }

--- a/scripts/workflow_catalog.py
+++ b/scripts/workflow_catalog.py
@@ -106,6 +106,32 @@ def configured_branch_targets(profile: RepoProfile) -> tuple[str | None, ...]:
     return (None, *profile.additional_branches)
 
 
+def validate_resolved_branch_targets(
+    profile: RepoProfile,
+    resolved: tuple[tuple[str | None, str, str], ...],
+) -> None:
+    """Require configured branch targets to retain one unambiguous identity."""
+
+    expected = configured_branch_targets(profile)
+    if len(resolved) != len(expected):
+        raise CatalogError("branch target resolution is incomplete")
+    if tuple(item[0] for item in resolved) != expected:
+        raise CatalogError("branch target resolution does not match the configuration")
+    defaults = {item[1] for item in resolved}
+    bases = [item[2] for item in resolved]
+    if (
+        any(
+            not isinstance(value, str) or not value
+            for item in resolved
+            for value in item[1:]
+        )
+        or len(defaults) != 1
+        or len(set(bases)) != len(bases)
+        or any(target is not None and target == default for target, default, _ in resolved)
+    ):
+        raise CatalogError("branch target resolution is inconsistent")
+
+
 def _require_keys(value: dict[str, object], *, exact: set[str], where: str) -> None:
     actual = set(value)
     if actual != exact:

--- a/scripts/workflow_catalog.py
+++ b/scripts/workflow_catalog.py
@@ -157,6 +157,7 @@ def _additional_branches(value: object, where: str) -> tuple[str, ...]:
         components = branch.split("/")
         if (
             not branch
+            or branch == "@"
             or branch.startswith(("-", "/"))
             or branch.endswith(("/", "."))
             or "//" in branch

--- a/scripts/workflow_catalog.py
+++ b/scripts/workflow_catalog.py
@@ -90,6 +90,7 @@ class RepoProfile:
     optional_workflows: frozenset[str]
     repo_write_auth: Literal["github_app", "github_token"]
     bootstrap_allowed: bool
+    additional_branches: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -98,6 +99,11 @@ class FleetConfig:
     automation_ref: str
     canonical_dir: PurePosixPath
     profiles: Mapping[str, RepoProfile]
+
+
+def configured_branch_targets(profile: RepoProfile) -> tuple[str | None, ...]:
+    """Return the default branch followed by configured additional targets."""
+    return (None, *profile.additional_branches)
 
 
 def _require_keys(value: dict[str, object], *, exact: set[str], where: str) -> None:
@@ -139,6 +145,32 @@ def _string(value: object, where: str) -> str:
     if not isinstance(value, str):
         raise CatalogError(f"{where} must be a string")
     return value
+
+
+def _additional_branches(value: object, where: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not all(isinstance(branch, str) for branch in value):
+        raise CatalogError(f"{where} must be a string list")
+    if len(value) != len(set(value)):
+        raise CatalogError(f"{where} must be unique")
+    for branch in value:
+        forbidden = " ~^:?*[\\"
+        components = branch.split("/")
+        if (
+            not branch
+            or branch.startswith(("-", "/"))
+            or branch.endswith(("/", "."))
+            or "//" in branch
+            or ".." in branch
+            or "@{" in branch
+            or any(character in branch for character in forbidden)
+            or any(ord(character) < 32 or ord(character) == 127 for character in branch)
+            or any(
+                not component or component.startswith(".") or component.endswith(".lock")
+                for component in components
+            )
+        ):
+            raise CatalogError(f"{where}: invalid Git branch name: {branch!r}")
+    return tuple(value)
 
 
 def _jobs(value: object, where: str) -> tuple[CallerJobContract, ...]:
@@ -201,7 +233,8 @@ def load_catalog(root: Path) -> WorkflowCatalog:
 def load_fleet_config(root: Path, catalog: WorkflowCatalog) -> FleetConfig:
     raw = _mapping(_load_json(root / "scripts/workflow-config.json"), "fleet config")
     _require_keys(raw, exact={"schema_version", "gh_owner", "automation_ref", "canonical_dir", "catalog", "repos"}, where="fleet config")
-    if raw["schema_version"] != 1:
+    schema_version = raw["schema_version"]
+    if schema_version not in {1, 2}:
         raise CatalogError("unsupported fleet config schema")
     canonical_dir = PurePosixPath(_string(raw["canonical_dir"], "canonical_dir"))
     if canonical_dir != _CANONICAL_DIR:
@@ -219,7 +252,13 @@ def load_fleet_config(root: Path, catalog: WorkflowCatalog) -> FleetConfig:
     bootstrap: set[str] = set()
     for name, value in repos.items():
         profile = _mapping(value, f"repos.{name}")
-        _require_keys(profile, exact={"profile", "optional_workflows", "repo_write_auth", "bootstrap_allowed"}, where=f"repos.{name}")
+        _require_keys(
+            profile,
+            exact={"profile", "optional_workflows", "repo_write_auth", "bootstrap_allowed"}
+            if schema_version == 1
+            else {"profile", "optional_workflows", "repo_write_auth", "bootstrap_allowed", "additional_branches"},
+            where=f"repos.{name}",
+        )
         optional = profile["optional_workflows"]
         auth = profile["repo_write_auth"]
         allowed = profile["bootstrap_allowed"]
@@ -233,9 +272,14 @@ def load_fleet_config(root: Path, catalog: WorkflowCatalog) -> FleetConfig:
             raise CatalogError(f"repos.{name}: invalid repo_write_auth")
         if not isinstance(allowed, bool):
             raise CatalogError(f"repos.{name}.bootstrap_allowed must be boolean")
+        additional_branches = () if schema_version == 1 else _additional_branches(
+            profile["additional_branches"], f"repos.{name}.additional_branches"
+        )
         if allowed:
             bootstrap.add(name)
-        profiles[name] = RepoProfile(name, "common-ai-v1", frozenset(optional), auth, allowed)
+        profiles[name] = RepoProfile(
+            name, "common-ai-v1", frozenset(optional), auth, allowed, additional_branches
+        )
     if bootstrap != generation.bootstrap:
         raise CatalogError(f"invalid bootstrap repositories: {sorted(bootstrap)}")
     return FleetConfig(_string(raw["gh_owner"], "gh_owner"), _string(raw["automation_ref"], "automation_ref"), canonical_dir, profiles)

--- a/scripts/workflow_fleet_git.py
+++ b/scripts/workflow_fleet_git.py
@@ -226,6 +226,7 @@ def _validate_branch(branch: object) -> None:
     if (
         not isinstance(branch, str)
         or not branch
+        or branch == "@"
         or branch.startswith(("-", "/"))
         or branch.endswith(("/", "."))
         or "//" in branch

--- a/scripts/workflow_fleet_git.py
+++ b/scripts/workflow_fleet_git.py
@@ -468,7 +468,7 @@ def refetch_branch(snapshot: RepositorySnapshot) -> str:
             "fetch",
             "--no-recurse-submodules",
             "origin",
-            base_branch,
+            f"+refs/heads/{base_branch}:refs/remotes/origin/{base_branch}",
         ],
         cwd=path,
     )

--- a/scripts/workflow_fleet_git.py
+++ b/scripts/workflow_fleet_git.py
@@ -35,7 +35,9 @@ WORKSPACE_MARKER = ".automation-fleet-workspace"
 _REPO_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,99}\Z")
 _OBJECT_ID = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})\Z")
 _SHA1 = re.compile(r"[0-9a-f]{40}\Z")
-_ROLLOUT_BRANCH = re.compile(r"automation/common-workflows-v[0-9]+(?:\.[0-9]+)+\Z")
+_ROLLOUT_BRANCH = re.compile(
+    r"automation/common-workflows-(v[0-9]+(?:\.[0-9]+)+)(?:-([0-9a-f]{64}))?\Z"
+)
 _PULL_URL = re.compile(
     r"https://github\.com/jhw7500/([A-Za-z0-9][A-Za-z0-9._-]{0,99})/pull/([1-9][0-9]*)\Z"
 )
@@ -59,6 +61,7 @@ class RepositorySnapshot:
     base_sha: str
     secret_names: frozenset[str]
     variable_names: frozenset[str]
+    base_branch: str | None = None
 
 
 @dataclass(frozen=True)
@@ -99,10 +102,12 @@ __all__ = (
     "PullRequest",
     "RepositorySnapshot",
     "RolloutCommit",
+    "clone_branch",
     "clone_default_branch",
     "create_rollout_branch",
     "create_pull_request",
     "list_rollout_prs",
+    "refetch_branch",
     "refetch_default",
     "remote_branch_sha",
 )
@@ -216,11 +221,11 @@ def _validate_target(owner: str, repo: str) -> None:
         raise FleetGitError("repository name is invalid")
 
 
-def _validate_branch(branch: str) -> None:
+def _validate_branch(branch: object) -> None:
     forbidden = " ~^:?*[\\"
-    components = branch.split("/")
     if (
-        not branch
+        not isinstance(branch, str)
+        or not branch
         or branch.startswith(("-", "/"))
         or branch.endswith(("/", "."))
         or "//" in branch
@@ -228,10 +233,12 @@ def _validate_branch(branch: str) -> None:
         or "@{" in branch
         or any(character in branch for character in forbidden)
         or any(ord(character) < 32 or ord(character) == 127 for character in branch)
-        or any(
-            not component or component.startswith(".") or component.endswith(".lock")
-            for component in components
-        )
+    ):
+        raise FleetGitError("branch name is invalid")
+    components = branch.split("/")
+    if any(
+        not component or component.startswith(".") or component.endswith(".lock")
+        for component in components
     ):
         raise FleetGitError("branch name is invalid")
 
@@ -343,8 +350,15 @@ def _snapshot_repo(snapshot: RepositorySnapshot) -> tuple[str, Path]:
     repo = snapshot.path.name
     _validate_target(OWNER, repo)
     _validate_branch(snapshot.default_branch)
+    _snapshot_base_branch(snapshot)
     _validate_object_id(snapshot.base_sha)
     return repo, _validate_repository_path(snapshot.path, repo)
+
+
+def _snapshot_base_branch(snapshot: RepositorySnapshot) -> str:
+    branch = snapshot.default_branch if snapshot.base_branch is None else snapshot.base_branch
+    _validate_branch(branch)
+    return branch
 
 
 def _inventory(owner: str, repo: str, kind: str) -> frozenset[str]:
@@ -362,10 +376,14 @@ def _inventory(owner: str, repo: str, kind: str) -> frozenset[str]:
     return frozenset(names)
 
 
-def clone_default_branch(owner: str, repo: str, workspace: Path) -> RepositorySnapshot:
-    """Clone exactly one permitted repository and inventory prerequisite names."""
+def clone_branch(
+    owner: str, repo: str, workspace: Path, branch: str | None
+) -> RepositorySnapshot:
+    """Clone one permitted selected branch and inventory prerequisite names."""
 
     _validate_target(owner, repo)
+    if branch is not None:
+        _validate_branch(branch)
     workspace = _resolved_without_symlinks(workspace, "workspace")
     marker_mode: int | None = None
     try:
@@ -404,6 +422,7 @@ def clone_default_branch(owner: str, repo: str, workspace: Path) -> RepositorySn
         raise FleetGitError("GitHub returned malformed repository metadata")
     default_branch = default_ref["name"]
     _validate_branch(default_branch)
+    base_branch = default_branch if branch is None else branch
     clone_url = _clone_url(repo, metadata.get("url"))
 
     _git(
@@ -412,7 +431,7 @@ def clone_default_branch(owner: str, repo: str, workspace: Path) -> RepositorySn
             "--no-recurse-submodules",
             "--single-branch",
             "--branch",
-            default_branch,
+            base_branch,
             clone_url,
             str(target),
         ]
@@ -428,29 +447,45 @@ def clone_default_branch(owner: str, repo: str, workspace: Path) -> RepositorySn
         base_sha=base_sha,
         secret_names=secret_names,
         variable_names=variable_names,
+        base_branch=base_branch,
     )
 
 
-def refetch_default(snapshot: RepositorySnapshot) -> str:
-    """Fetch and return the current permitted origin's default-branch SHA."""
+def clone_default_branch(owner: str, repo: str, workspace: Path) -> RepositorySnapshot:
+    """Clone the reported default branch for compatibility callers."""
+
+    return clone_branch(owner, repo, workspace, None)
+
+
+def refetch_branch(snapshot: RepositorySnapshot) -> str:
+    """Fetch and return the current permitted origin's selected-base SHA."""
 
     repo, path = _snapshot_repo(snapshot)
+    base_branch = _snapshot_base_branch(snapshot)
     _verify_origin(path, repo)
     _git(
         [
             "fetch",
             "--no-recurse-submodules",
             "origin",
-            snapshot.default_branch,
+            base_branch,
         ],
         cwd=path,
     )
     return _validate_object_id(
         _git(
-            ["rev-parse", f"refs/remotes/origin/{snapshot.default_branch}"],
+            ["rev-parse", f"refs/remotes/origin/{base_branch}"],
             cwd=path,
         )
     )
+
+
+def refetch_default(snapshot: RepositorySnapshot) -> str:
+    """Fetch the default branch for compatibility callers."""
+
+    if _snapshot_base_branch(snapshot) != snapshot.default_branch:
+        raise FleetGitError("snapshot does not select the default branch")
+    return refetch_branch(snapshot)
 
 
 def remote_branch_sha(snapshot: RepositorySnapshot, branch: str) -> str | None:
@@ -550,7 +585,9 @@ def _validate_ref_response(
         raise FleetGitError("GitHub returned an invalid ref identity")
 
 
-def _validate_rollout_commit(commit: RolloutCommit, branch: str) -> None:
+def _validate_rollout_commit(
+    commit: RolloutCommit, ref: str, base_branch: str, default_branch: str
+) -> None:
     if (
         not isinstance(commit, RolloutCommit)
         or not isinstance(commit.message, str)
@@ -565,8 +602,11 @@ def _validate_rollout_commit(commit: RolloutCommit, branch: str) -> None:
         (commit.base_sha, "default commit identity"),
     ):
         _validate_sha1(value, description)
-    ref = branch.removeprefix("automation/common-workflows-")
     expected_message = f"ci: adopt common automation workflows ({ref})"
+    if base_branch != default_branch:
+        expected_message = (
+            f"ci: adopt common automation workflows ({ref}; base={base_branch})"
+        )
     raw_commit = (
         f"tree {commit.tree_sha}\n"
         f"parent {commit.base_sha}\n"
@@ -625,11 +665,19 @@ def create_rollout_branch(
     """Atomically create one exact rollout ref through the closed Git Data API."""
 
     _validate_branch(branch)
-    if _ROLLOUT_BRANCH.fullmatch(branch) is None or branch == snapshot.default_branch:
+    match = _ROLLOUT_BRANCH.fullmatch(branch)
+    if match is None or branch == snapshot.default_branch:
         raise FleetGitError("rollout branch publication is not permitted")
     repo, path = _snapshot_repo(snapshot)
+    base_branch = _snapshot_base_branch(snapshot)
+    ref, suffix = match.groups()
+    if base_branch == snapshot.default_branch:
+        if suffix is not None:
+            raise FleetGitError("rollout branch publication is not permitted")
+    elif suffix != hashlib.sha256(base_branch.encode("utf-8")).hexdigest():
+        raise FleetGitError("rollout branch publication is not permitted")
     _verify_origin(path, repo)
-    _validate_rollout_commit(commit, branch)
+    _validate_rollout_commit(commit, ref, base_branch, snapshot.default_branch)
     if commit.base_sha != snapshot.base_sha:
         raise FleetGitError("rollout base does not match the repository snapshot")
 

--- a/tests/test_audit_workflow_fleet.py
+++ b/tests/test_audit_workflow_fleet.py
@@ -86,21 +86,28 @@ def apply_bundle(repo: Path, bundle: ReleaseBundle, profile) -> None:
 def test_audit_classifies_content_not_history(
     repo: Path, bundle: ReleaseBundle, profile
 ) -> None:
-    result = audit_repository(repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES)
+    result = audit_repository(
+        repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main"
+    )
     assert result.status == "drift"
     assert result.repo == "gstApp"
+    assert result.base_branch == "main"
     assert result.changed_paths == tuple(sorted(result.changed_paths))
 
     apply_bundle(repo, bundle, profile)
     assert (
-        audit_repository(repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES).status
+        audit_repository(
+            repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main"
+        ).status
         == "current"
     )
     (repo / ".github/workflows/project-build.yml").write_text(
         "on: push\n", encoding="utf-8"
     )
     assert (
-        audit_repository(repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES).status
+        audit_repository(
+            repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main"
+        ).status
         == "current"
     )
 
@@ -111,7 +118,9 @@ def test_audit_reports_managed_byte_mismatch_as_drift(
     apply_bundle(repo, bundle, profile)
     managed = repo / ".github/workflows/claude.yml"
     managed.write_bytes(managed.read_bytes() + b"# drift\n")
-    result = audit_repository(repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES)
+    result = audit_repository(
+        repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main"
+    )
     assert result.status == "drift"
     assert ".github/workflows/claude.yml" in result.changed_paths
 
@@ -122,9 +131,12 @@ def test_audit_reports_unknown_or_malformed_content_as_blocked(
     (repo / ".github/workflows/unknown.yml").write_text(
         "jobs:\n  call:\n    uses: jhw7500/automation/.github/workflows/claude.yml@v1.40\n"
     )
-    result = audit_repository(repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES)
+    result = audit_repository(
+        repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main"
+    )
     assert result == AuditResult(
         "gstApp",
+        "main",
         "blocked",
         "unknown central caller path: .github/workflows/unknown.yml",
         (),
@@ -134,7 +146,9 @@ def test_audit_reports_unknown_or_malformed_content_as_blocked(
     (repo / ".github/workflow-config.yml").write_text(
         "automation_ref:\n  nested: value\n"
     )
-    result = audit_repository(repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES)
+    result = audit_repository(
+        repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main"
+    )
     assert result.status == "blocked"
     assert "automation_ref must be a scalar" in result.detail
 
@@ -142,7 +156,7 @@ def test_audit_reports_unknown_or_malformed_content_as_blocked(
 def test_audit_reports_missing_prerequisite_names_as_blocked(
     repo: Path, bundle: ReleaseBundle, profile
 ) -> None:
-    result = audit_repository(repo, bundle, profile, set(), set())
+    result = audit_repository(repo, bundle, profile, set(), set(), base_branch="main")
     assert result.status == "blocked"
     assert "missing secrets" in result.detail
     assert "missing variables" in result.detail
@@ -151,6 +165,7 @@ def test_audit_reports_missing_prerequisite_names_as_blocked(
 def test_audit_result_contains_no_history_or_publish_fields() -> None:
     assert set(AuditResult.__dataclass_fields__) == {
         "repo",
+        "base_branch",
         "status",
         "detail",
         "changed_paths",
@@ -168,25 +183,38 @@ def test_fleet_cli_audits_all_profiles_with_refetch_and_no_remote_write(
     tmp_path: Path, bundle: ReleaseBundle, capsys
 ) -> None:
     workspace = marked_workspace(tmp_path)
-    cloned: list[str] = []
-    fetched: list[str] = []
+    cloned: list[tuple[str, str | None, Path]] = []
+    fetched: list[tuple[str, str]] = []
+    marked_clone_roots: list[bool] = []
 
-    def clone(_owner: str, repo: str, root: Path) -> RepositorySnapshot:
-        cloned.append(repo)
+    def clone(
+        _owner: str, repo: str, root: Path, branch: str | None = None
+    ) -> RepositorySnapshot:
+        cloned.append((repo, branch, root))
+        marked_clone_roots.append((root / audit.WORKSPACE_MARKER).is_file())
         path = root / repo
         path.mkdir()
         (path / ".git").mkdir()
         return RepositorySnapshot(
-            path, "main", BASE, frozenset(ALL_SECRETS), frozenset(ALL_VARIABLES)
+            path,
+            "main",
+            BASE,
+            frozenset(ALL_SECRETS),
+            frozenset(ALL_VARIABLES),
+            branch or "main",
         )
 
     def refetch(snapshot: RepositorySnapshot) -> str:
-        fetched.append(snapshot.path.name)
+        fetched.append((snapshot.path.name, snapshot.base_branch or snapshot.default_branch))
         return BASE
 
-    def classify(path, _bundle, _profile, _secrets, _variables, **_kwargs):
+    def classify(path, _bundle, _profile, _secrets, _variables, *, base_branch, **_kwargs):
         return AuditResult(
-            path.name, "drift", "managed drift", (".github/workflows/claude.yml",)
+            path.name,
+            base_branch,
+            "drift",
+            "managed drift",
+            (".github/workflows/claude.yml",),
         )
 
     commands: list[list[str]] = []
@@ -197,7 +225,9 @@ def test_fleet_cli_audits_all_profiles_with_refetch_and_no_remote_write(
             side_effect=lambda *_a, **_k: nullcontext(bundle),
         ),
         mock.patch.object(audit.fleet_git, "clone_default_branch", side_effect=clone),
+        mock.patch.object(audit.fleet_git, "clone_branch", side_effect=clone),
         mock.patch.object(audit.fleet_git, "refetch_default", side_effect=refetch),
+        mock.patch.object(audit.fleet_git, "refetch_branch", side_effect=refetch),
         mock.patch.object(audit, "audit_repository", side_effect=classify),
         mock.patch.object(
             audit,
@@ -210,11 +240,21 @@ def test_fleet_cli_audits_all_profiles_with_refetch_and_no_remote_write(
         )
 
     assert rc == 0
-    assert cloned == sorted(bundle.config.profiles)
-    assert fetched == cloned
+    assert len(cloned) == 17
+    assert [(repo, branch) for repo, branch, _root in cloned] == [
+        (repo, branch)
+        for repo in sorted(bundle.config.profiles)
+        for branch in (None, "ported")
+        if repo == "wlan-driver-v2" or branch is None
+    ]
+    assert fetched == [(repo, branch or "main") for repo, branch, _root in cloned]
+    assert len({root for _repo, _branch, root in cloned}) == 17
+    assert all(marked_clone_roots)
     assert all(command[:2] == ["switch", "--detach"] for command in commands)
     output = capsys.readouterr().out
-    assert "total=16" in output and "drift=16" in output and "blocked=0" in output
+    assert "DRIFT   wlan-driver-v2[main]: managed drift" in output
+    assert "DRIFT   wlan-driver-v2[ported]: managed drift" in output
+    assert "total=17" in output and "drift=17" in output and "blocked=0" in output
     flattened = " ".join(" ".join(command) for command in commands)
     for forbidden in (
         "push",
@@ -232,11 +272,11 @@ def test_fleet_cli_selects_repositories_and_blocks_only_on_blocked(
 ) -> None:
     workspace = marked_workspace(tmp_path)
 
-    def clone(_owner: str, repo: str, root: Path) -> RepositorySnapshot:
+    def clone(_owner: str, repo: str, root: Path, branch: str | None = None) -> RepositorySnapshot:
         path = root / repo
         path.mkdir()
         (path / ".git").mkdir()
-        return RepositorySnapshot(path, "main", BASE, frozenset(), frozenset())
+        return RepositorySnapshot(path, "main", BASE, frozenset(), frozenset(), branch or "main")
 
     with (
         mock.patch.object(
@@ -245,13 +285,15 @@ def test_fleet_cli_selects_repositories_and_blocks_only_on_blocked(
             side_effect=lambda *_a, **_k: nullcontext(bundle),
         ),
         mock.patch.object(audit.fleet_git, "clone_default_branch", side_effect=clone),
+        mock.patch.object(audit.fleet_git, "clone_branch", side_effect=clone),
         mock.patch.object(audit.fleet_git, "refetch_default", return_value=BASE),
+        mock.patch.object(audit.fleet_git, "refetch_branch", return_value=BASE),
         mock.patch.object(audit, "git", return_value=""),
         mock.patch.object(
             audit,
             "audit_repository",
-            side_effect=lambda path, *_a, **_k: AuditResult(
-                path.name, "blocked", "missing names", ()
+            side_effect=lambda path, *_a, **kwargs: AuditResult(
+                path.name, kwargs["base_branch"], "blocked", "missing names", ()
             ),
         ),
     ):
@@ -268,6 +310,94 @@ def test_fleet_cli_selects_repositories_and_blocks_only_on_blocked(
             ]
         )
     assert rc == 1
+
+
+def test_selected_repository_audits_main_and_ported_and_ported_drift_prevents_all_current(
+    tmp_path: Path, bundle: ReleaseBundle, capsys
+) -> None:
+    """Catch a selected active branch silently omitted from an otherwise current audit."""
+
+    workspace = marked_workspace(tmp_path)
+
+    def clone(_owner: str, repo: str, root: Path, branch: str | None) -> RepositorySnapshot:
+        path = root / repo
+        path.mkdir()
+        (path / ".git").mkdir()
+        return RepositorySnapshot(
+            path, "main", BASE, frozenset(ALL_SECRETS), frozenset(ALL_VARIABLES), branch or "main"
+        )
+
+    def classify(path, _bundle, _profile, _secrets, _variables, *, base_branch, **_kwargs):
+        status = "drift" if base_branch == "ported" else "current"
+        return AuditResult(path.name, base_branch, status, f"{base_branch} {status}", ())
+
+    with (
+        mock.patch.object(
+            audit, "materialize_release_bundle", side_effect=lambda *_a, **_k: nullcontext(bundle)
+        ),
+        mock.patch.object(audit.fleet_git, "clone_branch", side_effect=clone),
+        mock.patch.object(audit.fleet_git, "refetch_branch", return_value=BASE),
+        mock.patch.object(audit, "audit_repository", side_effect=classify),
+        mock.patch.object(audit, "git", return_value=""),
+    ):
+        rc = audit.main(
+            [
+                "--automation", str(ROOT), "--workspace", str(workspace), "--ref", "v1.40",
+                "--repo", "wlan-driver-v2",
+            ]
+        )
+
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "CURRENT wlan-driver-v2[main]: main current" in output
+    assert "DRIFT   wlan-driver-v2[ported]: ported drift" in output
+    assert "total=2 current=1 drift=1 blocked=0" in output
+
+
+def test_target_clone_failure_blocks_only_the_exact_target_and_stays_in_totals(
+    tmp_path: Path, bundle: ReleaseBundle, capsys
+) -> None:
+    """Catch a target failure that suppresses another target or loses its branch identity."""
+
+    workspace = marked_workspace(tmp_path)
+
+    def clone(_owner: str, repo: str, root: Path, branch: str | None) -> RepositorySnapshot:
+        if branch == "ported":
+            raise audit.FleetGitError("ported fetch unavailable")
+        path = root / repo
+        path.mkdir()
+        (path / ".git").mkdir()
+        return RepositorySnapshot(
+            path, "main", BASE, frozenset(ALL_SECRETS), frozenset(ALL_VARIABLES), "main"
+        )
+
+    with (
+        mock.patch.object(
+            audit, "materialize_release_bundle", side_effect=lambda *_a, **_k: nullcontext(bundle)
+        ),
+        mock.patch.object(audit.fleet_git, "clone_branch", side_effect=clone),
+        mock.patch.object(audit.fleet_git, "refetch_branch", return_value=BASE),
+        mock.patch.object(
+            audit,
+            "audit_repository",
+            side_effect=lambda path, *_a, **kwargs: AuditResult(
+                path.name, kwargs["base_branch"], "current", "managed content matches", ()
+            ),
+        ),
+        mock.patch.object(audit, "git", return_value=""),
+    ):
+        rc = audit.main(
+            [
+                "--automation", str(ROOT), "--workspace", str(workspace), "--ref", "v1.40",
+                "--repo", "wlan-driver-v2",
+            ]
+        )
+
+    assert rc == 1
+    output = capsys.readouterr().out
+    assert "CURRENT wlan-driver-v2[main]: managed content matches" in output
+    assert "BLOCKED wlan-driver-v2[ported]: repository audit failed" in output
+    assert "total=2 current=1 drift=0 blocked=1" in output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_audit_workflow_fleet.py
+++ b/tests/test_audit_workflow_fleet.py
@@ -401,13 +401,16 @@ def test_target_clone_failure_blocks_only_the_exact_target_and_stays_in_totals(
     assert "total=2 current=1 drift=0 blocked=1" in output
 
 
-def test_unresolved_implicit_default_has_a_label_distinct_from_a_branch_named_default(
+def test_unresolved_implicit_default_has_a_label_distinct_from_a_valid_branch_named_like_the_old_sentinel(
     tmp_path: Path, bundle: ReleaseBundle, capsys
 ) -> None:
-    """Catch a failed implicit-default clone mislabeled as a real `default` branch."""
+    """Catch a failed implicit-default clone mislabeled as a valid configured branch."""
 
     workspace = marked_workspace(tmp_path)
-    profile = replace(bundle.config.profiles["gstApp"], additional_branches=("default",))
+    profile = replace(
+        bundle.config.profiles["gstApp"],
+        additional_branches=("<default-unresolved>",),
+    )
     scenario_bundle = replace(
         bundle,
         config=replace(bundle.config, profiles={**bundle.config.profiles, "gstApp": profile}),
@@ -449,8 +452,8 @@ def test_unresolved_implicit_default_has_a_label_distinct_from_a_branch_named_de
 
     assert rc == 1
     output = capsys.readouterr().out
-    assert "BLOCKED gstApp[<default-unresolved>]: repository audit failed" in output
-    assert "CURRENT gstApp[default]: managed content matches" in output
+    assert "BLOCKED gstApp[default:unresolved]: repository audit failed" in output
+    assert "CURRENT gstApp[<default-unresolved>]: managed content matches" in output
     assert "total=2 current=1 drift=0 blocked=1" in output
 
 

--- a/tests/test_audit_workflow_fleet.py
+++ b/tests/test_audit_workflow_fleet.py
@@ -510,6 +510,67 @@ def test_target_refetch_failure_blocks_only_ported_and_keeps_main_visible(
 
 
 @pytest.mark.parametrize(
+    "defaults,labels",
+    [
+        ({None: "ported", "ported": "ported"}, ("default:ported", "ported")),
+        ({None: "main", "ported": "trunk"}, ("default:main", "ported")),
+    ],
+)
+def test_inconsistent_resolved_targets_are_blocked_without_hiding_target_rows(
+    tmp_path: Path,
+    bundle: ReleaseBundle,
+    capsys,
+    defaults: dict[str | None, str],
+    labels: tuple[str, str],
+) -> None:
+    """Catch audits that call duplicate or metadata-split targets all current."""
+
+    workspace = marked_workspace(tmp_path)
+
+    def clone(_owner: str, repo: str, root: Path, branch: str | None) -> RepositorySnapshot:
+        path = root / repo
+        path.mkdir()
+        (path / ".git").mkdir()
+        default_branch = defaults[branch]
+        return RepositorySnapshot(
+            path,
+            default_branch,
+            BASE,
+            frozenset(ALL_SECRETS),
+            frozenset(ALL_VARIABLES),
+            default_branch if branch is None else branch,
+        )
+
+    with (
+        mock.patch.object(
+            audit, "materialize_release_bundle", side_effect=lambda *_a, **_k: nullcontext(bundle)
+        ),
+        mock.patch.object(audit.fleet_git, "clone_branch", side_effect=clone),
+        mock.patch.object(audit.fleet_git, "refetch_branch", return_value=BASE),
+        mock.patch.object(
+            audit,
+            "audit_repository",
+            side_effect=lambda path, *_a, **kwargs: AuditResult(
+                path.name, kwargs["base_branch"], "current", "managed content matches", ()
+            ),
+        ),
+        mock.patch.object(audit, "git", return_value=""),
+    ):
+        rc = audit.main(
+            [
+                "--automation", str(ROOT), "--workspace", str(workspace), "--ref", "v1.40",
+                "--repo", "wlan-driver-v2",
+            ]
+        )
+
+    assert rc == 1
+    output = capsys.readouterr().out
+    assert f"BLOCKED wlan-driver-v2[{labels[0]}]:" in output
+    assert f"BLOCKED wlan-driver-v2[{labels[1]}]:" in output
+    assert "total=2 current=0 drift=0 blocked=2" in output
+
+
+@pytest.mark.parametrize(
     "args",
     [
         ["push", "origin", "main"],

--- a/tests/test_audit_workflow_fleet.py
+++ b/tests/test_audit_workflow_fleet.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
+from dataclasses import replace
 import json
 from pathlib import Path
 from unittest import mock
@@ -394,6 +395,111 @@ def test_target_clone_failure_blocks_only_the_exact_target_and_stays_in_totals(
         )
 
     assert rc == 1
+    output = capsys.readouterr().out
+    assert "CURRENT wlan-driver-v2[main]: managed content matches" in output
+    assert "BLOCKED wlan-driver-v2[ported]: repository audit failed" in output
+    assert "total=2 current=1 drift=0 blocked=1" in output
+
+
+def test_unresolved_implicit_default_has_a_label_distinct_from_a_branch_named_default(
+    tmp_path: Path, bundle: ReleaseBundle, capsys
+) -> None:
+    """Catch a failed implicit-default clone mislabeled as a real `default` branch."""
+
+    workspace = marked_workspace(tmp_path)
+    profile = replace(bundle.config.profiles["gstApp"], additional_branches=("default",))
+    scenario_bundle = replace(
+        bundle,
+        config=replace(bundle.config, profiles={**bundle.config.profiles, "gstApp": profile}),
+    )
+
+    def clone(_owner: str, repo: str, root: Path, branch: str | None) -> RepositorySnapshot:
+        if branch is None:
+            raise audit.FleetGitError("default metadata unavailable")
+        path = root / repo
+        path.mkdir()
+        (path / ".git").mkdir()
+        return RepositorySnapshot(
+            path, "main", BASE, frozenset(ALL_SECRETS), frozenset(ALL_VARIABLES), branch
+        )
+
+    with (
+        mock.patch.object(
+            audit,
+            "materialize_release_bundle",
+            side_effect=lambda *_a, **_k: nullcontext(scenario_bundle),
+        ),
+        mock.patch.object(audit.fleet_git, "clone_branch", side_effect=clone),
+        mock.patch.object(audit.fleet_git, "refetch_branch", return_value=BASE),
+        mock.patch.object(
+            audit,
+            "audit_repository",
+            side_effect=lambda path, *_a, **kwargs: AuditResult(
+                path.name, kwargs["base_branch"], "current", "managed content matches", ()
+            ),
+        ),
+        mock.patch.object(audit, "git", return_value=""),
+    ):
+        rc = audit.main(
+            [
+                "--automation", str(ROOT), "--workspace", str(workspace), "--ref", "v1.40",
+                "--repo", "gstApp",
+            ]
+        )
+
+    assert rc == 1
+    output = capsys.readouterr().out
+    assert "BLOCKED gstApp[<default-unresolved>]: repository audit failed" in output
+    assert "CURRENT gstApp[default]: managed content matches" in output
+    assert "total=2 current=1 drift=0 blocked=1" in output
+
+
+def test_target_refetch_failure_blocks_only_ported_and_keeps_main_visible(
+    tmp_path: Path, bundle: ReleaseBundle, capsys
+) -> None:
+    """Catch a post-clone ported refetch failure that hides the current main target."""
+
+    workspace = marked_workspace(tmp_path)
+    cloned: list[str] = []
+
+    def clone(_owner: str, repo: str, root: Path, branch: str | None) -> RepositorySnapshot:
+        cloned.append(branch or "main")
+        path = root / repo
+        path.mkdir()
+        (path / ".git").mkdir()
+        return RepositorySnapshot(
+            path, "main", BASE, frozenset(ALL_SECRETS), frozenset(ALL_VARIABLES), branch or "main"
+        )
+
+    def refetch(snapshot: RepositorySnapshot) -> str:
+        if snapshot.base_branch == "ported":
+            raise audit.FleetGitError("ported refetch unavailable")
+        return BASE
+
+    with (
+        mock.patch.object(
+            audit, "materialize_release_bundle", side_effect=lambda *_a, **_k: nullcontext(bundle)
+        ),
+        mock.patch.object(audit.fleet_git, "clone_branch", side_effect=clone),
+        mock.patch.object(audit.fleet_git, "refetch_branch", side_effect=refetch),
+        mock.patch.object(
+            audit,
+            "audit_repository",
+            side_effect=lambda path, *_a, **kwargs: AuditResult(
+                path.name, kwargs["base_branch"], "current", "managed content matches", ()
+            ),
+        ),
+        mock.patch.object(audit, "git", return_value=""),
+    ):
+        rc = audit.main(
+            [
+                "--automation", str(ROOT), "--workspace", str(workspace), "--ref", "v1.40",
+                "--repo", "wlan-driver-v2",
+            ]
+        )
+
+    assert rc == 1
+    assert cloned == ["main", "ported"]
     output = capsys.readouterr().out
     assert "CURRENT wlan-driver-v2[main]: managed content matches" in output
     assert "BLOCKED wlan-driver-v2[ported]: repository audit failed" in output

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -74,6 +74,7 @@ def outcome(repo: str, status: str = "planned") -> rollout.RepoOutcome:
         detail="one managed file differs",
         base_sha=BASE,
         changed_paths=(".github/workflows/claude.yml",),
+        base_branch="main",
     )
 
 
@@ -89,7 +90,9 @@ def prepared(repo: str, status: str = "planned") -> rollout.PreparedRepo:
         frozenset({"CLAUDE_CODE_OAUTH_TOKEN"}),
         frozenset(),
     )
-    return rollout.PreparedRepo(repo, "create_branch", outcome(repo, status), plan)
+    return rollout.PreparedRepo(
+        repo, "create_branch", outcome(repo, status), plan, "main", None, "main"
+    )
 
 
 def fake_bundle_context(bundle: ReleaseBundle):
@@ -417,6 +420,63 @@ def test_blocked_ported_prevalidation_prevents_all_selected_publication(
         ("gstApp", None),
     ]
     publish.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "default_by_target",
+    [
+        {None: "ported", "ported": "ported"},
+        {None: "main", "ported": "trunk"},
+    ],
+)
+def test_inconsistent_resolved_targets_block_the_repository_before_publication(
+    tmp_path: Path,
+    bundle: ReleaseBundle,
+    default_by_target: dict[str | None, str],
+) -> None:
+    """Catch target clones that collapse or disagree before the global publish gate."""
+
+    workspace = marked_workspace(tmp_path)
+
+    def prevalidate(*_args, repo: str, base_branch: str | None, **_kwargs):
+        default_branch = default_by_target[base_branch]
+        selected_base = default_branch if base_branch is None else base_branch
+        return rollout.PreparedRepo(
+            repo,
+            "create_branch",
+            rollout.RepoOutcome(
+                repo, "planned", "ready", BASE, base_branch=selected_base
+            ),
+            None,
+            selected_base,
+            base_branch,
+            default_branch,
+        )
+
+    with (
+        mock.patch.object(
+            rollout,
+            "materialize_release_bundle",
+            side_effect=lambda *_a, **_k: fake_bundle_context(bundle),
+        ),
+        mock.patch.object(rollout, "prevalidate_repository", side_effect=prevalidate),
+        mock.patch.object(
+            rollout,
+            "publish_repository",
+            return_value=rollout.RepoOutcome("wlan-driver-v2", "published", "ready"),
+        ) as publish,
+    ):
+        rc = rollout.main(
+            [
+                "--mode", "publish", "--confirm", "--workspace", str(workspace),
+                "--repo", "wlan-driver-v2",
+            ]
+        )
+
+    assert rc == 1
+    publish.assert_not_called()
+    manifest = json.loads((workspace / "rollout-manifest.json").read_text())
+    assert [item["status"] for item in manifest] == ["blocked", "blocked"]
 
 
 @pytest.mark.parametrize(
@@ -1035,9 +1095,9 @@ def test_main_journals_actual_fresh_stage_failure_after_prevalidation_base_moves
             "prevalidate_repository",
             return_value=prepared("gstApp"),
         ),
-        mock.patch.object(rollout.fleet_git, "clone_default_branch", return_value=snap),
+        mock.patch.object(rollout.fleet_git, "clone_branch", return_value=snap),
         mock.patch.object(
-            rollout.fleet_git, "refetch_default", return_value=FRESH_BASE
+            rollout.fleet_git, "refetch_branch", return_value=FRESH_BASE
         ),
         mock.patch.object(rollout, "git", return_value=""),
         mock.patch.object(rollout, "_render", side_effect=render),

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
-from dataclasses import fields
+from dataclasses import fields, replace
 import json
 from pathlib import Path, PurePosixPath
 import subprocess
@@ -106,6 +106,7 @@ def test_public_report_model_and_exact_release_text() -> None:
         "pr_url",
         "changed_paths",
         "stage",
+        "base_branch",
     ]
     assert rollout.rollout_branch("v1.40") == "automation/common-workflows-v1.40"
     assert rollout.rollout_branch("v2.3.4") == "automation/common-workflows-v2.3.4"
@@ -118,6 +119,155 @@ def test_public_report_model_and_exact_release_text() -> None:
         "Project-specific workflows are unchanged. This PR does not modify secrets. "
         "Merge and recovery use this repository's normal GitHub controls.\n"
     )
+
+
+def test_ported_identity_binds_the_head_title_body_and_pr_base(
+    tmp_path: Path,
+) -> None:
+    """Catch a rollout that reuses the default identity for an active port."""
+
+    digest = "8b6809aa4897b8f29d43ba741152d8c90bd46f96c609af9fc5daaee8e5348ea5"
+    branch = f"automation/common-workflows-v1.40-{digest}"
+    title = "ci: adopt common automation workflows (v1.40; base=ported)"
+    changed = (".github/workflows/claude.yml",)
+    body = (
+        "Standardize only the catalogued common AI workflow callers.\n\n"
+        "- automation tag: `v1.40`\n"
+        f"- automation commit: `{COMMIT}`\n"
+        "- base branch: `ported`\n"
+        "- managed paths:\n- `.github/workflows/claude.yml`\n\n"
+        "Project-specific workflows are unchanged. This PR does not modify secrets. "
+        "Merge and recovery use this repository's normal GitHub controls.\n"
+    )
+    snap = replace(snapshot(tmp_path), base_branch="ported")
+    request = PullRequest(
+        7,
+        "https://github.com/jhw7500/gstApp/pull/7",
+        "OPEN",
+        "ported",
+        branch,
+        "jhw7500/gstApp",
+        HEAD,
+        title,
+        body,
+    )
+    plan = RenderPlan(
+        "drift",
+        "managed bytes differ",
+        (
+            FileChange(
+                PurePosixPath(".github/workflows/claude.yml"), b"old\n", b"new\n"
+            ),
+        ),
+        frozenset(),
+        frozenset(),
+    )
+
+    assert rollout.rollout_branch("v1.40", "ported", "main") == branch
+    assert rollout.pr_title("v1.40", "ported", "main") == title
+    assert rollout.pr_body("v1.40", COMMIT, changed, "ported", "main") == body
+    with (
+        mock.patch.object(rollout.fleet_git, "remote_branch_sha", return_value=HEAD),
+        mock.patch.object(rollout, "validate_existing_branch"),
+        mock.patch.object(rollout.fleet_git, "list_rollout_prs", return_value=(request,)),
+    ):
+        assert (
+            rollout.inspect_rollout(snap, BASE, "v1.40", COMMIT, plan).action
+            == "reuse"
+        )
+
+
+def test_selected_profile_expands_default_and_ported_before_publication(
+    tmp_path: Path, bundle: ReleaseBundle
+) -> None:
+    """Catch an operator selection that silently skips the configured port."""
+
+    workspace = marked_workspace(tmp_path)
+    checked: list[tuple[str, str | None]] = []
+    published: list[tuple[str, str | None]] = []
+
+    def prevalidate(*_args, repo: str, base_branch: str | None, **_kwargs):
+        checked.append((repo, base_branch))
+        exact_base = "main" if base_branch is None else base_branch
+        return rollout.PreparedRepo(
+            repo,
+            "create_branch",
+            rollout.RepoOutcome(repo, "planned", "ready", BASE, base_branch=exact_base),
+            None,
+            exact_base,
+            base_branch,
+        )
+
+    def publish(*_args, repo: str, base_branch: str | None, **_kwargs):
+        published.append((repo, base_branch))
+        exact_base = "main" if base_branch is None else base_branch
+        return rollout.RepoOutcome(
+            repo, "published", "ready", BASE, base_branch=exact_base
+        )
+
+    with (
+        mock.patch.object(
+            rollout,
+            "materialize_release_bundle",
+            side_effect=lambda *_a, **_k: fake_bundle_context(bundle),
+        ),
+        mock.patch.object(rollout, "prevalidate_repository", side_effect=prevalidate),
+        mock.patch.object(rollout, "publish_repository", side_effect=publish),
+    ):
+        assert rollout.main(
+            [
+                "--mode", "publish", "--confirm", "--workspace", str(workspace),
+                "--repo", "wlan-driver-v2",
+            ]
+        ) == 0
+
+    assert checked == [("wlan-driver-v2", None), ("wlan-driver-v2", "ported")]
+    assert published == checked
+
+
+def test_blocked_ported_prevalidation_prevents_all_selected_publication(
+    tmp_path: Path, bundle: ReleaseBundle
+) -> None:
+    """Catch publication starting before every expanded branch target is gated."""
+
+    workspace = marked_workspace(tmp_path)
+    checked: list[tuple[str, str | None]] = []
+
+    def prevalidate(*_args, repo: str, base_branch: str | None, **_kwargs):
+        checked.append((repo, base_branch))
+        exact_base = "main" if base_branch is None else base_branch
+        status = "blocked" if base_branch == "ported" else "planned"
+        return rollout.PreparedRepo(
+            repo,
+            "blocked" if status == "blocked" else "create_branch",
+            rollout.RepoOutcome(repo, status, "ported is blocked", BASE, base_branch=exact_base),
+            None,
+            exact_base,
+            base_branch,
+        )
+
+    with (
+        mock.patch.object(
+            rollout,
+            "materialize_release_bundle",
+            side_effect=lambda *_a, **_k: fake_bundle_context(bundle),
+        ),
+        mock.patch.object(rollout, "prevalidate_repository", side_effect=prevalidate),
+        mock.patch.object(rollout, "publish_repository") as publish,
+    ):
+        assert rollout.main(
+            [
+                "--mode", "publish", "--confirm", "--workspace", str(workspace),
+                "--repo", "wlan-driver-v2", "--repo", "gstApp",
+            ]
+        ) == 1
+
+    assert checked == [
+        ("wlan-driver-v2", None),
+        ("wlan-driver-v2", "ported"),
+        ("gstApp", None),
+    ]
+    publish.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -1366,6 +1516,7 @@ def test_real_mode_only_drift_is_planned_audited_and_published_as_a_repair(
     published = rollout._prepared_outcome(
         snap.path.name,
         base,
+        snap.base_branch or snap.default_branch,
         plan,
         rollout.RolloutInspection("create_branch"),
     )
@@ -1381,7 +1532,10 @@ def test_real_mode_only_drift_is_planned_audited_and_published_as_a_repair(
     )
     rollout.validate_commit_tree(snap, constructed.head_sha, base, plan)
     rollout.fleet_git._validate_rollout_commit(
-        constructed, rollout.rollout_branch(bundle.ref)
+        constructed,
+        bundle.ref,
+        snap.base_branch or snap.default_branch,
+        snap.default_branch,
     )
     assert tree_entry(snap.path, constructed.head_sha, relative)[:2] == (
         "100644",
@@ -1658,7 +1812,10 @@ def test_local_commit_identity_matches_atomic_api_commit_contract(
     )
 
     rollout.fleet_git._validate_rollout_commit(
-        constructed, "automation/common-workflows-v1.40"
+        constructed,
+        "v1.40",
+        snap.base_branch or snap.default_branch,
+        snap.default_branch,
     )
 
 

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -177,6 +177,154 @@ def test_ported_identity_binds_the_head_title_body_and_pr_base(
         )
 
 
+def test_ported_commit_matches_the_task2_branch_publication_contract(
+    tmp_path: Path, bundle: ReleaseBundle
+) -> None:
+    """Catch a ported rollout commit that Task 2 would reject."""
+
+    snap, plan = initialized_repository(tmp_path)
+    ported = replace(snap, base_branch="ported")
+
+    constructed = rollout.construct_rollout_commit(
+        ported, ported.base_sha, "v1.40", plan, bundle.catalog
+    )
+
+    rollout.fleet_git._validate_rollout_commit(
+        constructed, "v1.40", "ported", "main"
+    )
+    assert constructed.message == "ci: adopt common automation workflows (v1.40; base=ported)"
+    assert rollout.rollout_branch("v1.40", "ported", "main") == (
+        "automation/common-workflows-v1.40-"
+        "8b6809aa4897b8f29d43ba741152d8c90bd46f96c609af9fc5daaee8e5348ea5"
+    )
+
+
+def test_ported_pr_creation_and_attestation_bind_the_exact_base(
+    tmp_path: Path, bundle: ReleaseBundle
+) -> None:
+    """Catch a ported publication that creates or attests a PR against main."""
+
+    workspace = marked_workspace(tmp_path)
+    snap = replace(snapshot(workspace), base_branch="ported")
+    plan = make_plan()
+    branch = rollout.rollout_branch(bundle.ref, "ported", "main")
+    body = rollout.pr_body(
+        bundle.ref,
+        bundle.commit,
+        rollout._changed_paths(plan),
+        "ported",
+        "main",
+    )
+    request = PullRequest(
+        7,
+        "https://github.com/jhw7500/gstApp/pull/7",
+        "OPEN",
+        "ported",
+        branch,
+        "jhw7500/gstApp",
+        HEAD,
+        rollout.pr_title(bundle.ref, "ported", "main"),
+        body,
+    )
+    created_bases: list[str] = []
+
+    def create_pr(_owner, _repo, base, *_args):
+        created_bases.append(base)
+        return request
+
+    with (
+        mock.patch.object(
+            rollout, "_make_clone_workspace", return_value=nullcontext(str(workspace))
+        ),
+        mock.patch.object(rollout.fleet_git, "clone_branch", return_value=snap),
+        mock.patch.object(rollout.fleet_git, "refetch_branch", return_value=BASE),
+        mock.patch.object(rollout, "git", return_value=""),
+        mock.patch.object(rollout, "_render", return_value=plan),
+        mock.patch.object(rollout, "validate_managed_result"),
+        mock.patch.object(
+            rollout,
+            "inspect_rollout",
+            return_value=rollout.RolloutInspection("create_pr", HEAD),
+        ),
+        mock.patch.object(rollout.fleet_git, "create_pull_request", side_effect=create_pr),
+        mock.patch.object(rollout.fleet_git, "remote_branch_sha", return_value=HEAD),
+        mock.patch.object(rollout.fleet_git, "list_rollout_prs", return_value=(request,)),
+    ):
+        result = rollout.publish_repository(
+            bundle,
+            workspace,
+            repo="gstApp",
+            base_branch="ported",
+            prevalidated_default_branch="main",
+            bootstrap=False,
+            actionlint=Path("/bin/true"),
+        )
+
+    assert result.status == "published"
+    assert result.base_branch == "ported"
+    assert created_bases == ["ported"]
+
+
+def test_direct_additional_target_bootstrap_is_rejected(
+    tmp_path: Path, bundle: ReleaseBundle
+) -> None:
+    """Catch bootstrap rendering on a configured additional branch."""
+
+    workspace = marked_workspace(tmp_path)
+    snap = replace(snapshot(workspace), base_branch="ported")
+    with (
+        mock.patch.object(rollout.fleet_git, "clone_branch", return_value=snap),
+        mock.patch.object(rollout.fleet_git, "refetch_branch", return_value=BASE),
+        mock.patch.object(rollout, "_render") as render,
+        mock.patch.object(rollout, "git") as local_git,
+    ):
+        result = rollout.prevalidate_repository(
+            bundle,
+            workspace,
+            repo="gstApp",
+            base_branch="ported",
+            bootstrap=True,
+            actionlint=Path("/bin/true"),
+        )
+
+    assert result.outcome.status == "blocked"
+    assert result.outcome.base_branch == "ported"
+    render.assert_not_called()
+    local_git.assert_not_called()
+
+
+def test_default_metadata_change_after_prevalidation_blocks_publication_before_mutation(
+    tmp_path: Path, bundle: ReleaseBundle
+) -> None:
+    """Catch a default target republished after its repository default changed."""
+
+    workspace = marked_workspace(tmp_path)
+    fresh = replace(snapshot(workspace), default_branch="trunk", base_branch="main")
+    with (
+        mock.patch.object(rollout, "_make_clone_workspace", return_value=nullcontext(str(workspace))),
+        mock.patch.object(rollout.fleet_git, "clone_branch", return_value=fresh),
+        mock.patch.object(rollout.fleet_git, "refetch_branch") as refetch,
+        mock.patch.object(rollout.fleet_git, "create_rollout_branch") as create_branch,
+        mock.patch.object(rollout.fleet_git, "create_pull_request") as create_pr,
+    ):
+        result = rollout.publish_repository(
+            bundle,
+            workspace,
+            repo="gstApp",
+            base_branch="main",
+            prevalidated_default_branch="main",
+            bootstrap=False,
+            actionlint=Path("/bin/true"),
+        )
+
+    assert result.status == "blocked"
+    assert result.base_branch == "main"
+    assert "prevalidated" in result.detail
+    refetch.assert_not_called()
+    create_branch.assert_not_called()
+    create_pr.assert_not_called()
+
+
 def test_selected_profile_expands_default_and_ported_before_publication(
     tmp_path: Path, bundle: ReleaseBundle
 ) -> None:
@@ -196,6 +344,7 @@ def test_selected_profile_expands_default_and_ported_before_publication(
             None,
             exact_base,
             base_branch,
+            "main",
         )
 
     def publish(*_args, repo: str, base_branch: str | None, **_kwargs):
@@ -222,7 +371,7 @@ def test_selected_profile_expands_default_and_ported_before_publication(
         ) == 0
 
     assert checked == [("wlan-driver-v2", None), ("wlan-driver-v2", "ported")]
-    assert published == checked
+    assert published == [("wlan-driver-v2", "main"), ("wlan-driver-v2", "ported")]
 
 
 def test_blocked_ported_prevalidation_prevents_all_selected_publication(

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -5,7 +5,12 @@ from pathlib import Path, PurePosixPath
 
 import pytest
 
-from scripts.workflow_catalog import CatalogError, load_catalog, load_fleet_config
+from scripts.workflow_catalog import (
+    CatalogError,
+    configured_branch_targets,
+    load_catalog,
+    load_fleet_config,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -77,6 +82,55 @@ def test_catalog_and_profiles_are_closed() -> None:
             "opened", "synchronize", "ready_for_review",
         ]
         assert "review_mode" in entry.caller_jobs[0].with_keys
+
+
+def test_live_configures_ordered_additional_branch_targets() -> None:
+    config = load_fleet_config(ROOT, load_catalog(ROOT))
+
+    assert config.profiles["wlan-driver-v2"].additional_branches == ("ported",)
+    assert configured_branch_targets(config.profiles["wlan-driver-v2"]) == (None, "ported")
+    for name, profile in config.profiles.items():
+        if name != "wlan-driver-v2":
+            assert profile.additional_branches == ()
+            assert configured_branch_targets(profile) == (None,)
+
+
+def test_schema_one_config_remains_default_only(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    for filename in ("workflow-catalog.json", "workflow-config.json"):
+        (scripts / filename).write_text((ROOT / "scripts" / filename).read_text())
+    config_path = scripts / "workflow-config.json"
+    config = json.loads(config_path.read_text())
+    config["schema_version"] = 1
+    for profile in config["repos"].values():
+        profile.pop("additional_branches")
+    config_path.write_text(json.dumps(config))
+
+    fleet = load_fleet_config(tmp_path, load_catalog(tmp_path))
+    assert all(profile.additional_branches == () for profile in fleet.profiles.values())
+
+
+@pytest.mark.parametrize("additional_branches", [
+    ["ported", "ported"],
+    ["ported", 1],
+    [""],
+    ["-invalid"],
+])
+def test_schema_two_rejects_invalid_additional_branches(
+    tmp_path: Path, additional_branches: list[object]
+) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    for filename in ("workflow-catalog.json", "workflow-config.json"):
+        (scripts / filename).write_text((ROOT / "scripts" / filename).read_text())
+    config_path = scripts / "workflow-config.json"
+    config = json.loads(config_path.read_text())
+    config["repos"]["wlan-driver-v2"]["additional_branches"] = additional_branches
+    config_path.write_text(json.dumps(config))
+
+    with pytest.raises(CatalogError):
+        load_fleet_config(tmp_path, load_catalog(tmp_path))
 
 
 def _write(root: Path, catalog: list[dict], repos: dict[str, dict]) -> None:

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -5,6 +5,7 @@ from pathlib import Path, PurePosixPath
 
 import pytest
 
+from scripts import workflow_catalog
 from scripts.workflow_catalog import (
     CatalogError,
     configured_branch_targets,
@@ -93,6 +94,24 @@ def test_live_configures_ordered_additional_branch_targets() -> None:
         if name != "wlan-driver-v2":
             assert profile.additional_branches == ()
             assert configured_branch_targets(profile) == (None,)
+
+
+@pytest.mark.parametrize(
+    "resolved",
+    [
+        ((None, "ported", "ported"), ("ported", "ported", "ported")),
+        ((None, "main", "main"), ("ported", "trunk", "ported")),
+    ],
+)
+def test_resolved_targets_fail_closed_on_duplicate_or_changing_default_metadata(
+    resolved: tuple[tuple[str | None, str, str], ...]
+) -> None:
+    """Catch configured targets that collapse or disagree after repository lookup."""
+
+    profile = load_fleet_config(ROOT, load_catalog(ROOT)).profiles["wlan-driver-v2"]
+
+    with pytest.raises(workflow_catalog.CatalogError, match="branch target"):
+        workflow_catalog.validate_resolved_branch_targets(profile, resolved)
 
 
 def test_schema_one_config_remains_default_only(tmp_path: Path) -> None:

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -116,6 +116,7 @@ def test_schema_one_config_remains_default_only(tmp_path: Path) -> None:
     ["ported", 1],
     [""],
     ["-invalid"],
+    ["@"],
 ])
 def test_schema_two_rejects_invalid_additional_branches(
     tmp_path: Path, additional_branches: list[object]

--- a/tests/test_workflow_fleet_git.py
+++ b/tests/test_workflow_fleet_git.py
@@ -574,7 +574,12 @@ def test_refetch_default_uses_origin_tracking_ref(
     assert calls == [
         ["remote", "get-url", "--all", "origin"],
         ["remote", "get-url", "--push", "--all", "origin"],
-        ["fetch", "--no-recurse-submodules", "origin", "main"],
+        [
+            "fetch",
+            "--no-recurse-submodules",
+            "origin",
+            "+refs/heads/main:refs/remotes/origin/main",
+        ],
         ["rev-parse", "refs/remotes/origin/main"],
     ]
 
@@ -602,9 +607,74 @@ def test_refetch_branch_uses_selected_base_origin_tracking_ref(
     assert calls == [
         ["remote", "get-url", "--all", "origin"],
         ["remote", "get-url", "--push", "--all", "origin"],
-        ["fetch", "--no-recurse-submodules", "origin", "ported"],
+        [
+            "fetch",
+            "--no-recurse-submodules",
+            "origin",
+            "+refs/heads/ported:refs/remotes/origin/ported",
+        ],
         ["rev-parse", "refs/remotes/origin/ported"],
     ]
+
+
+def test_refetch_branch_advances_selected_origin_tracking_ref(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def git(*args: str, cwd: Path | None = None) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+
+    remote = tmp_path / "remote.git"
+    source = tmp_path / "source"
+    root = tmp_path / "workspace"
+    source.mkdir()
+    root.mkdir()
+    workspace(root)
+    git("init", "--bare", "-q", str(remote))
+    git("init", "-q", "-b", "main", cwd=source)
+    git("config", "user.name", "Fleet Test", cwd=source)
+    git("config", "user.email", "fleet-test@example.invalid", cwd=source)
+    (source / "tracked.txt").write_text("main\n", encoding="utf-8")
+    git("add", "tracked.txt", cwd=source)
+    git("commit", "-q", "-m", "main", cwd=source)
+    git("remote", "add", "origin", str(remote), cwd=source)
+    git("push", "-q", "origin", "main", cwd=source)
+    git("switch", "-q", "-c", "ported", cwd=source)
+    (source / "tracked.txt").write_text("ported one\n", encoding="utf-8")
+    git("commit", "-qam", "ported one", cwd=source)
+    git("push", "-q", "-u", "origin", "ported", cwd=source)
+
+    clone = root / "repo"
+    git("clone", "-q", "--single-branch", "--branch", "ported", str(remote), str(clone))
+    before = git("rev-parse", "refs/remotes/origin/ported", cwd=clone)
+    git(
+        "config",
+        "--replace-all",
+        "remote.origin.fetch",
+        "+refs/heads/main:refs/remotes/origin/main",
+        cwd=clone,
+    )
+    (source / "tracked.txt").write_text("ported two\n", encoding="utf-8")
+    git("commit", "-qam", "ported two", cwd=source)
+    expected = git("rev-parse", "HEAD", cwd=source)
+    git("push", "-q", "origin", "ported", cwd=source)
+    item = workflow_fleet_git.RepositorySnapshot(
+        path=clone,
+        default_branch="main",
+        base_sha=before,
+        secret_names=frozenset(),
+        variable_names=frozenset(),
+        base_branch="ported",
+    )
+    monkeypatch.setattr(workflow_fleet_git, "_verify_origin", lambda *_args: None)
+
+    assert workflow_fleet_git.refetch_branch(item) == expected
+    assert git("rev-parse", "refs/remotes/origin/ported", cwd=clone) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_workflow_fleet_git.py
+++ b/tests/test_workflow_fleet_git.py
@@ -34,12 +34,14 @@ def object_oid(kind: str, payload: bytes) -> str:
     ).hexdigest()
 
 
-def atomic_publication_values(base_sha: str = SHA) -> dict[str, object]:
+def atomic_publication_values(
+    base_sha: str = SHA,
+    message: str = "ci: adopt common automation workflows (v1.40)",
+) -> dict[str, object]:
     content = b"name: managed\n"
     blob_sha = object_oid("blob", content)
     base_tree_sha = "4" * 40
     tree_sha = "5" * 40
-    message = "ci: adopt common automation workflows (v1.40)"
     commit_payload = (
         f"tree {tree_sha}\n"
         f"parent {base_sha}\n"
@@ -132,6 +134,7 @@ def raw_snapshot(path: Path) -> workflow_fleet_git.RepositorySnapshot:
         base_sha=SHA,
         secret_names=frozenset({"A_SECRET"}),
         variable_names=frozenset({"A_VARIABLE"}),
+        base_branch="main",
     )
 
 
@@ -357,6 +360,7 @@ def test_clone_reads_only_metadata_and_prerequisite_names(
         base_sha=SHA,
         secret_names=frozenset({"CLAUDE_CODE_OAUTH_TOKEN"}),
         variable_names=frozenset({"APP_ID"}),
+        base_branch="main",
     )
     clone = next(
         git_payload(args) for args, _ in calls if args[0] == "git" and "clone" in args
@@ -399,6 +403,90 @@ def test_clone_reads_only_metadata_and_prerequisite_names(
             "name",
         ],
     ]
+
+
+def test_clone_branch_retains_repository_default_and_selected_base(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = workspace(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        if args[:3] == ["gh", "repo", "view"]:
+            return completed(
+                args,
+                json.dumps(
+                    {
+                        "defaultBranchRef": {"name": "main"},
+                        "url": "https://github.com/jhw7500/wlan-package",
+                    }
+                ),
+            )
+        if args[:3] in (["gh", "secret", "list"], ["gh", "variable", "list"]):
+            return completed(args, "[]")
+        payload = git_payload(args)
+        if payload[0] == "clone":
+            Path(payload[-1]).mkdir()
+            (Path(payload[-1]) / ".git").mkdir()
+            return completed(args)
+        if payload in [
+            ["remote", "get-url", "--all", "origin"],
+            ["remote", "get-url", "--push", "--all", "origin"],
+        ]:
+            return completed(args, "https://github.com/jhw7500/wlan-package.git\n")
+        if payload == ["rev-parse", "HEAD"]:
+            return completed(args, SHA)
+        raise AssertionError(args)
+
+    monkeypatch.setattr(workflow_fleet_git.subprocess, "run", fake_run)
+
+    result = workflow_fleet_git.clone_branch(
+        "jhw7500", "wlan-package", root, "ported"
+    )
+
+    assert result.default_branch == "main"
+    assert result.base_branch == "ported"
+    assert next(
+        git_payload(args)
+        for args in calls
+        if args[0] == "git" and "clone" in args
+    ) == [
+        "clone",
+        "--no-recurse-submodules",
+        "--single-branch",
+        "--branch",
+        "ported",
+        "https://github.com/jhw7500/wlan-package.git",
+        str(root / "wlan-package"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"url": "https://github.com/jhw7500/repo"},
+        {"defaultBranchRef": None, "url": "https://github.com/jhw7500/repo"},
+        {
+            "defaultBranchRef": {"name": "bad branch"},
+            "url": "https://github.com/jhw7500/repo",
+        },
+    ],
+)
+def test_clone_branch_rejects_missing_or_malformed_default_branch_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, metadata: dict[str, object]
+) -> None:
+    monkeypatch.setattr(
+        workflow_fleet_git.subprocess,
+        "run",
+        lambda args, **kwargs: completed(args, json.dumps(metadata)),
+    )
+
+    with pytest.raises(
+        workflow_fleet_git.FleetGitError,
+        match="malformed repository metadata|branch name is invalid",
+    ):
+        workflow_fleet_git.clone_branch("jhw7500", "repo", workspace(tmp_path), "ported")
 
 
 @pytest.mark.parametrize(
@@ -491,6 +579,34 @@ def test_refetch_default_uses_origin_tracking_ref(
     ]
 
 
+def test_refetch_branch_uses_selected_base_origin_tracking_ref(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(git_payload(args))
+        if calls[-1] in [
+            ["remote", "get-url", "--all", "origin"],
+            ["remote", "get-url", "--push", "--all", "origin"],
+        ]:
+            return completed(args, "https://github.com/jhw7500/repo.git")
+        if calls[-1] == ["rev-parse", "refs/remotes/origin/ported"]:
+            return completed(args, HEAD_SHA)
+        return completed(args)
+
+    monkeypatch.setattr(workflow_fleet_git.subprocess, "run", fake_run)
+    item = replace(snapshot(tmp_path / "repo"), base_branch="ported")
+
+    assert workflow_fleet_git.refetch_branch(item) == HEAD_SHA
+    assert calls == [
+        ["remote", "get-url", "--all", "origin"],
+        ["remote", "get-url", "--push", "--all", "origin"],
+        ["fetch", "--no-recurse-submodules", "origin", "ported"],
+        ["rev-parse", "refs/remotes/origin/ported"],
+    ]
+
+
 @pytest.mark.parametrize(
     ("output", "expected"),
     [("", None), (f"{HEAD_SHA}\trefs/heads/release\n", HEAD_SHA)],
@@ -520,6 +636,40 @@ def test_remote_branch_sha_is_read_only(
         == expected
     )
     assert calls[-1] == ["ls-remote", "--heads", "origin", "refs/heads/release"]
+
+
+def test_additional_base_rollout_identity_requires_its_exact_digest_and_commit_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base_branch = "ported"
+    digest = hashlib.sha256(base_branch.encode("utf-8")).hexdigest()
+    branch = f"automation/common-workflows-v1.40-{digest}"
+    message = f"ci: adopt common automation workflows (v1.40; base={base_branch})"
+    item = replace(snapshot(tmp_path / "repo"), base_branch=base_branch)
+    values = atomic_publication_values(message=message)
+
+    monkeypatch.setattr(workflow_fleet_git, "_verify_origin", lambda *_args: None)
+    monkeypatch.setattr(
+        workflow_fleet_git,
+        "_github_post",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("reached GitHub API")),
+    )
+
+    with pytest.raises(RuntimeError, match="reached GitHub API"):
+        workflow_fleet_git.create_rollout_branch(
+            item, branch, commit=rollout_commit(values)
+        )
+
+    for invalid_branch, invalid_message in (
+        (f"automation/common-workflows-v1.40-{'0' * 64}", message),
+        ("automation/common-workflows-v1.40", message),
+        (branch, "ci: adopt common automation workflows (v1.40)"),
+    ):
+        invalid_values = atomic_publication_values(message=invalid_message)
+        with pytest.raises(workflow_fleet_git.FleetGitError):
+            workflow_fleet_git.create_rollout_branch(
+                item, invalid_branch, commit=rollout_commit(invalid_values)
+            )
 
 
 def test_atomic_rollout_branch_creation_uses_only_literal_git_data_post_schemas(
@@ -1316,10 +1466,12 @@ def test_adapter_exposes_no_merge_revert_or_prerequisite_write_api() -> None:
         "PullRequest",
         "RepositorySnapshot",
         "RolloutCommit",
+        "clone_branch",
         "clone_default_branch",
         "create_pull_request",
         "create_rollout_branch",
         "list_rollout_prs",
+        "refetch_branch",
         "refetch_default",
         "remote_branch_sha",
     }

--- a/tests/test_workflow_fleet_git.py
+++ b/tests/test_workflow_fleet_git.py
@@ -471,6 +471,10 @@ def test_clone_branch_retains_repository_default_and_selected_base(
             "defaultBranchRef": {"name": "bad branch"},
             "url": "https://github.com/jhw7500/repo",
         },
+        {
+            "defaultBranchRef": {"name": "@"},
+            "url": "https://github.com/jhw7500/repo",
+        },
     ],
 )
 def test_clone_branch_rejects_missing_or_malformed_default_branch_metadata(


### PR DESCRIPTION
## Summary
- add schema-v2 additional branch targets while preserving schema-v1 default-only behavior
- bind clone, refetch, rollout identity, PR reuse/attestation, and manifests to the exact selected base
- audit and prevalidate the same 17 configured targets with fail-closed consistency checks
- document historical v1.40.1 behavior separately from the first post-merge multi-branch release

## Validation
- release verifier: 646 passed
- workflow YAML parser: 30 files parsed
- actionlint 1.7.12: verified archive digest and lint passed
- full pytest: 2869 passed, 48 subtests passed
- independent full-range review: no Critical, Important, or Minor findings

## Scope
- no release or consumer rollout is performed by this PR
- issue #52 and Notion are unchanged

Fixes #76