### PR TITLE
chore(workflows): default rollout to v1.54

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.53",
+  "automation_ref": "v1.54",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.53"
+    assert config.automation_ref == "v1.54"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
v1.54 릴리스(tag object a0f03a1bff5afa27f3c648f36c2643608749659f, commit cec20f03a64a2930b9ef6e81ce5bbbeaac79fd68)를 fleet 기본 핀으로 승격한다.

- 검증: `python3 -m scripts.verify_workflow_release --ref v1.54 --expected-commit cec20f03…` → PASS
- 관련: #85 (PR #89 머지)