### PR TITLE
chore(workflows): default rollout to v1.52

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.51",
+  "automation_ref": "v1.52",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.51"
+    assert config.automation_ref == "v1.52"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
Advance the fleet rollout default from immutable automation release v1.51 to verified annotated v1.52 (tag object 4bb3912d16c7ce5bfe95d1bd71685a897f3c5cc7, peeled commit 103db505b721bd5323272ccd3a93b182d5a8086a). The catalog expectation was changed first and failed against v1.51, then the config was advanced. Validation: 2871 passed, 48 subtests passed; release verifier PASS; fleet plan 16 planned, 0 blocked with jhw-notion deferred.