### PR TITLE
fix(review): keep the request-scoped caller run name

### DIFF
--- a/examples/baseline-workflows/.github/workflows/claude.yml
+++ b/examples/baseline-workflows/.github/workflows/claude.yml
@@ -1,4 +1,5 @@
 name: Claude Code
+run-name: jhw-review-comment-${{ github.event.comment.id || github.run_id }}
 
 on:
   issue_comment:

--- a/examples/baseline-workflows/.github/workflows/gemini-dispatch.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-dispatch.yml
@@ -1,4 +1,5 @@
 name: Gemini Dispatch
+run-name: jhw-review-comment-${{ github.event.comment.id || github.run_id }}
 
 on:
   pull_request_review_comment:

--- a/tests/test_canonical_workflow_tree.py
+++ b/tests/test_canonical_workflow_tree.py
@@ -40,6 +40,11 @@ SELF_REVIEW_MODE_EXPRESSION = " ".join(
 )
 
 
+ISSUE_RUN_NAME_VALUE = "jhw-review-comment-${{ github.event.comment.id || github.run_id }}"
+ISSUE_RUN_NAME_LINE = f"run-name: {ISSUE_RUN_NAME_VALUE}"
+ISSUE_RUN_NAME_CALLERS = ("claude.yml", "gemini-dispatch.yml")
+
+
 EXPECTED_WORKFLOW_NAMES = {
     "auto-rereview-request",
     "claude",
@@ -517,3 +522,16 @@ def test_self_auto_review_callers_forward_label_review_mode() -> None:
         assert " ".join(job["with"]["review_mode"].split()) == SELF_REVIEW_MODE_EXPRESSION
         assert "github.event.pull_request.draft == false" in job["if"]
         assert job["with"]["force_review"] == "false"
+
+
+def test_comment_callers_carry_the_request_scoped_run_name() -> None:
+    for filename in ISSUE_RUN_NAME_CALLERS:
+        path = CANONICAL / "workflows" / filename
+        matches = [
+            line
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if re.sub(r"\s+#.*$", "", line) == ISSUE_RUN_NAME_LINE
+        ]
+
+        assert len(matches) == 1, filename
+        assert load_yaml(path)["run-name"] == ISSUE_RUN_NAME_VALUE, filename

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -53,6 +53,11 @@ HERMETIC_REMOTE_GIT_ENV = {
     "GIT_PROTOCOL_FROM_USER": "0",
     "GIT_CEILING_DIRECTORIES": "/",
 }
+REQUEST_SCOPED_RUN_NAME_LINE = (
+    "run-name: jhw-review-comment-${{ github.event.comment.id || github.run_id }}\n"
+)
+
+
 HARDENED_MANUAL_OUTPUT_BLOCK = """          write_output() {
             local name="$1"
             local value="$2"
@@ -138,6 +143,18 @@ def restore_historical_v140_manual_outputs(repo: Path) -> None:
     snapshot = fixture_root / "workflow-config-v1.40.json"
     (repo / "scripts/workflow-config.json").write_bytes(snapshot.read_bytes())
     root = repo / "examples/baseline-workflows/.github/workflows"
+    # 요청 범위 run-name 은 v1.40 이후에 추가됐다 — 정책 스냅샷 바이트를 맞추려면
+    # 태그 픽스처에서 그 줄을 제거해야 한다.
+    for filename in ("claude.yml", "gemini-dispatch.yml"):
+        path = root / filename
+        text = path.read_text(encoding="utf-8")
+        assert text.count(REQUEST_SCOPED_RUN_NAME_LINE) == 1, (
+            f"{filename} 에서 요청 범위 run-name 을 정확히 1회 찾지 못했습니다 — "
+            "라이브 워크플로우가 바뀌었으면 이 픽스처 상수를 함께 갱신하세요"
+        )
+        path.write_text(
+            text.replace(REQUEST_SCOPED_RUN_NAME_LINE, "", 1), encoding="utf-8"
+        )
     for filename in ("gemini-issue-triage.yml", "gemini-pr-review.yml"):
         path = root / filename
         text = path.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #86

## 문제

fleet 렌더러는 관리 워크플로를 통째로 재생성하므로, 소비자 저장소의 로컬 커스터마이즈는 롤아웃마다 소거된다. jhw-notion을 v1.52로 올리려던 롤아웃 PR(jhw7500/jhw-notion#102, 닫음)이 아래 줄을 삭제하는 것이 확인됐다.

```diff
 name: Claude Code
-run-name: jhw-review-comment-${{ github.event.comment.id || github.run_id }}
```

- `.github/workflows/claude.yml`
- `.github/workflows/gemini-dispatch.yml`

`/jhw:issue`가 이 줄에 결속돼 있다 (`jhw-notion:skills/claude/issue.md`).

- preflight(`:225`, `:251`): 검사 대상은 `claude.yml`·`gemini-dispatch.yml` 두 파일뿐이며, 해당 줄이 정확히 1개 없으면 `process.exit(1)`로 리뷰 요청을 거부한다.
- bounded review wait(`:636`, `:727`, `:830`): `display_title === jhw-review-comment-<request_comment_id>` 인 run만 그 요청의 acknowledgment/failure 좌표로 인정한다.

정본 베이스라인에는 이 줄이 없었으므로, 이것은 소비자의 로컬 문제가 아니라 베이스라인 누락이다. 나머지 15개 저장소도 같은 이유로 `/jhw:issue --review` preflight를 통과하지 못한다.

## 변경

정본 베이스라인의 두 comment-triggered caller에 `run-name:`을 추가한다. comment 이벤트가 아닌 실행에서는 `github.event.comment.id`가 비어 `github.run_id`로 폴백하므로 fleet 전체에 안전하다.

`gemini-chat.yml`·`opencode.yml`도 comment 트리거를 갖지만 skill 검사 대상이 아니므로 건드리지 않았다. 중앙 재사용 워크플로(`.github/workflows/{claude,gemini-dispatch}.yml`)는 `on: workflow_call`이라 `run-name` 좌표를 소유하지 않는다.

## 검증

- `tests/test_canonical_workflow_tree.py::test_comment_callers_carry_the_request_scoped_run_name` 추가 — 두 caller가 그 줄을 주석 제거 후 정확히 1회 보유하고 파싱된 `run-name` 값이 일치하는지 검사. **되돌림 확인**: 베이스라인 수정 전 실행 시 `AssertionError: claude.yml / assert 0 == 1`로 실패.
- `python3 -m pytest tests/test_canonical_workflow_tree.py -q` → 10 passed
- `actionlint 1.7.12 -shellcheck= -pyflakes=` (CI와 동일 경계, 다이제스트 `8aca8db9…` 검증) → exit 0

## 후속

머지 후 v1.53 릴리스 + fleet 롤아웃이 필요하다. jhw-notion drift(현재 v1.51 핀) 해소는 그 롤아웃으로 대체한다.
