### PR TITLE
docs(review): enable Codex automatic reviews

### DIFF
--- a/docs/superpowers/plans/2026-08-31-review-mode-jhw-commands.md
+++ b/docs/superpowers/plans/2026-08-31-review-mode-jhw-commands.md
@@ -668,6 +668,10 @@ code_review:
 
 For repositories with Codex Code review, record operator confirmation that Code review remains enabled and Automatic reviews is disabled. Do not install a new App merely to satisfy this feature. Repositories without an App mark that channel `UNAVAILABLE`.
 
+> **Superseded 2026-09-03:** Codex Automatic reviews is now **enabled**, so Codex reviews every
+> pull request alongside the managed reviewers. The operator confirmation described below is no
+> longer required. See `docs/workflows/contracts.md` for the current policy.
+
 - [ ] **Step 5: Publish in bounded batches**
 
 Publish the fleet plan first to the already-proven jhw-notion canary, then batches of at most four repositories. For each rollout PR, verify immutable caller pins, `ready_for_review`, `review_mode`, unchanged auth profile, actionlint, and config preservation before merge. Stop the batch on any duplicate App review, provider invocation under skip/draft/conflict, label race, or verifier mismatch.

--- a/docs/superpowers/plans/2026-08-31-review-mode-workflow-control.md
+++ b/docs/superpowers/plans/2026-08-31-review-mode-workflow-control.md
@@ -536,6 +536,10 @@ In `docs/workflows/contracts.md`, add sections that state:
 - labels control only managed Claude/Gemini/OpenCode workflows;
 - `/jhw:pr` posts `@codex review` and `/gemini review` after the final ready head;
 - Codex Code review remains enabled while Automatic reviews is disabled in ChatGPT Codex settings;
+
+> **Superseded 2026-09-03:** Codex Automatic reviews is now **enabled**, so Codex reviews every
+> pull request alongside the managed reviewers. The operator confirmation described below is no
+> longer required. See `docs/workflows/contracts.md` for the current policy.
 - Gemini uses only `pull_request_opened.code_review: false` and preserves all unrelated existing keys;
 - `review:skip` cannot cancel an already-started App or workflow review; and
 - fleet activation stops without Codex operator confirmation and mechanically verified Gemini config.

--- a/docs/superpowers/specs/2026-08-31-review-mode-command-control-design.md
+++ b/docs/superpowers/specs/2026-08-31-review-mode-command-control-design.md
@@ -220,6 +220,10 @@ External Apps must not retain PR-open automatic review while command-level selec
 ### 9.1 Codex
 
 Keep repository Code review enabled, turn off **Automatic reviews** in Codex repository settings,
+
+> **Superseded 2026-09-03:** Codex Automatic reviews is now **enabled**, so Codex reviews every
+> pull request alongside the managed reviewers. The operator confirmation described below is no
+> longer required. See `docs/workflows/contracts.md` for the current policy.
 and use the documented `@codex review` PR comment for explicit requests. This separates App access
 from automatic invocation. The JHW command cannot safely mutate this account-level setting, so
 activation requires a one-time operator confirmation.

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -178,8 +178,9 @@ their managed callers. These inventory and semantic checks apply only to `v1.51+
 earlier release retain their existing closed inventories and historical caller contracts.
 
 `/jhw:pr` posts `@codex review` and `/gemini review` after the final ready head, so manual
-App review remains available. Operators must keep Codex Code review enabled while disabling
-Automatic reviews in ChatGPT Codex settings. Gemini disables only PR-open automatic review:
+App review remains available. Codex keeps both Code review and **Automatic reviews** enabled in
+ChatGPT Codex settings, so Codex reviews every pull request like the managed reviewers do. Gemini
+disables only PR-open automatic review:
 
 ```yaml
 code_review:
@@ -192,10 +193,16 @@ and preserves unrelated existing Gemini configuration keys. `review:skip` cannot
 or managed-workflow review that has already started. Fleet activation stops unless an operator
 confirms the Codex setting and the Gemini configuration is mechanically verified.
 
+`review:skip` and `review:request` steer only the managed Actions reviewers. They do not reach
+Codex, whose automatic review is decided entirely in ChatGPT Codex settings, so a `review:skip`
+pull request still receives a Codex review. Codex also needs its repository registered under
+Codex code-review settings; a custom cloud environment is not required, because the default
+`universal` image serves review. An unregistered repository either answers a mention with
+"create an environment for this repo" or stays silent, and no review appears.
+
 To roll back the external-App opt-in, restore only Gemini's
-`pull_request_opened.code_review` value to `true` and re-enable Automatic reviews in ChatGPT
-Codex settings; keep Codex Code review enabled. No label or managed-workflow policy changes are
-needed for this rollback.
+`pull_request_opened.code_review` value to `true`; keep Codex Code review and Automatic reviews
+enabled. No label or managed-workflow policy changes are needed for this rollback.
 
 ## Deterministic automated-review input
 


### PR DESCRIPTION
Codex 자동 리뷰를 켜는 결정에 맞춰 문서를 갱신한다. 워크플로·코드 변경은 없다(문서 전용).

## 배경

이슈 #83 조사 과정에서 확인된 사실들이다.

- Codex 커넥터는 정상 동작한다 — automation 85초, wlan-driver-v2 71초로 실제 리뷰 확인.
- **environment 는 불필요**하다. 두 저장소 모두 environments 목록에 없는 상태로 리뷰가 돌았다. 필요한 것은 Codex code-review settings 등록뿐이다.
- 롤아웃 PR 들에 Codex 리뷰가 없던 이유는 **Automatic reviews 가 꺼져 있었기 때문**이며, 이는 v1.51 리뷰 모드 설계의 의도된 결정이었다.

관리 리뷰어(Claude · Gemini · OpenCode)는 `default_auto_true`(`resolve_review_policy.py:_automatic_decision`)로 **기본 자동 실행**이고 `review:skip` 으로 끄는 구조인데, Codex 만 반대(기본 꺼짐 + 멘션으로 켬)여서 일관되지 않았다. 이 PR 은 Codex 를 나머지와 같은 기본값으로 맞춘다.

## 변경

**`docs/workflows/contracts.md`** — 살아 있는 계약이므로 새 정책으로 교체했다.

- "keep Codex Code review enabled while **disabling** Automatic reviews" → **둘 다 enabled**
- 롤백 절차에서 Codex 재활성화 단계 제거(이제 계속 켜둔다)
- 새로 명시한 것:
  - `review:skip` / `review:request` 는 **관리 Actions 리뷰어만** 제어한다. Codex 에는 닿지 않으므로 `review:skip` PR 에도 Codex 리뷰가 붙는다.
  - Codex 는 저장소가 code-review settings 에 등록돼야 하며 **커스텀 environment 는 불필요**하다(기본 `universal` 이미지로 충분).
  - 미등록 저장소는 멘션에 "create an environment for this repo" 로 답하거나 무응답이다.

**계획·설계 문서 3건** — 실행이 끝난 이력이므로 원문은 보존하고 supersede 주석만 덧붙였다. 다음 세션이 낡은 운영 요구사항(Automatic reviews 비활성 확인)을 그대로 따르지 않도록 하기 위함이다.

## 검증

- `test_canonical_workflow_tree.py` · `test_workflow_catalog.py` · `test_legacy_workflow_writers.py` → 59 passed
- 워크플로 바이트 변경 없음 → **릴리스·롤아웃 불필요**, 다이제스트 갱신 불필요

## 운영자 조치

ChatGPT Codex 설정에서 **Automatic reviews 를 켜야** 이 문서와 실제 동작이 일치한다. 토글은 계정 화면에서만 가능하다.
