### PR TITLE
fix(review): expose filtered OpenCode candidate artifact

### DIFF
--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -383,7 +383,7 @@ jobs:
           PREV_SUCCESSFUL_HEAD="$(printf '%s\n' "$PREV_RECORD" | jq -r '.state.successful_head // ""')"
           PREV_FULL_HASH="$(printf '%s\n' "$PREV_RECORD" | jq -r '.state.full_diff_sha256 // ""')"
           # Reserved workflow-owned text is never model input, even from a validated record.
-          PREV_REVIEW="$(printf '%s\n' "$PREV_REVIEW" | grep -vE '^(## OpenCode Review \(latest\)|<!-- automation:|<!-- automation-state:|- Status: |- Run: |- Reviewed: |- Validation: |- Last attempt: )' || true)"
+          PREV_REVIEW="$(printf '%s\n' "$PREV_REVIEW" | grep -vE '^(## OpenCode Review \(latest\)|<!-- automation:|<!-- automation-state:|- Status: |- Run: |- Reviewed: |- Validation: |- Filtered candidate \(raw\): |- Last attempt: )' || true)"
           # A first failure has no checkpoint and must not become re-review context. A stale
           # failure is useful only when it retained a validated successful checkpoint/body.
           if ! [[ "$PREV_SUCCESSFUL_HEAD" =~ ^[0-9a-f]{40}$ ]] \
@@ -399,7 +399,7 @@ jobs:
             '[.[] | select((.user.type // "") != "Bot")] | .[-10:]
              | map("@" + (.user.login // "ghost") + " (" + (.created_at // "") + "):\n" + ((.body // "") | .[0:1500]))
              | join("\n\n---\n\n")' "$COMMENTS" \
-            | grep -vE '^(## OpenCode Review \(latest\)|<!-- automation:|<!-- automation-state:|- Status: |- Run: |- Reviewed: |- Validation: |- Last attempt: )' || true)"
+            | grep -vE '^(## OpenCode Review \(latest\)|<!-- automation:|<!-- automation-state:|- Status: |- Run: |- Reviewed: |- Validation: |- Filtered candidate \(raw\): |- Last attempt: )' || true)"
 
           clip() {
             local text="$1"
@@ -4040,7 +4040,7 @@ jobs:
               }
               return true;
             };
-            const reserved = /^(## OpenCode Review \(latest\)|<!-- automation:|<!-- automation-candidate:|<!-- automation-state:|- Status: (success|failure|stale)$|- Run: https?:\/\/\S+$|- Attestation: [1-9][0-9]*$|- Reviewed: [0-9a-f]{40}$|- Validation: filtered_invalid_new_findings=[1-9][0-9]*; reasons=[a-z_,]+$|- Last attempt: failure \(https?:\/\/\S+\)$|- Reason: [a-z_]+$)/;
+            const reserved = /^(## OpenCode Review \(latest\)|<!-- automation:|<!-- automation-candidate:|<!-- automation-state:|- Status: (success|failure|stale)$|- Run: https?:\/\/\S+$|- Attestation: [1-9][0-9]*$|- Reviewed: [0-9a-f]{40}$|- Validation: filtered_invalid_new_findings=[1-9][0-9]*; reasons=[a-z_,]+$|- Filtered candidate \(raw\): artifact `opencode-candidate-[1-9][0-9]*-[1-9][0-9]*` → `review\.md`$|- Last attempt: failure \(https?:\/\/\S+\)$|- Reason: [a-z_]+$)/;
             const clean = (body) => {
               const rawLines = (body || '').split('\n');
               // OpenCode can include tool/thinking traces in the final text event. Only an exact
@@ -4740,12 +4740,15 @@ jobs:
             const validationSummary = modelSucceeded && filteredNewFindings.length > 0
               ? `\n- Validation: filtered_invalid_new_findings=${filteredNewFindings.length}; reasons=${filteredReasons}`
               : '';
+            const filteredCandidateSummary = modelSucceeded && filteredNewFindings.length > 0
+              ? `\n- Filtered candidate (raw): artifact \`opencode-candidate-${runId}-${runAttempt}\` → \`review.md\``
+              : '';
             const retainedNewFindingCount = parsedReview
               ? parsedReview.blocks.filter((entry) => entry.section === 'New findings'
                 && !filteredEntries.has(entry)).length : 0;
             const qualityFiltered = modelSucceeded && filteredNewFindings.length > 0
               && retainedNewFindingCount === 0;
-            const bodyFor = (attestationId) => `${header}\n${marker}\n<!-- automation-state:${JSON.stringify(state)} -->\n${legacyMarker}\n\n- Status: ${status}\n- Run: ${process.env.RUN_URL}\n- Attestation: ${attestationId}${succeeded ? `\n- Reviewed: ${attemptHead}` : ''}${validationSummary}${!succeeded ? `\n- Last attempt: failure (${process.env.RUN_URL})\n- Reason: ${failureReason}` : ''}\n\n${displayBody}`;
+            const bodyFor = (attestationId) => `${header}\n${marker}\n<!-- automation-state:${JSON.stringify(state)} -->\n${legacyMarker}\n\n- Status: ${status}\n- Run: ${process.env.RUN_URL}\n- Attestation: ${attestationId}${succeeded ? `\n- Reviewed: ${attemptHead}` : ''}${validationSummary}${filteredCandidateSummary}${!succeeded ? `\n- Last attempt: failure (${process.env.RUN_URL})\n- Reason: ${failureReason}` : ''}\n\n${displayBody}`;
             if (Buffer.byteLength(bodyFor(Number.MAX_SAFE_INTEGER), 'utf8') > 65536) {
               throw new Error('canonical OpenCode comment exceeds 65,536-byte publication limit');
             }

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -384,7 +384,11 @@ removed, whose line is not an actual added-side line, or whose quoted current li
 omitted with reason `anchor_out_of_scope`. Valid blocks—including `[HIGH]` blocks—remain unchanged.
 If every new block is omitted, the canonical section becomes exactly `### New findings` followed by
 `None`; the successful attested comment reports `filtered_invalid_new_findings=N` and the sorted
-set of filtering reasons on its visible validation line. Git invocation or parsing failures, sealed
+set of filtering reasons on its visible validation line. Whenever that count is nonzero, the next
+line identifies the untrusted source as artifact `opencode-candidate-<run_id>-<run_attempt>` and
+file `review.md`; the adjacent run URL opens the Actions run that owns the artifact. The artifact is
+retained for one day, and this workflow-owned location line is excluded from later review context.
+Git invocation or parsing failures, sealed
 manifest inconsistencies, malformed document or section grammar, and invalid carryover or
 disposition evidence still fail the checkpoint without advancing `successful_head`.
 

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -664,12 +664,12 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256 = (
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
     "claude": "d34dfc388a393a6679bfd6a38ac281cc2c14a843063a010e9f1303c68df58cc7",
     "gemini": "54bbd6c197a74a6c0524509877a1bbe6b1918bc83d28b6c98605b63ec4bece7d",
-    "opencode": "c249bd40a072d74179f5313f4e53d8ef9817f05bbdbc1f0c0e94bf513af1d2ba",
+    "opencode": "c13a61cf3362586da6230f3de03f623fea8e50b9756f337408351c35d970c0f0",
 }
 EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256 = {
     "claude": "2950d9dbf0923dfc463a872e8602e4d73ba2457a0df90ca3cca228ffb661343a",
     "gemini": "0c00a267e7415c0f2d90ba538ee5432f1c1e78c29ab76c44472b44263e97aec8",
-    "opencode": "6a80a008783826618baed22c0675f354cdf7a1b845ef8f6aecd224f00f800249",
+    "opencode": "947600cb0ae3d0564a59ba03f8eccc4b5fa991138b280152c24e18e61ecc25a2",
 }
 EXPECTED_REVIEW_POLICY_HELPER_SHA256 = (
     "3e0fd3c86b1dc40dc35213ca41c3d63122c9ebf757042f5a2c86f4fc1e99ac8a"
@@ -6864,6 +6864,32 @@ def _verify_commit_content(
             and repair_call > body_limit_gate
             and canonical_script.count("if (!(await repairComments())) return;") == 1
         )
+        filtered_candidate_location_contract = (
+            "const filteredCandidateSummary = modelSucceeded "
+            "&& filteredNewFindings.length > 0"
+            in canonical_script
+            and canonical_script.count(
+                "? `\\n- Filtered candidate (raw): artifact "
+                "\\`opencode-candidate-${runId}-${runAttempt}\\` → "
+                "\\`review.md\\``"
+            )
+            == 1
+            and (
+                "${validationSummary}${filteredCandidateSummary}"
+                "${!succeeded"
+            )
+            in canonical_script
+            and (
+                "- Filtered candidate \\(raw\\): artifact "
+                "`opencode-candidate-[1-9][0-9]*-[1-9][0-9]*` → "
+                "`review\\.md`$"
+            )
+            in canonical_script
+            and prepare_script.count(
+                "|- Filtered candidate \\(raw\\): |"
+            )
+            == 2
+        )
         artifact_contract = (
             prepare.get("permissions") == expected_prepare
             and canonical.get("permissions") == expected_canonical
@@ -6928,6 +6954,7 @@ def _verify_commit_content(
             and canonical_anchor_contract
             and (canonical_removed_contract or approved_legacy_opencode_release)
             and canonical_pre_mutation_size_contract
+            and (filtered_candidate_location_contract if budget_release else True)
             and "github.rest.checks.create" in canonical_script
             and "github.rest.checks.update" in canonical_script
             and "github.rest.actions.listWorkflowRunsForRepo" in canonical_script

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -14801,6 +14801,7 @@ def test_opencode_changed_anchor_scope_accepts_none_or_anchored_findings(tmp_pat
     assert state["attempt_status"] == "success"
     assert state["diff_mode"] == "full"
     assert state["successful_head"] == state["attempt_head"]
+    assert "- Filtered candidate (raw):" not in body
 
 
 @node_required
@@ -14838,6 +14839,10 @@ def test_opencode_filters_out_of_scope_new_finding_but_keeps_valid_high(tmp_path
     assert (
         "- Validation: filtered_invalid_new_findings=1; "
         "reasons=anchor_out_of_scope"
+    ) in body
+    assert (
+        "- Filtered candidate (raw): artifact "
+        "`opencode-candidate-42-1` → `review.md`"
     ) in body
 
 
@@ -14946,6 +14951,11 @@ def test_opencode_all_out_of_scope_new_findings_becomes_clean_success(tmp_path):
         "- Validation: filtered_invalid_new_findings=2; "
         "reasons=anchor_out_of_scope"
     ) in body
+    filtered_candidate_location = (
+        "- Filtered candidate (raw): artifact "
+        "`opencode-candidate-42-1` → `review.md`"
+    )
+    assert filtered_candidate_location in body
 
     canonical, receipt = _opencode_published_from_calls(calls)
     next_round = tmp_path / "next-round"
@@ -14955,6 +14965,54 @@ def test_opencode_all_out_of_scope_new_findings_becomes_clean_success(tmp_path):
     )
     assert "### New findings\nNone" in context
     assert "filtered_invalid_new_findings" not in context
+    assert "Filtered candidate (raw)" not in context
+
+
+@node_required
+def test_opencode_failed_retry_does_not_republish_prior_filtered_candidate_location(
+    tmp_path,
+):
+    anchor = json.dumps(
+        {"path": OPENCODE_SCOPE_PATH, "line": 1},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    candidate = _bot(
+        "github-actions[bot]",
+        (
+            f"{OPENCODE_MARKER}\n### New findings\n"
+            "#### [MEDIUM] Misquoted current source\n"
+            f"- Changed anchor: {anchor}\n"
+            '- Current line: "not the current added line"\n'
+            "The quoted source does not match the prepared diff."
+        ),
+        10,
+        updated="u2",
+    )
+    successful_calls = _run_opencode_canonicalize(tmp_path, [], [candidate])
+    canonical, receipt = _opencode_published_from_calls(successful_calls)
+    assert "- Filtered candidate (raw):" in canonical["body"]
+
+    retry = tmp_path / "failed-retry"
+    retry.mkdir()
+    failed_calls = _run_opencode_canonicalize(
+        retry,
+        [canonical],
+        [canonical],
+        run_id="43",
+        outcome="failure",
+        failure_reason="provider_failed",
+        check_runs=[receipt],
+    )
+    body = _single_mutation_body(failed_calls)
+    state = json.loads(
+        re.search(r"<!-- automation-state:(\{.*\}) -->", body).group(1)
+    )
+
+    assert state["attempt_status"] == "failure"
+    assert state["successful_head"] is not None
+    assert "- Status: stale" in body
+    assert "- Filtered candidate (raw):" not in body
 
 
 @node_required
@@ -15644,6 +15702,7 @@ def test_opencode_changed_anchor_scope_rejects_invalid_output_grammar(tmp_path, 
     state = json.loads(re.search(r"<!-- automation-state:(\{.*\}) -->", body).group(1))
     assert state["attempt_status"] == "failure"
     assert state["successful_head"] is None
+    assert "- Filtered candidate (raw):" not in body
 
 
 @node_required

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -1629,6 +1629,32 @@ def test_current_release_rejects_opencode_attestation_boundary_drift(
         release_verifier.verify_commit_content(repo, "v1.47", bad_commit)
 
 
+def test_v147_rejects_opencode_filtered_candidate_location_drift(
+    current_release_repo: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _ = current_release_repo
+    path = repo / ".github/workflows/opencode-auto-review.yml"
+    mutate_named_step_text(
+        path,
+        "Canonicalize OpenCode review",
+        "` → \\`review.md\\``",
+        "` → \\`filtered.md\\``",
+    )
+    bad_commit = commit(repo, "drift filtered OpenCode candidate location")
+    monkeypatch.setitem(
+        release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256,
+        "opencode",
+        hashlib.sha256(path.read_bytes()).hexdigest(),
+    )
+
+    with pytest.raises(
+        ReleaseVerificationError,
+        match="OpenCode sealed handoff/attestation contract is invalid",
+    ):
+        release_verifier.verify_commit_content(repo, "v1.47", bad_commit)
+
+
 def test_prepare_diff_capability_boundary_is_shared_with_release_inventory() -> None:
     capability = getattr(
         release_inventory, "release_supports_prepare_review_diff", None


### PR DESCRIPTION
## Summary

- show the exact OpenCode candidate artifact name and review.md path when findings are filtered
- keep the location out of clean, failure, stale, and next-round review context
- bind the v1.47+ release verifier contract and document the one-day artifact retention

## Validation

- python3 -m pytest -q: 2871 passed, 48 subtests passed
- OpenCode workflow tests: 1207 passed
- release verifier tests: 574 passed
- YAML parsing and git diff --check passed
- independent code review: ready to merge, no findings

Closes #74