### PR TITLE
test: recheck codex review connectivity

### DIFF
--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -952,3 +952,5 @@ normal CI, review, and GitHub merge controls. After merge, verify default-branch
 with `scripts/audit_workflow_fleet.py`. See
 [`docs/workflow-fleet-rollout.md`](../workflow-fleet-rollout.md) for exact commands,
 canaries, bootstrap, and recovery.
+
+<!-- codex connectivity recheck: 확인용 일회성 PR — 머지하지 않는다 -->


### PR DESCRIPTION
이슈 #83 재확인용 **일회성 PR — 머지하지 않는다.**

automation 을 Codex cloud 에 등록한 뒤 리뷰가 실제로 오는지 판별한다.

- 정상 리뷰 → 등록 완료·동작
- "create an environment for this repo" → 아직 미등록
- 무응답 → wlan-driver-v2 와 같은 상태

자체 리뷰어는 `review:skip` 으로 제외한다. 확인 후 PR 과 브랜치는 삭제한다.