### PR TITLE
chore(workflows): default rollout to v1.55

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.54",
+  "automation_ref": "v1.55",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.54"
+    assert config.automation_ref == "v1.55"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
v1.55 릴리스(tag object 619a8cfa6afa383f5a45fb7c4830a8b9379e92e8, commit 60e09a0ffaf1fa6548eb9a55533adc3607122b36)를 fleet 기본 핀으로 승격한다.

- 검증: `python3 -m scripts.verify_workflow_release --ref v1.55 --expected-commit 60e09a0f…` → PASS
- 관련: #90 (PR #94 머지)