### PR TITLE
chore(workflows): default rollout to v1.57

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.56",
+  "automation_ref": "v1.57",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.56"
+    assert config.automation_ref == "v1.57"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
v1.57 릴리스(tag object 966c9b525c3558579f6b42ac44fb1dc5429455b4, commit c1595f277c819c7ccf9ff2ab3ad01e5afabdda45)를 fleet 기본 핀으로 승격한다.

- 검증: `verify_workflow_release --ref v1.57 --expected-commit c1595f27…` → PASS
- 관련: #99 (PR #101 머지)