### PR TITLE
ci(self-review): allow a dispatched force review round

### DIFF
--- a/.github/workflows/_self-claude-review.yml
+++ b/.github/workflows/_self-claude-review.yml
@@ -8,13 +8,26 @@ name: Self Claude Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        type: number
+        required: true
+      force_review:
+        description: Perform one authorized same-HEAD review
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   claude-review:
     if: >-
+      (github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false
+      github.event.pull_request.draft == false) ||
+      (github.event_name == 'workflow_dispatch' && inputs.force_review)
     permissions:
       actions: read
       contents: read
@@ -23,11 +36,12 @@ jobs:
       id-token: write
     uses: ./.github/workflows/claude-code-review.yml
     with:
-      pr_number: '${{ github.event.pull_request.number }}'
+      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       force_run: false
-      force_review: false
+      force_review: ${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}
       review_mode: >-
         ${{
+          github.event_name == 'workflow_dispatch' && inputs.force_review && 'request' ||
           contains(github.event.pull_request.labels.*.name, 'review:request') &&
           contains(github.event.pull_request.labels.*.name, 'review:skip') && 'conflict' ||
           contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||

--- a/.github/workflows/_self-gemini-auto-review.yml
+++ b/.github/workflows/_self-gemini-auto-review.yml
@@ -10,6 +10,17 @@ name: Self Gemini Auto Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        type: number
+        required: true
+      force_review:
+        description: Perform one authorized same-HEAD review
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   check-secret:
@@ -35,9 +46,11 @@ jobs:
     needs: check-secret
     if: >-
       needs.check-secret.outputs.has_key == 'true' &&
+      ((github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false
+      github.event.pull_request.draft == false) ||
+      (github.event_name == 'workflow_dispatch' && inputs.force_review))
     permissions:
       actions: read
       contents: read
@@ -45,10 +58,11 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/gemini-auto-review.yml
     with:
-      pr_number: ${{ github.event.pull_request.number }}
-      force_review: false
+      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
+      force_review: ${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}
       review_mode: >-
         ${{
+          github.event_name == 'workflow_dispatch' && inputs.force_review && 'request' ||
           contains(github.event.pull_request.labels.*.name, 'review:request') &&
           contains(github.event.pull_request.labels.*.name, 'review:skip') && 'conflict' ||
           contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||

--- a/.github/workflows/_self-opencode-auto-review.yml
+++ b/.github/workflows/_self-opencode-auto-review.yml
@@ -9,6 +9,17 @@ name: Self OpenCode Auto Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        type: number
+        required: true
+      force_review:
+        description: Perform one authorized same-HEAD review
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   check-secret:
@@ -36,9 +47,11 @@ jobs:
     # 호출부에서도 명시해 이중 방어 + _self-gemini 쪽과 조건을 통일한다.
     if: >-
       needs.check-secret.outputs.has_key == 'true' &&
+      ((github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false
+      github.event.pull_request.draft == false) ||
+      (github.event_name == 'workflow_dispatch' && inputs.force_review))
     permissions:
       actions: read
       checks: write
@@ -47,10 +60,11 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/opencode-auto-review.yml
     with:
-      pr_number: ${{ github.event.pull_request.number }}
-      force_review: false
+      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
+      force_review: ${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}
       review_mode: >-
         ${{
+          github.event_name == 'workflow_dispatch' && inputs.force_review && 'request' ||
           contains(github.event.pull_request.labels.*.name, 'review:request') &&
           contains(github.event.pull_request.labels.*.name, 'review:skip') && 'conflict' ||
           contains(github.event.pull_request.labels.*.name, 'review:request') && 'request' ||

--- a/tests/test_canonical_workflow_tree.py
+++ b/tests/test_canonical_workflow_tree.py
@@ -519,9 +519,38 @@ def test_self_auto_review_callers_forward_label_review_mode() -> None:
         assert caller["on"]["pull_request"]["types"] == [
             "opened", "synchronize", "ready_for_review",
         ]
-        assert " ".join(job["with"]["review_mode"].split()) == SELF_REVIEW_MODE_EXPRESSION
+        assert " ".join(job["with"]["review_mode"].split()) == REVIEW_MODE_EXPRESSION
         assert "github.event.pull_request.draft == false" in job["if"]
-        assert job["with"]["force_review"] == "false"
+
+        # 라운드 소진 후 재판정을 요청할 수 있어야 한다. 예산 액션이 override 라운드에
+        # workflow_dispatch provenance 를 요구하므로 트리거와 전달이 함께 있어야 한다.
+        assert caller["on"]["workflow_dispatch"]["inputs"]["pr_number"]["type"] == "number"
+        assert caller["on"]["workflow_dispatch"]["inputs"]["pr_number"]["required"] == "true"
+        force_input = caller["on"]["workflow_dispatch"]["inputs"]["force_review"]
+        assert force_input["type"] == "boolean"
+        assert force_input["default"] == "false"
+        assert job["with"]["force_review"] == (
+            "${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}"
+        )
+        assert job["with"]["pr_number"] == (
+            "${{ github.event.pull_request.number || inputs.pr_number }}"
+        )
+        assert (
+            "(github.event_name == 'workflow_dispatch' && inputs.force_review)"
+            in " ".join(job["if"].split())
+        )
+
+        # && 가 || 보다 강하게 결합하므로, 시크릿 게이트가 있는 caller 는 이벤트 분기
+        # 전체를 괄호로 묶어야 workflow_dispatch 경로가 그 게이트를 건너뛰지 않는다.
+        condition = " ".join(job["if"].split())
+        if "needs.check-secret" in condition:
+            assert condition.startswith(
+                "needs.check-secret.outputs.has_key == 'true' "
+                "&& ((github.event_name == 'pull_request'"
+            ), filename
+            assert condition.endswith(
+                "|| (github.event_name == 'workflow_dispatch' && inputs.force_review))"
+            ), filename
 
 
 def test_comment_callers_carry_the_request_scoped_run_name() -> None:


### PR DESCRIPTION
Closes #91

## 문제

자동 리뷰 라운드가 소진된 뒤 **automation 자체 PR 에서는 재판정을 요청할 수단이 없었다.** 소비 저장소에는 `force_review` 경로(#58)가 있지만 자체 도그푸딩 caller 에는 배선돼 있지 않았다.

- `_self-*` 세 caller 는 트리거가 `pull_request` 뿐이고 `force_review: false` 로 하드코딩돼 있었다.
- 예산 액션은 override 라운드에 `workflow_dispatch` provenance 를 요구한다 (`review_invocation_budget.py:749-756`), 그래서 `max_override_rounds: 1` 이 자체 PR 에서 도달 불가능했다.

이 공백은 PR #89 에서 실제로 비용을 냈다 — Claude 재리뷰가 자체 출력 포맷 위반으로 실패해 자동 라운드가 2/2 로 소진됐고, 직전 finding 의 수정 여부를 Claude 관점으로 확인받지 못한 채 예외 기록 후 머지해야 했다.

## 변경 — 소비자 baseline 과 동일한 형태

세 caller 에 동일하게 적용했다.

- `workflow_dispatch` 트리거 + `pr_number`(number, required) · `force_review`(boolean, default false)
- `pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}`
- `force_review: ${{ github.event_name == 'workflow_dispatch' && inputs.force_review }}`
- job `if` 에 `(github.event_name == 'workflow_dispatch' && inputs.force_review)` 분기 추가
- `review_mode` 에 `github.event_name == 'workflow_dispatch' && inputs.force_review && 'request'` 접두 추가 (소비자와 동일한 `REVIEW_MODE_EXPRESSION`)

`pull_request` 경로에서는 `force_review` 가 여전히 거짓이다 — 표현식이 이벤트 이름을 먼저 검사한다.

## 구현 중 잡은 결함

`needs.check-secret` 게이트가 있는 gemini/opencode caller 에서, 이벤트 분기를 그냥 이어붙이면 **`&&` 가 `||` 보다 강하게 결합해 workflow_dispatch 경로가 API 키 확인을 우회**한다.

```
needs.check-secret... && (pull_request 조건) || (workflow_dispatch && force_review)
= (needs.check-secret... && pull_request 조건) || (workflow_dispatch && force_review)
```

이벤트 분기 전체를 괄호로 묶어 보정했고, 그 형태를 계약으로 고정했다.

## 검증

- `tests/test_canonical_workflow_tree.py::test_self_auto_review_callers_forward_label_review_mode` 확장 — 트리거·입력 타입·전달 표현식·job `if` 분기, 그리고 시크릿 게이트의 괄호 결합을 고정
- **되돌림 확인 완료**: 괄호를 제거하면 그 어서션이 실제로 실패한다
- 전체 스위트 **2 failed / 2882 passed / 48 subtests** — 실패 2건은 unmodified main 에서도 실패하는 로컬 `umask 0002` 파일모드 문제(CI 는 통과)
- `actionlint 1.7.12 -shellcheck= -pyflakes=` exit 0

## 범위

`_self-*` 는 automation 자체 도그푸딩 전용이며 fleet catalog 배포 대상이 아니다 — **릴리스·롤아웃이 필요 없다.** 소비 저장소의 `force_review` 경로는 이미 존재하며 변경하지 않았다.
