### PR TITLE
fix(review): preserve the rejected Claude candidate

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -692,6 +692,19 @@ jobs:
           previous-sha: ${{ steps.prepare-review-input.outputs.previous_sha }}
           previous-review-file: ${{ steps.prepare-review-input.outputs.previous_sha != '' && format('{0}/claude-previous-review.md', runner.temp) || '' }}
 
+      # 거부된 후보의 원문이 없으면 프롬프트/포맷 회귀와 검증기 과잉을 구분할 수 없다.
+      # 노출을 최소화하기 위해 거부된 라운드에서만, 원문이 실제로 있을 때만 보존한다.
+      - name: Upload Claude review candidate
+        id: upload-candidate
+        if: ${{ always() && steps.review-budget-claim.outputs.allow-invocation == 'true' && steps.canonicalize-review.outcome != 'skipped' && steps.canonicalize-review.outputs.document-valid != 'true' && hashFiles('claude-review.md') != '' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: claude-candidate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ github.workspace }}/claude-review.md
+          if-no-files-found: ignore
+          retention-days: 1
+          overwrite: false
+
       - name: Upload rejected Claude review diagnostic
         if: ${{ always() && steps.review-budget-claim.outputs.allow-invocation == 'true' && steps.canonicalize-review.outcome != 'skipped' && steps.canonicalize-review.outputs.document-valid != 'true' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -729,6 +742,7 @@ jobs:
           NORMALIZED_COUNT: ${{ steps.canonicalize-review.outputs.normalized-count }}
           FILTERED_MAX_SEVERITY: ${{ steps.canonicalize-review.outputs.filtered-max-severity }}
           CANONICAL_FAILURE_REASON: ${{ steps.canonicalize-review.outputs.failure-reason }}
+          CANDIDATE_ARTIFACT: ${{ steps.upload-candidate.outcome }}
           BUDGET_ALLOW_INVOCATION: ${{ steps.review-budget-claim.outputs.allow-invocation }}
           BOT_LOGIN: 'github-actions[bot]'
         with:
@@ -1001,12 +1015,19 @@ jobs:
                 failureReason = 'candidate_oversize';
               }
             }
+            // 업로드 스텝이 성공한 라운드에만 안내한다. 후보 파일이 없으면 그 스텝은
+            // skipped 이므로, 존재하지 않는 아티팩트를 가리키지 않는다.
+            const candidateUploaded =
+              (process.env.CANDIDATE_ARTIFACT || '').toLowerCase() === 'success';
+            const candidatePointer = candidateUploaded
+              ? `\n\nCandidate (raw): artifact \`claude-candidate-${runId}-${runAttempt}\``
+              : '';
             const preserveSuccess = checkpointFailed && existing
               && sha1(existing.state.successful_head) && preservedProse.length > 0;
             const state = buildState(checkpointFailed, preserveSuccess);
             const content = checkpointFailed
               ? (preserveSuccess ? preservedProse
-                : `### Error\n\nClaude review failed: \`${failureReason}\`. (See run logs: ${runUrl})`)
+                : `### Error\n\nClaude review failed: \`${failureReason}\`. (See run logs: ${runUrl})${candidatePointer}`)
               : successBody;
             const body = envelope(state, content);
             if (checkpointFailed && Buffer.byteLength(body, 'utf8') > 65536) {

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -472,16 +472,16 @@ v3 sticky envelope under GitHub's 65,536-byte comment limit.
 After an attempted Claude or Gemini canonicalization that does not produce
 `document-valid=true`, the workflow uploads the bounded schema-1
 `<reviewer>-review-result.json` as a uniquely named, non-overwriting diagnostic artifact for one
-day. Gemini additionally uploads the rejected raw candidate as
-`gemini-candidate-<run>-<attempt>` under that same rejection-only condition and the same
-one-day, non-overwriting bound, because the structural code alone cannot separate a
-prompt/format regression from an over-strict validator. Claude never uploads its raw candidate.
-The Gemini upload is bounded to rejected rounds, whose text is by definition never published,
+day. Each reviewer additionally uploads the rejected raw candidate as
+`<reviewer>-candidate-<run>-<attempt>` under that same rejection-only condition, only when the
+candidate file actually exists, and with the same one-day, non-overwriting bound, because the
+structural code alone cannot separate a prompt/format regression from an over-strict validator.
+The upload is bounded to rejected rounds, whose text is by definition never published,
 and it stays untrusted provider output that no program reads: the upsert program never names or
-opens the raw file, and the failure comment cites only the artifact name. The workspace path is
-safe because the reset step removes it with `rm -f --` before generation and the canonicalizer
-runs only after that reset succeeds, so no checkout-seeded symlink target survives. A missing
-result is ignored. The diagnostic is not authority: neither the upsert program nor later review state or
+opens the raw file, and the failure comment cites only the artifact name, and only when that
+upload step reported success. The workspace path is safe because the reset step removes it with
+`rm -f --` before generation and the canonicalizer runs only after that reset succeeds, so no
+checkout-seeded symlink target survives. A missing result is ignored. The diagnostic is not authority: neither the upsert program nor later review state or
 carryover reads it. For `ambiguous_document`, logs expose only a fixed structural diagnostic code
 such as `preamble`, `unknown_section_before_document`,
 `unknown_section_after_document`, or `invalid_finding_heading`; candidate text is never copied into

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -662,12 +662,12 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256 = (
     "43f15d59df0f529e2fa4f06488e49dc5ff78280762ee8d7248dbecb45cbb609d"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
-    "claude": "d34dfc388a393a6679bfd6a38ac281cc2c14a843063a010e9f1303c68df58cc7",
+    "claude": "d4db53b86603a3a113999409e2e4e35c397adf276981e7f68c0ea57a6198faa2",
     "gemini": "531c91663071e8a4985c85d6bc123024c29ee9e9efefc834ea6f5b440ccca41b",
     "opencode": "c13a61cf3362586da6230f3de03f623fea8e50b9756f337408351c35d970c0f0",
 }
 EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256 = {
-    "claude": "2950d9dbf0923dfc463a872e8602e4d73ba2457a0df90ca3cca228ffb661343a",
+    "claude": "8e16c59b04aeaaf7419571b0bda3fb1e46a29da3b847bbb0409ab0437a1027d7",
     "gemini": "a395bbfe4ec6a09449812968b32716fe16cd23567820a612197238e57c24b8f7",
     "opencode": "947600cb0ae3d0564a59ba03f8eccc4b5fa991138b280152c24e18e61ecc25a2",
 }
@@ -1165,7 +1165,7 @@ REVIEW_PUBLICATION_CONTRACTS = {
             "d2f1d2eab1e974bf05f184406e854cfe0861ab4b863520a4189d987ceccf27cc"
         ),
         "upsert_sha256_v147": (
-            "bc79b2db414640a7a707f9c5dfe6e13fd05a726aaad74ad163c6d46f71caf766"
+            "f23f444b3a9c7b04707779f3f8431da60107c8792558c02f5c011216ca93d805"
         ),
         "bot_login": "github-actions[bot]",
         "workflow_prefix": (
@@ -6024,7 +6024,7 @@ def _verify_review_publication_contracts(
             ):
                 raise ValueError("rejected review diagnostic differs")
             candidate_upload = None
-            if budget and contract["reviewer"] == "gemini":
+            if budget:
                 candidate_upload = _named_step(
                     job,
                     f"Upload {contract['reviewer'].capitalize()} review candidate",

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -4481,6 +4481,7 @@ def _claude_upsert(
     current_head: str | None = None,
     workflow_runs: list[dict] | None = None,
     workflow_run_attempt_sequences: dict[str, list[dict]] | None = None,
+    candidate_artifact: str = "success",
 ) -> list:
     workdir = tmp_path / ("with-review" if with_review else "without-review")
     workdir.mkdir()
@@ -4508,6 +4509,7 @@ def _claude_upsert(
         "NORMALIZED_COUNT": normalized_count,
         "FILTERED_MAX_SEVERITY": filtered_max_severity,
         "CANONICAL_FAILURE_REASON": canonical_failure_reason,
+        "CANDIDATE_ARTIFACT": candidate_artifact,
         "BUDGET_ALLOW_INVOCATION": budget_allow_invocation,
         "BOT_LOGIN": "github-actions[bot]",
     }
@@ -17312,6 +17314,88 @@ def test_gemini_success_comment_omits_the_raw_candidate_pointer(tmp_path):
     calls = _gemini_upsert(tmp_path, "success", [], with_review=True)
 
     assert "gemini-candidate-" not in _single_mutation_body(calls)
+
+
+
+def test_claude_uploads_the_raw_candidate_alongside_the_rejected_diagnostic():
+    workflow = _load("claude-code-review.yml")
+    names = [step.get("name") for step in workflow["jobs"]["claude-review"]["steps"]]
+    candidate = _step(workflow, "claude-review", "Upload Claude review candidate")
+
+    assert (
+        names.index("Canonicalize Claude review")
+        < names.index("Upload Claude review candidate")
+        < names.index("Upload rejected Claude review diagnostic")
+    )
+    assert candidate["id"] == "upload-candidate"
+    assert candidate["uses"] == (
+        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+    )
+    assert candidate["if"] == (
+        "${{ always() "
+        "&& steps.review-budget-claim.outputs.allow-invocation == 'true' "
+        "&& steps.canonicalize-review.outcome != 'skipped' "
+        "&& steps.canonicalize-review.outputs.document-valid != 'true' "
+        "&& hashFiles('claude-review.md') != '' }}"
+    )
+    assert candidate["with"] == {
+        "name": "claude-candidate-${{ github.run_id }}-${{ github.run_attempt }}",
+        "path": "${{ github.workspace }}/claude-review.md",
+        "if-no-files-found": "ignore",
+        "retention-days": "1",
+        "overwrite": "false",
+    }
+
+
+def test_claude_upsert_receives_the_candidate_upload_outcome():
+    workflow = _load("claude-code-review.yml")
+    upsert = _step(workflow, "claude-review", "Upsert review comment")
+
+    assert upsert["env"]["CANDIDATE_ARTIFACT"] == (
+        "${{ steps.upload-candidate.outcome }}"
+    )
+
+
+@node_required
+def test_claude_rejected_candidate_failure_comment_names_the_raw_artifact(tmp_path):
+    calls = _claude_upsert(
+        tmp_path,
+        "success",
+        [],
+        with_review=False,
+        canonical_outcome="success",
+        document_valid="false",
+        canonical_failure_reason="ambiguous_document",
+    )
+
+    body = _single_mutation_body(calls)
+    assert "Claude review failed: `ambiguous_document`" in body
+    assert "Candidate (raw): artifact `claude-candidate-42-1`" in body
+
+
+@node_required
+def test_claude_missing_candidate_rejection_omits_the_pointer(tmp_path):
+    calls = _claude_upsert(
+        tmp_path,
+        "skipped",
+        [],
+        with_review=False,
+        canonical_outcome="success",
+        document_valid="false",
+        canonical_failure_reason="candidate_missing",
+        candidate_artifact="skipped",
+    )
+
+    body = _single_mutation_body(calls)
+    assert "- Status: failure" in body
+    assert "claude-candidate-" not in body
+
+
+@node_required
+def test_claude_success_comment_omits_the_raw_candidate_pointer(tmp_path):
+    calls = _claude_upsert(tmp_path, "success", [], with_review=True)
+
+    assert "claude-candidate-" not in _single_mutation_body(calls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #90

## 문제

Claude auto review 도 후보 문서 검증에서 거부되면 **모델이 실제로 생성한 원문이 어느 채널에도 남지 않았다.** #85 가 Gemini 에 대해 지적한 것과 같은 공백이고, PR #89(v1.54)는 Gemini 만 해소했다.

이 공백은 바로 그 PR #89 에서 실증됐다 — Claude 재리뷰 run [33604012390](https://github.com/jhw7500/automation/actions/runs/33604012390) 이 `invalid_finding_heading`(line 6) 으로 거부되면서 자동 라운드가 2/2 로 소진됐고, 직전 라운드 finding 의 수정 여부를 Claude 관점으로 확인받지 못한 채 예외 기록 후 머지해야 했다. 그 6행이 실질 지적이었는지 서식만 어긋난 정상 리뷰였는지는 지금도 알 수 없다.

## 변경 — Gemini(PR #89)와 대칭

**1. 거부된 후보 원문 보존** — `Canonicalize Claude review` 직후, 진단 업로드 바로 앞.

```yaml
- name: Upload Claude review candidate
  id: upload-candidate
  if: ${{ always() && ... && steps.canonicalize-review.outputs.document-valid != 'true'
          && hashFiles('claude-review.md') != '' }}
  with:
    name: claude-candidate-${{ github.run_id }}-${{ github.run_attempt }}
    path: ${{ github.workspace }}/claude-review.md
```

**2. 실패 코멘트가 그 아티팩트를 안내** — 업로드 스텝 outcome 이 `success` 인 라운드에만. PR #89 의 리뷰에서 지적된 결함(원문이 없어 업로드가 no-op 인데 안내만 남는 경우)을 처음부터 배제했다.

`hashFiles(...)` 조건이 그 보증의 한 축이다: `Run Claude Code Review` 는 `always()` 가 없어 선행 스텝 실패 시 skip 되지만 `Canonicalize Claude review` 는 `always()` 로 실행돼 `candidate_missing` 을 만든다. 그 경로에서 업로드 스텝은 skipped 가 되고, 안내도 붙지 않는다.

**3. 릴리스 계약 일반화** — 후보 업로드 계약 검증을 Gemini 전용에서 두 리뷰어 공통으로 확장했다(`_expected_review_candidate_upload_step` 는 `contract["raw"]` 로 이미 일반화돼 있었다).

**4. 문서** — `docs/workflows/contracts.md` 를 `<reviewer>-candidate-<run>-<attempt>` 로 일반화하고, "업로드 성공을 보고한 라운드에만 안내한다"는 조건을 명시했다.

## 검증

- 신규 회귀 테스트 5건 — 스텝 형태·순서, env 브리지, 거부 시 안내 존재, 성공 시 부재, **원문 없는 거부에서 부재**
- **되돌림 확인 완료**: 안내 조건을 판정 기준으로 되돌리면 `test_claude_missing_candidate_rejection_omits_the_pointer` 가 실패한다
- 전체 스위트 **2 failed / 2882 passed / 48 subtests** — 실패 2건은 unmodified main 에서도 실패하는 로컬 `umask 0002` 파일모드 문제(CI 는 통과)
- `actionlint 1.7.12 -shellcheck= -pyflakes=` exit 0
- 다이제스트 3종 갱신: claude `upsert_sha256_v147`, `EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256["claude"]`, `EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256["claude"]`(v1.47 변형본)

## 범위 밖

provider 오류가 후보 파일에 기록돼 `ambiguous_document` 로 표시되는 문제(#93 의 부수 관찰)는 이 PR 에서 다루지 않는다.
