### PR TITLE
chore(workflows): default rollout to v1.58

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.57",
+  "automation_ref": "v1.58",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.57"
+    assert config.automation_ref == "v1.58"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
v1.58 릴리스(tag object 773961b2cf60f9c3dea682d44809fa6af4b68a91, commit 1b98172325533ef6ad37f3d2cfc3870073fac26d)를 fleet 기본 핀으로 승격한다.

- 검증: `verify_workflow_release --ref v1.58 --expected-commit 1b981723…` → PASS
- 관련: #100 (PR #103 머지)