### PR TITLE
fix(review): preserve the rejected Gemini candidate

### DIFF
--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -1411,7 +1411,8 @@ jobs:
       # 거부된 후보의 원문이 없으면 프롬프트/포맷 회귀와 검증기 과잉을 구분할 수 없다.
       # 노출을 최소화하기 위해 거부된 라운드에서만, 진단과 같은 조건으로 보존한다.
       - name: Upload Gemini review candidate
-        if: ${{ always() && steps.review-budget-claim.outputs.allow-invocation == 'true' && steps.canonicalize-review.outcome != 'skipped' && steps.canonicalize-review.outputs.document-valid != 'true' }}
+        id: upload-candidate
+        if: ${{ always() && steps.review-budget-claim.outputs.allow-invocation == 'true' && steps.canonicalize-review.outcome != 'skipped' && steps.canonicalize-review.outputs.document-valid != 'true' && hashFiles('gemini_review.md') != '' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: gemini-candidate-${{ github.run_id }}-${{ github.run_attempt }}
@@ -1459,6 +1460,7 @@ jobs:
           NORMALIZED_COUNT: ${{ steps.canonicalize-review.outputs.normalized-count }}
           FILTERED_MAX_SEVERITY: ${{ steps.canonicalize-review.outputs.filtered-max-severity }}
           CANONICAL_FAILURE_REASON: ${{ steps.canonicalize-review.outputs.failure-reason }}
+          CANDIDATE_ARTIFACT: ${{ steps.upload-candidate.outcome }}
           BOT_LOGIN: ${{ steps.auth.outputs.bot-login }}
           AUTH_MODE: ${{ inputs.repo_write_auth }}
           PUBLISHER_APP_ID: ${{ inputs.publisher_app_id }}
@@ -1790,10 +1792,13 @@ jobs:
                 failureReason = 'candidate_oversize';
               }
             }
-            const candidatePointer =
-              invocationAllowed && canonicalOutcome !== 'skipped' && !documentValid
-                ? `\n\nCandidate (raw): artifact \`gemini-candidate-${runId}-${runAttempt}\``
-                : '';
+            // 업로드 스텝이 성공한 라운드에만 안내한다. 후보 파일이 없으면 그 스텝은
+            // skipped 이므로, 존재하지 않는 아티팩트를 가리키지 않는다.
+            const candidateUploaded =
+              (process.env.CANDIDATE_ARTIFACT || '').toLowerCase() === 'success';
+            const candidatePointer = candidateUploaded
+              ? `\n\nCandidate (raw): artifact \`gemini-candidate-${runId}-${runAttempt}\``
+              : '';
             const preserveSuccess = checkpointFailed && existing
               && sha1(existing.state.successful_head) && preservedProse.length > 0;
             const state = buildState(checkpointFailed, preserveSuccess);

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -1408,6 +1408,18 @@ jobs:
           previous-sha: ${{ steps.pr-details.outputs.previous_sha }}
           previous-review-file: ${{ steps.pr-details.outputs.previous_sha != '' && format('{0}/gemini-previous-review.md', runner.temp) || '' }}
 
+      # 거부된 후보의 원문이 없으면 프롬프트/포맷 회귀와 검증기 과잉을 구분할 수 없다.
+      # 노출을 최소화하기 위해 거부된 라운드에서만, 진단과 같은 조건으로 보존한다.
+      - name: Upload Gemini review candidate
+        if: ${{ always() && steps.review-budget-claim.outputs.allow-invocation == 'true' && steps.canonicalize-review.outcome != 'skipped' && steps.canonicalize-review.outputs.document-valid != 'true' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: gemini-candidate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ github.workspace }}/gemini_review.md
+          if-no-files-found: ignore
+          retention-days: 1
+          overwrite: false
+
       - name: Upload rejected Gemini review diagnostic
         if: ${{ always() && steps.review-budget-claim.outputs.allow-invocation == 'true' && steps.canonicalize-review.outcome != 'skipped' && steps.canonicalize-review.outputs.document-valid != 'true' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -1778,12 +1790,16 @@ jobs:
                 failureReason = 'candidate_oversize';
               }
             }
+            const candidatePointer =
+              invocationAllowed && canonicalOutcome !== 'skipped' && !documentValid
+                ? `\n\nCandidate (raw): artifact \`gemini-candidate-${runId}-${runAttempt}\``
+                : '';
             const preserveSuccess = checkpointFailed && existing
               && sha1(existing.state.successful_head) && preservedProse.length > 0;
             const state = buildState(checkpointFailed, preserveSuccess);
             const content = checkpointFailed
               ? (preserveSuccess ? preservedProse
-                : `### Error\n\nReason: ${failureReason}\n\nGemini review did not produce a valid covered review. (See run logs: ${runUrl})`)
+                : `### Error\n\nReason: ${failureReason}\n\nGemini review did not produce a valid covered review. (See run logs: ${runUrl})${candidatePointer}`)
               : successBody;
             const body = envelope(state, content);
             if (checkpointFailed && Buffer.byteLength(body, 'utf8') > 65536) {

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -470,11 +470,18 @@ body above 64,000 UTF-8 bytes. The second bound is checked after canonical JSON 
 escaping, before the canonical file is published, and reserves 1,536 bytes for the authenticated
 v3 sticky envelope under GitHub's 65,536-byte comment limit.
 After an attempted Claude or Gemini canonicalization that does not produce
-`document-valid=true`, the workflow uploads only the bounded schema-1
+`document-valid=true`, the workflow uploads the bounded schema-1
 `<reviewer>-review-result.json` as a uniquely named, non-overwriting diagnostic artifact for one
-day. The untrusted raw candidate is never uploaded: it may contain provider-echoed secrets and a
-workspace path could otherwise expose a checkout-seeded symlink target. A missing result is
-ignored. The diagnostic is not authority: neither the upsert program nor later review state or
+day. Gemini additionally uploads the rejected raw candidate as
+`gemini-candidate-<run>-<attempt>` under that same rejection-only condition and the same
+one-day, non-overwriting bound, because the structural code alone cannot separate a
+prompt/format regression from an over-strict validator. Claude never uploads its raw candidate.
+The Gemini upload is bounded to rejected rounds, whose text is by definition never published,
+and it stays untrusted provider output that no program reads: the upsert program never names or
+opens the raw file, and the failure comment cites only the artifact name. The workspace path is
+safe because the reset step removes it with `rm -f --` before generation and the canonicalizer
+runs only after that reset succeeds, so no checkout-seeded symlink target survives. A missing
+result is ignored. The diagnostic is not authority: neither the upsert program nor later review state or
 carryover reads it. For `ambiguous_document`, logs expose only a fixed structural diagnostic code
 such as `preamble`, `unknown_section_before_document`,
 `unknown_section_after_document`, or `invalid_finding_heading`; candidate text is never copied into

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -663,12 +663,12 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256 = (
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
     "claude": "d34dfc388a393a6679bfd6a38ac281cc2c14a843063a010e9f1303c68df58cc7",
-    "gemini": "54bbd6c197a74a6c0524509877a1bbe6b1918bc83d28b6c98605b63ec4bece7d",
+    "gemini": "16d400da3e074f3a4deb3c5c49089e300b61639aee239979235e63f1abc9c937",
     "opencode": "c13a61cf3362586da6230f3de03f623fea8e50b9756f337408351c35d970c0f0",
 }
 EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256 = {
     "claude": "2950d9dbf0923dfc463a872e8602e4d73ba2457a0df90ca3cca228ffb661343a",
-    "gemini": "0c00a267e7415c0f2d90ba538ee5432f1c1e78c29ab76c44472b44263e97aec8",
+    "gemini": "f20fc659d9023585cd3d2201d4fbe380e97c5796d0ea2bd442b9cf42457a51f1",
     "opencode": "947600cb0ae3d0564a59ba03f8eccc4b5fa991138b280152c24e18e61ecc25a2",
 }
 EXPECTED_REVIEW_POLICY_HELPER_SHA256 = (
@@ -1197,7 +1197,7 @@ REVIEW_PUBLICATION_CONTRACTS = {
             "cc81b9e370c357366a384a059c9d6e1fe02065f085985f30532b92410c49c43d"
         ),
         "upsert_sha256_v147": (
-            "b924753e8c9eda60ac3047dfc2c085ec4c56d62b2d6ad81a3ec979a3ff85e5f0"
+            "dcd3ae4370bc4048dce767d89755102f17d1bf97a503bc0b73b52cc7676d9047"
         ),
         "bot_login": "${{ steps.auth.outputs.bot-login }}",
         "auth_mode": "${{ inputs.repo_write_auth }}",
@@ -5940,6 +5940,32 @@ def _expected_rejected_review_diagnostic_upload_step(
     }
 
 
+def _expected_review_candidate_upload_step(
+    contract: dict[str, str],
+) -> dict[str, object]:
+    reviewer = contract["reviewer"]
+    return {
+        "name": f"Upload {reviewer.capitalize()} review candidate",
+        "if": (
+            "${{ always() "
+            "&& steps.review-budget-claim.outputs.allow-invocation == 'true' "
+            "&& steps.canonicalize-review.outcome != 'skipped' "
+            "&& steps.canonicalize-review.outputs.document-valid != 'true' }}"
+        ),
+        "uses": UPLOAD_ARTIFACT_ACTION,
+        "with": {
+            "name": (
+                f"{reviewer}-candidate-${{{{ github.run_id }}}}-"
+                "${{ github.run_attempt }}"
+            ),
+            "path": f"${{{{ github.workspace }}}}/{contract['raw']}",
+            "if-no-files-found": "ignore",
+            "retention-days": "1",
+            "overwrite": "false",
+        },
+    }
+
+
 def _verify_review_publication_contracts(
     documents: dict[str, dict], ref: str
 ) -> None:
@@ -5995,6 +6021,22 @@ def _verify_review_publication_contracts(
                 )
             ):
                 raise ValueError("rejected review diagnostic differs")
+            candidate_upload = None
+            if budget and contract["reviewer"] == "gemini":
+                candidate_upload = _named_step(
+                    job,
+                    f"Upload {contract['reviewer'].capitalize()} review candidate",
+                )
+                if candidate_upload != _expected_review_candidate_upload_step(
+                    contract
+                ):
+                    raise ValueError("review candidate upload differs")
+                if not (
+                    job["steps"].index(canonical_step)
+                    < job["steps"].index(candidate_upload)
+                    < job["steps"].index(rejected_diagnostic_upload)
+                ):
+                    raise ValueError("review candidate upload order differs")
             prepared_head_checkout = _named_step(job, "Checkout prepared review head")
             if prepared_head_checkout != _expected_prepared_head_checkout_step(
                 budget=budget

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -663,12 +663,12 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256 = (
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
     "claude": "d34dfc388a393a6679bfd6a38ac281cc2c14a843063a010e9f1303c68df58cc7",
-    "gemini": "16d400da3e074f3a4deb3c5c49089e300b61639aee239979235e63f1abc9c937",
+    "gemini": "531c91663071e8a4985c85d6bc123024c29ee9e9efefc834ea6f5b440ccca41b",
     "opencode": "c13a61cf3362586da6230f3de03f623fea8e50b9756f337408351c35d970c0f0",
 }
 EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256 = {
     "claude": "2950d9dbf0923dfc463a872e8602e4d73ba2457a0df90ca3cca228ffb661343a",
-    "gemini": "f20fc659d9023585cd3d2201d4fbe380e97c5796d0ea2bd442b9cf42457a51f1",
+    "gemini": "a395bbfe4ec6a09449812968b32716fe16cd23567820a612197238e57c24b8f7",
     "opencode": "947600cb0ae3d0564a59ba03f8eccc4b5fa991138b280152c24e18e61ecc25a2",
 }
 EXPECTED_REVIEW_POLICY_HELPER_SHA256 = (
@@ -1197,7 +1197,7 @@ REVIEW_PUBLICATION_CONTRACTS = {
             "cc81b9e370c357366a384a059c9d6e1fe02065f085985f30532b92410c49c43d"
         ),
         "upsert_sha256_v147": (
-            "dcd3ae4370bc4048dce767d89755102f17d1bf97a503bc0b73b52cc7676d9047"
+            "62f29ebd7ca5fe47f4449cfa43a03ebb5a04e6b051a170b2221a670986c04ea8"
         ),
         "bot_login": "${{ steps.auth.outputs.bot-login }}",
         "auth_mode": "${{ inputs.repo_write_auth }}",
@@ -5946,11 +5946,13 @@ def _expected_review_candidate_upload_step(
     reviewer = contract["reviewer"]
     return {
         "name": f"Upload {reviewer.capitalize()} review candidate",
+        "id": "upload-candidate",
         "if": (
             "${{ always() "
             "&& steps.review-budget-claim.outputs.allow-invocation == 'true' "
             "&& steps.canonicalize-review.outcome != 'skipped' "
-            "&& steps.canonicalize-review.outputs.document-valid != 'true' }}"
+            "&& steps.canonicalize-review.outputs.document-valid != 'true' "
+            f"&& hashFiles('{contract['raw']}') != '' }}}}"
         ),
         "uses": UPLOAD_ARTIFACT_ACTION,
         "with": {

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -4773,6 +4773,7 @@ def _gemini_upsert(
     auth_mode: str = "github_token",
     publisher_app_id: str = "",
     budget_allow_invocation: str = "true",
+    candidate_artifact: str = "success",
 ) -> list:
     workdir = tmp_path / ("gemini-with-review" if with_review else "gemini-without-review")
     workdir.mkdir(parents=True)
@@ -4802,6 +4803,7 @@ def _gemini_upsert(
         "NORMALIZED_COUNT": normalized_count,
         "FILTERED_MAX_SEVERITY": filtered_max_severity,
         "CANONICAL_FAILURE_REASON": canonical_failure_reason,
+        "CANDIDATE_ARTIFACT": candidate_artifact,
         "BOT_LOGIN": bot_login,
         "AUTH_MODE": auth_mode,
         "PUBLISHER_APP_ID": publisher_app_id,
@@ -17226,11 +17228,13 @@ def test_gemini_uploads_the_raw_candidate_alongside_the_rejected_diagnostic():
     assert candidate["uses"] == (
         "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
     )
+    assert candidate["id"] == "upload-candidate"
     assert candidate["if"] == (
         "${{ always() "
         "&& steps.review-budget-claim.outputs.allow-invocation == 'true' "
         "&& steps.canonicalize-review.outcome != 'skipped' "
-        "&& steps.canonicalize-review.outputs.document-valid != 'true' }}"
+        "&& steps.canonicalize-review.outputs.document-valid != 'true' "
+        "&& hashFiles('gemini_review.md') != '' }}"
     )
     assert candidate["with"] == {
         "name": "gemini-candidate-${{ github.run_id }}-${{ github.run_attempt }}",
@@ -17239,6 +17243,15 @@ def test_gemini_uploads_the_raw_candidate_alongside_the_rejected_diagnostic():
         "retention-days": "1",
         "overwrite": "false",
     }
+
+
+def test_gemini_upsert_receives_the_candidate_upload_outcome():
+    workflow = _load("gemini-auto-review.yml")
+    upsert = _step(workflow, "gemini-review", "Upsert review comment")
+
+    assert upsert["env"]["CANDIDATE_ARTIFACT"] == (
+        "${{ steps.upload-candidate.outcome }}"
+    )
 
 
 @node_required
@@ -17267,10 +17280,30 @@ def test_gemini_failure_without_a_rejected_candidate_omits_the_pointer(tmp_path)
         with_review=False,
         canonical_outcome="skipped",
         document_valid="false",
+        candidate_artifact="skipped",
     )
 
     body = _single_mutation_body(calls)
     assert "- Status: failure" in body
+    assert "gemini-candidate-" not in body
+
+
+@node_required
+def test_gemini_missing_candidate_rejection_omits_the_pointer(tmp_path):
+    calls = _gemini_upsert(
+        tmp_path,
+        "skipped",
+        [],
+        with_review=False,
+        canonical_outcome="success",
+        document_valid="false",
+        canonical_failure_reason="candidate_missing",
+        candidate_artifact="skipped",
+    )
+
+    body = _single_mutation_body(calls)
+    # gemini-review 가 건너뛰어져 원문이 없는 라운드 — 업로드도 함께 건너뛰어진다.
+    assert "Reason: provider_failed" in body
     assert "gemini-candidate-" not in body
 
 

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -17213,5 +17213,73 @@ def test_dogfood_workflows_registered_in_config():
         )
 
 
+def test_gemini_uploads_the_raw_candidate_alongside_the_rejected_diagnostic():
+    workflow = _load("gemini-auto-review.yml")
+    names = [step.get("name") for step in workflow["jobs"]["gemini-review"]["steps"]]
+    candidate = _step(workflow, "gemini-review", "Upload Gemini review candidate")
+
+    assert (
+        names.index("Canonicalize Gemini review")
+        < names.index("Upload Gemini review candidate")
+        < names.index("Upload rejected Gemini review diagnostic")
+    )
+    assert candidate["uses"] == (
+        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+    )
+    assert candidate["if"] == (
+        "${{ always() "
+        "&& steps.review-budget-claim.outputs.allow-invocation == 'true' "
+        "&& steps.canonicalize-review.outcome != 'skipped' "
+        "&& steps.canonicalize-review.outputs.document-valid != 'true' }}"
+    )
+    assert candidate["with"] == {
+        "name": "gemini-candidate-${{ github.run_id }}-${{ github.run_attempt }}",
+        "path": "${{ github.workspace }}/gemini_review.md",
+        "if-no-files-found": "ignore",
+        "retention-days": "1",
+        "overwrite": "false",
+    }
+
+
+@node_required
+def test_gemini_rejected_candidate_failure_comment_names_the_raw_artifact(tmp_path):
+    calls = _gemini_upsert(
+        tmp_path,
+        "success",
+        [],
+        with_review=False,
+        canonical_outcome="success",
+        document_valid="false",
+        canonical_failure_reason="ambiguous_document",
+    )
+
+    body = _single_mutation_body(calls)
+    assert "Reason: ambiguous_document" in body
+    assert "Candidate (raw): artifact `gemini-candidate-42-1`" in body
+
+
+@node_required
+def test_gemini_failure_without_a_rejected_candidate_omits_the_pointer(tmp_path):
+    calls = _gemini_upsert(
+        tmp_path,
+        "failure",
+        [],
+        with_review=False,
+        canonical_outcome="skipped",
+        document_valid="false",
+    )
+
+    body = _single_mutation_body(calls)
+    assert "- Status: failure" in body
+    assert "gemini-candidate-" not in body
+
+
+@node_required
+def test_gemini_success_comment_omits_the_raw_candidate_pointer(tmp_path):
+    calls = _gemini_upsert(tmp_path, "success", [], with_review=True)
+
+    assert "gemini-candidate-" not in _single_mutation_body(calls)
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Closes #85

## 문제

Gemini 후보 문서가 검증에서 거부되면(`ambiguous_document` 등) **모델이 실제로 생성한 원문이 어느 채널에도 남지 않았다.** 남는 것은 `gemini-review-result.json` 의 sha256 + 규칙명 + 파서 위치뿐이라, "프롬프트/포맷 회귀"인지 "검증기 과잉"인지 유료 재실행 없이 구분할 수 없었다.

v1.53 fleet 롤아웃이 이 공백을 실증했다 — 17타깃 중 5건이 `rule=preamble, line=1` 로 실패했고, 그중 pcap-analyzer·imx-vpu·wlan-opc 는 후보 문서 sha256 이 **동일**(`72cccbd271ae…`)했다. 즉 모델이 그 diff 형태에 대해 결정적으로 같은 문서를 냈고 재실행은 무의미했는데, 원문이 없어 원인을 확정할 수 없었다. (이슈 #85 코멘트에 증거)

## 변경

**1. 거부된 후보 원문을 아티팩트로 보존** — `Canonicalize Gemini review` 직후, 진단 업로드 바로 앞.

```yaml
- name: Upload Gemini review candidate
  if: ${{ always() && ... && steps.canonicalize-review.outputs.document-valid != 'true' }}
  with:
    name: gemini-candidate-${{ github.run_id }}-${{ github.run_attempt }}
    path: ${{ github.workspace }}/gemini_review.md
```

**2. 실패 코멘트가 그 아티팩트를 안내** — 후보가 실제로 업로드된 라운드에만 붙는다(`invocationAllowed && canonicalOutcome !== 'skipped' && !documentValid`). 존재하지 않는 아티팩트를 가리키지 않는다.

## 계약 변경 — 명시적으로 짚을 것

`docs/workflows/contracts.md` 는 **"The untrusted raw candidate is never uploaded"** 를 명시하고 있었다(근거: provider-echoed secrets, checkout-seeded symlink). 이 PR 은 그 계약을 Gemini 에 한해 바꾸며, 두 근거를 각각 처리했다.

- **symlink**: 해당 벡터는 구조적으로 닫혀 있다. `Reset Gemini review artifacts` 가 그 경로를 `rm -f --` 로 먼저 제거하고, `Canonicalize Gemini review` 는 `reset-gemini-artifacts.outcome == 'success'` 를 요구하며, 이 업로드는 `canonicalize-review.outcome != 'skipped'` 를 요구한다. 업로드 시점의 그 경로는 워크플로가 만든 정규 파일이다.
- **노출 최소화**: 이슈 원안의 `always()` 대신 **거부된 라운드로 한정**했다(진단 아티팩트와 동일 조건). 성공 라운드 원문은 계속 보존하지 않는다. 보존은 1일, 덮어쓰기 금지. Claude 경로는 종전대로 미업로드.
- **원문은 여전히 어떤 프로그램도 읽지 않는다**: `verify_workflow_release.py` 는 upsert 스크립트에 원문 파일명이 등장하는 것을 금지한다(`contract["raw"] not in upsert_script`). 그래서 실패 코멘트는 파일명이 아니라 **아티팩트 이름만** 인용한다.

문서의 해당 문단을 이 정책으로 교체했다.

## 검증

- 신규 회귀 테스트 4건 (`tests/test_review_workflow_logic.py`) — **되돌림 확인 완료**(구현 전 `StopIteration`/assertion 실패):
  - 업로드 스텝의 `uses`/`name`/`path`/`if`/보존기간과 **순서**(canonicalize → candidate → diagnostic) 고정
  - 거부 시 실패 코멘트에 안내 존재
  - 성공 시 안내 부재
  - canonicalize 가 `skipped` 인 실패에서는 안내 부재(존재하지 않는 아티팩트 방지)
- `tests/test_verify_workflow_release.py` → **2 failed / 572 passed**, unmodified main 과 동일(남은 2건은 로컬 `umask 0002` 파일모드 환경 실패로 CI 는 통과).
- `actionlint 1.7.12 -shellcheck= -pyflakes=` (CI 와 동일 경계) → exit 0
- 릴리스 계약: 새 스텝 형태를 `_expected_review_candidate_upload_step` 으로 고정 + 순서 검증 추가. 워크플로 바이트 변경에 따라 `upsert_sha256_v147`, `EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256["gemini"]`, `EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256["gemini"]`(v1.47 변형본) 갱신.

## 하지 않은 것

- 진단 아티팩트와 업로드 조건이 같지만 **합치지 않았다** — 진단은 bounded schema-1, 후보는 untrusted raw 로 신뢰 등급이 다르고, 기존 아티팩트 이름은 소비자 계약이다.
- Claude 경로에는 같은 공백이 남아 있다(#85 범위 밖). 필요하면 별도 이슈로 다룬다.
