### PR TITLE
chore(workflows): default rollout to v1.53

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.52",
+  "automation_ref": "v1.53",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.52"
+    assert config.automation_ref == "v1.53"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
v1.53 릴리스(태그 ffda72b4c4b03eaaef0c1890ba190f95fd24f618, commit 87b6e774aa67f2d280f1ce405c562dcb04e6b3d4)를 fleet 기본 핀으로 승격한다.

- 검증: `python3 -m scripts.verify_workflow_release --ref v1.53 --expected-commit 87b6e774…` → PASS
- 관련: #86 (PR #87 머지)