### PR TITLE
fix(gemini): fall back when the primary round is cancelled

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -465,13 +465,14 @@ jobs:
             Keep the response concise and structured with clear headings.
 
       - name: Log primary model failure
-        if: steps.gemini_review_primary.outcome == 'failure' && steps.gemini_review_fallback_route.outputs.enabled == 'true'
+        if: contains(fromJSON('["failure","cancelled","timed_out"]'), steps.gemini_review_primary.outcome) && steps.gemini_review_fallback_route.outputs.enabled == 'true'
         env:
           GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
           ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
           PRIMARY_MODEL: '${{ vars.GEMINI_MODEL }}'
           FALLBACK_MODEL: '${{ vars.GEMINI_FALLBACK_MODEL }}'
           ERRORS: '${{ steps.gemini_review_primary.outputs.error }}'
+          PRIMARY_OUTCOME: '${{ steps.gemini_review_primary.outcome }}'
           REPOSITORY: '${{ github.repository }}'
         run: |-
           error_comment="${RUNNER_TEMP}/gemini-review-primary-error.md"
@@ -479,6 +480,7 @@ jobs:
           {
             printf '%s\n\n' '## ⚠️ Primary Model Failed'
             printf '**Primary Model:** %s\n' "$PRIMARY_MODEL"
+            printf '**Primary Outcome:** %s\n' "$PRIMARY_OUTCOME"
             printf '**Attempting Fallback:** %s\n\n' "$FALLBACK_MODEL"
             printf '%s\n' '<details>' '<summary>Error Details</summary>' '' '```'
             printf '%s\n' "$ERRORS"
@@ -491,7 +493,7 @@ jobs:
 
       - name: Run Gemini pull request review (fallback)
         id: gemini_review_fallback
-        if: steps.gemini_review_primary.outcome == 'failure' && steps.gemini_review_fallback_route.outputs.enabled == 'true'
+        if: contains(fromJSON('["failure","cancelled","timed_out"]'), steps.gemini_review_primary.outcome) && steps.gemini_review_fallback_route.outputs.enabled == 'true'
         uses: google-github-actions/run-gemini-cli@v0
         continue-on-error: true
         env:
@@ -590,7 +592,12 @@ jobs:
             outcome='failure'
             model="$PRIMARY_MODEL"
             response=''
-            errors="$PRIMARY_ERRORS"
+            status="primary=${PRIMARY_OUTCOME:-unknown}; fallback=${FALLBACK_OUTCOME:-not_run}"
+            if [[ -n "$PRIMARY_ERRORS" ]]; then
+              errors="${status}"$'\n\n'"${PRIMARY_ERRORS}"
+            else
+              errors="$status"
+            fi
           fi
 
           write_output outcome "$outcome"
@@ -931,13 +938,14 @@ jobs:
           prompt: '/gemini-invoke'
 
       - name: Log primary model failure (invoke)
-        if: steps.gemini_invoke_primary.outcome == 'failure' && vars.GEMINI_FALLBACK_MODEL != ''
+        if: contains(fromJSON('["failure","cancelled","timed_out"]'), steps.gemini_invoke_primary.outcome) && vars.GEMINI_FALLBACK_MODEL != ''
         env:
           GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
           ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
           PRIMARY_MODEL: '${{ vars.GEMINI_MODEL }}'
           FALLBACK_MODEL: '${{ vars.GEMINI_FALLBACK_MODEL }}'
           ERRORS: '${{ steps.gemini_invoke_primary.outputs.error }}'
+          PRIMARY_OUTCOME: '${{ steps.gemini_invoke_primary.outcome }}'
           REPOSITORY: '${{ github.repository }}'
         run: |-
           error_comment="${RUNNER_TEMP}/gemini-invoke-primary-error.md"
@@ -945,6 +953,7 @@ jobs:
           {
             printf '%s\n\n' '## ⚠️ Primary Model Failed'
             printf '**Primary Model:** %s\n' "$PRIMARY_MODEL"
+            printf '**Primary Outcome:** %s\n' "$PRIMARY_OUTCOME"
             printf '**Attempting Fallback:** %s\n\n' "$FALLBACK_MODEL"
             printf '%s\n' '<details>' '<summary>Error Details</summary>' '' '```'
             printf '%s\n' "$ERRORS"
@@ -957,7 +966,7 @@ jobs:
 
       - name: Run Gemini CLI (fallback)
         id: gemini_invoke_fallback
-        if: steps.gemini_invoke_primary.outcome == 'failure' && vars.GEMINI_FALLBACK_MODEL != ''
+        if: contains(fromJSON('["failure","cancelled","timed_out"]'), steps.gemini_invoke_primary.outcome) && vars.GEMINI_FALLBACK_MODEL != ''
         uses: google-github-actions/run-gemini-cli@v0
         env:
           TITLE: '${{ github.event.pull_request.title || github.event.issue.title }}'

--- a/tests/test_legacy_workflow_writers.py
+++ b/tests/test_legacy_workflow_writers.py
@@ -563,6 +563,7 @@ def test_failure_comments_propagate_adversarial_error_text_as_data(
         "GITHUB_TOKEN": "token",
         "ISSUE_NUMBER": "17",
         "PRIMARY_MODEL": model,
+        "PRIMARY_OUTCOME": "cancelled",
         "FALLBACK_MODEL": "fallback-model",
         "ERRORS": errors,
         "REPOSITORY": "jhw7500/example",
@@ -583,6 +584,8 @@ def test_failure_comments_propagate_adversarial_error_text_as_data(
     body = capture.read_text(encoding="utf-8")
     assert model in body
     assert errors in body
+    # 취소도 데이터로 그대로 전달돼야 한다 — "failed" 로 뭉뚱그리지 않는다.
+    assert "**Primary Outcome:** cancelled" in body
     assert "$PRIMARY_MODEL" not in body
     assert "$ERRORS" not in body
 

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -6799,10 +6799,33 @@ def test_dispatch_resolves_fallback_route_with_case_sensitive_model_comparison(
         assert _github_outputs(output) == {"enabled": expected}
 
 
+def _github_delimited_outputs(path: Path) -> dict[str, str]:
+    """`name<<DELIM ... DELIM` 형식만 쓰는 스텝 출력을 읽는다."""
+
+    values: dict[str, str] = {}
+    lines = path.read_text(encoding="utf-8").split("\n")
+    index = 0
+    while index < len(lines):
+        if "<<" in lines[index]:
+            name, delimiter = lines[index].split("<<", 1)
+            index += 1
+            body: list[str] = []
+            while index < len(lines) and lines[index] != delimiter:
+                body.append(lines[index])
+                index += 1
+            values[name] = "\n".join(body)
+        index += 1
+    return values
+
+
+RETRYABLE_PRIMARY_OUTCOMES = "'[\"failure\",\"cancelled\",\"timed_out\"]'"
+
+
 def test_dispatch_skips_identical_fallback_model_route():
     workflow = _load("gemini-dispatch.yml")
     expected = (
-        "steps.gemini_review_primary.outcome == 'failure' && "
+        f"contains(fromJSON({RETRYABLE_PRIMARY_OUTCOMES}), "
+        "steps.gemini_review_primary.outcome) && "
         "steps.gemini_review_fallback_route.outputs.enabled == 'true'"
     )
 
@@ -6811,6 +6834,85 @@ def test_dispatch_skips_identical_fallback_model_route():
         _step(workflow, "review", "Run Gemini pull request review (fallback)")["if"]
         == expected
     )
+
+
+def test_dispatch_falls_back_for_every_non_success_primary_outcome():
+    # 취소·타임아웃도 fallback 대상이다. 성공/건너뜀은 아니다.
+    workflow = _load("gemini-dispatch.yml")
+    invoke_expected = (
+        f"contains(fromJSON({RETRYABLE_PRIMARY_OUTCOMES}), "
+        "steps.gemini_invoke_primary.outcome) && vars.GEMINI_FALLBACK_MODEL != ''"
+    )
+
+    for name in (
+        "Log primary model failure",
+        "Run Gemini pull request review (fallback)",
+    ):
+        condition = _step(workflow, "review", name)["if"]
+        assert "cancelled" in condition, name
+        assert "timed_out" in condition, name
+        assert "'success'" not in condition, name
+
+    assert _step(workflow, "invoke", "Log primary model failure (invoke)")["if"] == (
+        invoke_expected
+    )
+    assert _step(workflow, "invoke", "Run Gemini CLI (fallback)")["if"] == invoke_expected
+
+    # 취소·타임아웃에서도 "무엇이 일어났는지"가 코멘트에 남아야 한다.
+    for job, name, step_id in (
+        ("review", "Log primary model failure", "gemini_review_primary"),
+        ("invoke", "Log primary model failure (invoke)", "gemini_invoke_primary"),
+    ):
+        step = _step(workflow, job, name)
+        assert step["env"]["PRIMARY_OUTCOME"] == f"${{{{ steps.{step_id}.outcome }}}}"
+        assert "**Primary Outcome:**" in step["run"]
+
+
+@pytest.mark.parametrize(
+    ("primary_outcome", "fallback_outcome", "expected_outcome", "expected_model"),
+    (
+        ("success", "skipped", "success", "primary-model"),
+        ("cancelled", "success", "success", "fallback-model"),
+        ("failure", "success", "success", "fallback-model"),
+        ("cancelled", "skipped", "failure", "primary-model"),
+        ("timed_out", "failure", "failure", "primary-model"),
+    ),
+)
+def test_dispatch_final_review_records_the_primary_and_fallback_outcomes(
+    tmp_path, primary_outcome, fallback_outcome, expected_outcome, expected_model
+):
+    workflow = _load("gemini-dispatch.yml")
+    final = _step(workflow, "review", "Set final review result")
+    output = tmp_path / "github-output"
+
+    result = subprocess.run(
+        ["bash", "-c", final["run"]],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "PRIMARY_OUTCOME": primary_outcome,
+            "PRIMARY_MODEL": "primary-model",
+            "PRIMARY_RESPONSE": "PRIMARY BODY",
+            "PRIMARY_ERRORS": "",
+            "FALLBACK_OUTCOME": fallback_outcome,
+            "FALLBACK_MODEL": "fallback-model",
+            "FALLBACK_RESPONSE": "FALLBACK BODY",
+            "FALLBACK_ERRORS": "",
+            "GITHUB_OUTPUT": str(output),
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    outputs = _github_delimited_outputs(output)
+    assert outputs["outcome"] == expected_outcome
+    assert outputs["model"] == expected_model
+    if expected_outcome == "failure":
+        # 취소·타임아웃은 오류 텍스트를 남기지 않으므로 실행 상태가 원인으로 남아야 한다.
+        assert f"primary={primary_outcome}" in outputs["errors"]
+        assert f"fallback={fallback_outcome}" in outputs["errors"]
 
 
 def _extract_gemini_python() -> str:


### PR DESCRIPTION
Closes #84

## 문제

`gemini-dispatch` 의 fallback 게이트가 `steps.gemini_review_primary.outcome == 'failure'` 하나뿐이라, primary 가 **`cancelled`** 로 끝나면 조건을 만족하지 못해 fallback 이 `skipped` 된다. primary 스텝은 `continue-on-error: true` 라 잡은 계속 진행하지만 **리뷰 결과가 전혀 생성되지 않는다.**

실사례(이슈 #84): redmine PR #58, run [33503734795](https://github.com/jhw7500/redmine/actions/runs/33503734795) — primary `cancelled`, fallback `skipped`, 로그에 `The operation was canceled.`

부수 문제 두 가지도 같이 있었다.

- **실패 원인이 남지 않는다.** `Set final review result` 는 실패 시 `errors="$PRIMARY_ERRORS"` 를 쓰는데, 취소·타임아웃은 오류 텍스트를 만들지 않으므로 sticky 코멘트에 원인이 비어서 게시된다.
- **중간 코멘트가 부정확하다.** `## ⚠️ Primary Model Failed` 는 취소를 "failed" 로 뭉뚱그린다.

## 변경 — `.github/workflows/gemini-dispatch.yml`

**1. fallback 자격 정규화** (4곳: review 2 + invoke 2)

```
contains(fromJSON('["failure","cancelled","timed_out"]'), steps.<primary>.outcome)
```

`success` 와 `skipped` 는 제외해 fail-closed 를 유지한다. fallback 은 단일 스텝이라 여전히 최대 1회이고, 호출 예산 제한도 그대로다.

**2. 실패 원인 기록** — 실패 분기에서 실행 상태를 원인으로 남긴다.

```
primary=cancelled; fallback=not_run
```

오류 텍스트가 있으면 그 앞에 붙인다. 이 값이 `final_review.outputs.errors` 로 흘러 sticky 코멘트에 렌더된다.

**3. 중간 코멘트 정확화** — `**Primary Outcome:** <outcome>` 줄 추가.

## 범위 판단

invoke 경로(`gemini_invoke_primary`)도 **동일한 결함**이라 함께 고쳤다. 이슈의 완료 조건이 "`failure`, `timed_out`, `cancelled` 모두 fallback 대상으로 정규화" 로 일반 진술이고, 한쪽만 고치면 같은 버그가 그대로 남는다.

## 검증

- 신규 테스트 3종 (`tests/test_review_workflow_logic.py`)
  - `if` 조건 계약(정규화된 allow-list) 고정
  - review·invoke 네 스텝이 `cancelled`/`timed_out` 을 포함하고 `'success'` 를 포함하지 않음 + 중간 코멘트의 `PRIMARY_OUTCOME` 전달
  - `Set final review result` 를 실제 실행하는 파라미터 5케이스 — `success/skipped`, `cancelled/success`, `failure/success`, `cancelled/skipped`, `timed_out/failure`
- **되돌림 확인 완료**: 게이트를 `== 'failure'` 로 되돌리면 `test_dispatch_falls_back_for_every_non_success_primary_outcome` 이 실제로 실패한다
- 기존 보안 테스트 보강: `test_failure_comments_propagate_adversarial_error_text_as_data` 가 스텝이 새로 선언한 `PRIMARY_OUTCOME` 을 env 로 공급하고, 그 값이 데이터로 전달되는지도 확인한다
- 전체 스위트 **2 failed / 2888 passed / 48 subtests** — 실패 2건은 unmodified main 에서도 실패하는 로컬 `umask 0002` 파일모드 문제(CI 는 통과)
- `actionlint 1.7.12 -shellcheck= -pyflakes=` exit 0

## 후속

`gemini-dispatch.yml` 은 fleet 배포 대상이므로 머지 후 v1.56 릴리스와 롤아웃이 필요하다.
