### PR TITLE
fix(gemini): keep provider failures out of the candidate document

### DIFF
--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -589,6 +589,7 @@ jobs:
             "$GITHUB_WORKSPACE/gemini-review-result.json" \
             "$GITHUB_WORKSPACE/gemini_review.py" \
             "$GITHUB_WORKSPACE/gemini_failure_reason.txt" \
+            "$GITHUB_WORKSPACE/gemini_provider_error.txt" \
             "$GITHUB_WORKSPACE/review_diff_truncated.txt"
 
       - name: Start Gemini review metrics
@@ -664,6 +665,7 @@ jobs:
               USING_CURRENT_SDK = False
 
           FAILURE_REASON_FILE = 'gemini_failure_reason.txt'
+          PROVIDER_ERROR_FILE = 'gemini_provider_error.txt'
 
           class ProviderFailure(RuntimeError):
               pass
@@ -1270,8 +1272,11 @@ jobs:
           except Exception as e:
               print(f"Error generating review: {e}")
               record_failure_reason(provider_failure_reason(e))
-              with open('gemini_review.md', 'w') as f:
-                  f.write(f"⚠️ Failed to generate Gemini review: {str(e)}")
+              # 후보 문서에는 모델 출력만 담는다. provider 오류를 여기에 쓰면
+              # 정규화기가 그것을 산문으로 읽어 ambiguous_document 로 거부하고,
+              # provider 실패가 문서 포맷 오류로 위장된다.
+              with open(PROVIDER_ERROR_FILE, 'w') as f:
+                  f.write(f"Failed to generate Gemini review: {str(e)}\n")
               exit(1)
           PYTHON_EOF
 
@@ -1300,7 +1305,7 @@ jobs:
           }; then
             review_exit=124
             printf '%s' 'provider_timeout' > gemini_failure_reason.txt
-            printf '%s\n' '⚠️ Failed to generate Gemini review: provider request exceeded the process deadline' > gemini_review.md
+            printf '%s\n' 'Failed to generate Gemini review: provider request exceeded the process deadline' > gemini_provider_error.txt
           fi
           printf 'diff_truncated=%s\n' "$(cat review_diff_truncated.txt 2>/dev/null || printf 'false')" >> "$GITHUB_OUTPUT"
           printf 'failure_reason=%s\n' "$(cat gemini_failure_reason.txt 2>/dev/null || printf 'provider_failed')" >> "$GITHUB_OUTPUT"
@@ -1417,6 +1422,18 @@ jobs:
         with:
           name: gemini-candidate-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ github.workspace }}/gemini_review.md
+          if-no-files-found: ignore
+          retention-days: 1
+          overwrite: false
+
+      # provider 오류 원문은 untrusted provider 출력이므로 정규화기 소유 진단과
+      # 섞지 않고 별도 아티팩트로 올린다.
+      - name: Upload Gemini provider error
+        if: ${{ always() && steps.review-budget-claim.outputs.allow-invocation == 'true' && hashFiles('gemini_provider_error.txt') != '' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: gemini-provider-error-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ github.workspace }}/gemini_provider_error.txt
           if-no-files-found: ignore
           retention-days: 1
           overwrite: false

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -481,7 +481,16 @@ and it stays untrusted provider output that no program reads: the upsert program
 opens the raw file, and the failure comment cites only the artifact name, and only when that
 upload step reported success. The workspace path is safe because the reset step removes it with
 `rm -f --` before generation and the canonicalizer runs only after that reset succeeds, so no
-checkout-seeded symlink target survives. A missing result is ignored. The diagnostic is not authority: neither the upsert program nor later review state or
+checkout-seeded symlink target survives. A missing result is ignored.
+
+A Gemini provider failure or process-deadline timeout never writes into the candidate file.
+Writing it there made the canonicalizer read provider text as a document and report
+`ambiguous_document`/`preamble`, so a provider outage looked like a model format regression.
+The reason still travels through `gemini_failure_reason.txt` to the sticky comment, and the
+provider text is uploaded as its own one-day, non-overwriting `gemini-provider-error-<run>-<attempt>`
+artifact — never merged into the canonicalizer-owned diagnostic, which stays bounded schema-1
+output. With no candidate file the canonicalizer reports `candidate_missing`, which is what
+actually happened. The diagnostic is not authority: neither the upsert program nor later review state or
 carryover reads it. For `ambiguous_document`, logs expose only a fixed structural diagnostic code
 such as `preamble`, `unknown_section_before_document`,
 `unknown_section_after_document`, or `invalid_finding_heading`; candidate text is never copied into

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -663,12 +663,12 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256 = (
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
     "claude": "d4db53b86603a3a113999409e2e4e35c397adf276981e7f68c0ea57a6198faa2",
-    "gemini": "531c91663071e8a4985c85d6bc123024c29ee9e9efefc834ea6f5b440ccca41b",
+    "gemini": "cbd69aba74ec0f3380591f14d0adcb6543faad5e237a855dbec246750e2b5206",
     "opencode": "c13a61cf3362586da6230f3de03f623fea8e50b9756f337408351c35d970c0f0",
 }
 EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256 = {
     "claude": "8e16c59b04aeaaf7419571b0bda3fb1e46a29da3b847bbb0409ab0437a1027d7",
-    "gemini": "a395bbfe4ec6a09449812968b32716fe16cd23567820a612197238e57c24b8f7",
+    "gemini": "ac48c84dbc60071e88f89d6ecadebb781b50d5beb7da0e0a1ec363fab5599ce8",
     "opencode": "947600cb0ae3d0564a59ba03f8eccc4b5fa991138b280152c24e18e61ecc25a2",
 }
 EXPECTED_REVIEW_POLICY_HELPER_SHA256 = (
@@ -5968,6 +5968,31 @@ def _expected_review_candidate_upload_step(
     }
 
 
+def _expected_provider_error_upload_step(
+    contract: dict[str, str],
+) -> dict[str, object]:
+    reviewer = contract["reviewer"]
+    return {
+        "name": f"Upload {reviewer.capitalize()} provider error",
+        "if": (
+            "${{ always() "
+            "&& steps.review-budget-claim.outputs.allow-invocation == 'true' "
+            f"&& hashFiles('{reviewer}_provider_error.txt') != '' }}}}"
+        ),
+        "uses": UPLOAD_ARTIFACT_ACTION,
+        "with": {
+            "name": (
+                f"{reviewer}-provider-error-${{{{ github.run_id }}}}-"
+                "${{ github.run_attempt }}"
+            ),
+            "path": f"${{{{ github.workspace }}}}/{reviewer}_provider_error.txt",
+            "if-no-files-found": "ignore",
+            "retention-days": "1",
+            "overwrite": "false",
+        },
+    }
+
+
 def _verify_review_publication_contracts(
     documents: dict[str, dict], ref: str
 ) -> None:
@@ -6023,6 +6048,21 @@ def _verify_review_publication_contracts(
                 )
             ):
                 raise ValueError("rejected review diagnostic differs")
+            # provider 오류 원문은 정규화기 소유 진단과 신뢰 등급이 달라 별도
+            # 아티팩트로 올린다. gemini 만 provider 예외를 파일로 남긴다.
+            if budget and contract["reviewer"] == "gemini":
+                provider_error_upload = _named_step(
+                    job, f"Upload {contract['reviewer'].capitalize()} provider error"
+                )
+                if provider_error_upload != _expected_provider_error_upload_step(
+                    contract
+                ):
+                    raise ValueError("provider error upload differs")
+                if not (
+                    job["steps"].index(provider_error_upload)
+                    < job["steps"].index(rejected_diagnostic_upload)
+                ):
+                    raise ValueError("provider error upload order differs")
             candidate_upload = None
             if budget:
                 candidate_upload = _named_step(

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -17500,5 +17500,68 @@ def test_claude_success_comment_omits_the_raw_candidate_pointer(tmp_path):
     assert "claude-candidate-" not in _single_mutation_body(calls)
 
 
+
+def test_gemini_provider_failure_never_writes_a_candidate_document(tmp_path):
+    """provider 오류를 후보 파일에 쓰면 정규화기가 그것을 문서 오류로 거부한다."""
+
+    (tmp_path / "gemini_review.py").write_text(
+        _extract_gemini_python(), encoding="utf-8"
+    )
+    _write_legacy_gemini_request_stub(
+        tmp_path,
+        "        raise RuntimeError(\"403 PERMISSION_DENIED. "
+        "{'error': {'message': 'Your project has been denied access.'}}\")\n",
+    )
+    _write_gemini_script_inputs(tmp_path)
+
+    result = subprocess.run(
+        ["python3", "gemini_review.py"],
+        cwd=tmp_path,
+        env=_gemini_script_env(tmp_path),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    # 후보 문서는 모델 출력만 담는다 — 없으면 candidate_missing 이 정확한 진단이다.
+    assert not (tmp_path / "gemini_review.md").exists()
+    provider_error = (tmp_path / "gemini_provider_error.txt").read_text(encoding="utf-8")
+    assert "403 PERMISSION_DENIED" in provider_error
+    assert (tmp_path / "gemini_failure_reason.txt").read_text().strip() != ""
+
+
+def test_gemini_provider_error_is_uploaded_outside_the_canonicalizer_diagnostic():
+    workflow = _load("gemini-auto-review.yml")
+    steps = workflow["jobs"]["gemini-review"]["steps"]
+    names = [step.get("name") for step in steps]
+    reset = _step(workflow, "gemini-review", "Reset Gemini review artifacts")
+    provider_error = _step(workflow, "gemini-review", "Upload Gemini provider error")
+    diagnostic = _step(
+        workflow, "gemini-review", "Upload rejected Gemini review diagnostic"
+    )
+
+    assert "gemini_provider_error.txt" in reset["run"]
+    # 정규화기 소유 진단은 bounded 결과 JSON 만 담는다 — untrusted 원문을 섞지 않는다.
+    assert diagnostic["with"]["path"] == (
+        "${{ github.workspace }}/gemini-review-result.json"
+    )
+    assert provider_error["with"] == {
+        "name": "gemini-provider-error-${{ github.run_id }}-${{ github.run_attempt }}",
+        "path": "${{ github.workspace }}/gemini_provider_error.txt",
+        "if-no-files-found": "ignore",
+        "retention-days": "1",
+        "overwrite": "false",
+    }
+    assert provider_error["if"] == (
+        "${{ always() "
+        "&& steps.review-budget-claim.outputs.allow-invocation == 'true' "
+        "&& hashFiles('gemini_provider_error.txt') != '' }}"
+    )
+    assert names.index("Upload Gemini provider error") < names.index(
+        "Upload rejected Gemini review diagnostic"
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Closes #99

## 문제

provider 오류가 **문서 포맷 오류로 위장**됐다. 진단 아티팩트만 보면 모델이 잘못된 문서를 낸 것처럼 보인다.

```
failure_reason = ambiguous_document
rule           = preamble
line = 1, column = 1
```

실제 원인은 `403 PERMISSION_DENIED` / `503 UNAVAILABLE` / `504 DEADLINE_EXCEEDED` 였다.

원인은 provider 예외·하드 타임아웃 경로가 **에러 문구를 후보 파일에 쓰기** 때문이다(`gemini-auto-review.yml`의 `except` 블록과 워치독 분기). 그 다음 `Canonicalize Gemini review` 가 그 파일을 후보 문서로 읽어 산문이라 거부한다. 정규화기는 정상 동작이고 입력이 잘못 주어진 것이다.

v1.53 롤아웃에서 이 위장 때문에 "모델이 결정적으로 같은 잘못된 문서를 낸다"는 오진에 도달했다 — 세 저장소의 후보 sha256 이 동일했던 이유는 같은 403 에러 문자열이었기 때문이다.

## 변경 (A안)

1. **후보 파일 오염 제거** — provider 예외와 하드 타임아웃이 `gemini_review.md` 대신 `gemini_provider_error.txt` 에 기록한다. 후보 문서는 모델 출력만 담는다.
2. **원문 보존 유지** — provider 오류 원문을 `gemini-provider-error-<run>-<attempt>` 아티팩트로 올린다(1일, 덮어쓰기 금지, 파일이 있을 때만).
3. `Reset Gemini review artifacts` 목록에 새 파일 추가.
4. 릴리스 계약에 새 스텝 형태·순서를 고정하고 다이제스트 2종을 갱신.

**효과**: provider 실패 라운드에는 후보 파일이 없으므로 정규화기가 `candidate_missing` 을 보고한다 — "모델 출력이 없다" 는 사실과 일치한다. sticky 코멘트의 `Reason:` 은 기존대로 `gemini_failure_reason.txt` 채널을 쓰므로 변화 없다.

## 설계에서 한 번 교정한 것

처음에는 provider 오류를 **기존 진단 아티팩트에 함께** 올렸는데, `test_rejected_candidates_retain_only_canonicalizer_owned_diagnostics` 가 이를 거부했다.

```python
assert "candidate" not in upload["with"]["path"]
assert upload["with"]["path"].endswith("-result.json")
```

거부 진단은 **정규화기 소유의 bounded schema-1 출력만** 담는다는 의도적 경계였다. untrusted provider 원문은 신뢰 등급이 다르므로 별도 아티팩트로 분리했다. 기존 계약이 설계 오류를 잡아준 사례다.

## 범위

Claude 경로에는 이 결함이 없다 — 모델이 직접 `claude-review.md` 를 쓰고 워크플로가 에러 문구를 넣지 않는다. Gemini 전용으로 한정했다.

## 검증

- 신규 회귀 테스트 2건 — provider 예외 시 후보 파일 부재 + 오류 원문 기록(스크립트 실제 실행), 업로드 스텝 형태·순서와 진단 아티팩트 불변성
- **되돌림 확인 완료**: 에러를 다시 후보 파일에 쓰도록 되돌리면 `test_gemini_provider_failure_never_writes_a_candidate_document` 가 실패한다
- `tests/test_verify_workflow_release.py` → 2 failed / 572 passed (실패 2건은 unmodified main 에서도 실패하는 로컬 `umask 0002` 파일모드 문제)
- `actionlint 1.7.12 -shellcheck= -pyflakes=` exit 0
- 다이제스트 갱신: `EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256["gemini"]`, `EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256["gemini"]`(v1.47 변형본)
