### PR TITLE
chore(workflows): default rollout to v1.56

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.55",
+  "automation_ref": "v1.56",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.55"
+    assert config.automation_ref == "v1.56"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
v1.56 릴리스(tag object 52e5fd4975124bf5a5ef202456df2d951a3fe474, commit 03461f81a8dd06b5cda34f2f9dba9acd925f2a85)를 fleet 기본 핀으로 승격한다.

- 검증: `python3 -m scripts.verify_workflow_release --ref v1.56 --expected-commit 03461f81…` → PASS
- 관련: #84 (PR #97 머지)