### PR TITLE
fix(review): default managed reviewers to opt-in

### DIFF
--- a/.github/actions/resolve-review-policy/resolve_review_policy.py
+++ b/.github/actions/resolve-review-policy/resolve_review_policy.py
@@ -181,7 +181,7 @@ def _automatic_decision(request: PolicyRequest, head_sha: str) -> PolicyDecision
             f"review_auto_{str(automatic).lower()}",
             head_sha,
         )
-    return PolicyDecision(True, "auto", "default_auto_true", head_sha)
+    return PolicyDecision(False, "auto", "default_auto_false", head_sha)
 
 
 def _required_boolean(value: object, error: str) -> bool:

--- a/docs/superpowers/plans/2026-08-31-review-mode-jhw-commands.md
+++ b/docs/superpowers/plans/2026-08-31-review-mode-jhw-commands.md
@@ -187,6 +187,12 @@ assert.notEqual((await runMode("--review --no-review")).code, 0);
 
 Add global-config cases proving `review.auto: true`, `review.auto: false`, and missing config resolve to `true`, `false`, and compatibility `true`; a non-boolean value must fail before mutation.
 
+> **Pending change 2026-09-03 (issue #109):** automation's resolver defaults the absent-key case to
+> `false` from `v1.59`. The `jhw_pr_global_auto_enabled` compatibility default described here and in
+> Steps 3 and 6 still reads `true` and must stay `true` until the `v1.59` fleet rollout has landed on
+> every target; changing it earlier would describe neither the pre-rollout nor the post-rollout fleet.
+> The jhw-notion skill update is tracked in issue #109 as a separate, later pull request.
+
 Add a mutation-log fake `gh` and assert exact order for new and existing PRs:
 
 ```javascript

--- a/docs/superpowers/plans/2026-08-31-review-mode-workflow-control.md
+++ b/docs/superpowers/plans/2026-08-31-review-mode-workflow-control.md
@@ -20,6 +20,13 @@
 - `review:request` overrides automatic mode but never overrides `workflows.<name>.enabled`.
 - Automatic precedence remains `workflows.<name>.auto -> review.auto -> true`.
 - The baseline remains explicit `review.auto: false`.
+
+> **Superseded 2026-09-03 (issue #109):** from `v1.59` the automatic precedence ends in `false`,
+> not `true`. `_automatic_decision` returns `default_auto_false` when both keys are absent, so a
+> repository without a `review:` key now matches the baseline instead of reviewing every pull
+> request; `review:request` is the opt-in. This supersedes the precedence line above, the
+> `_automatic_decision` requirement in Step 3, and the `default_auto_true` entry in the
+> expected-literal list later in this plan. Current policy: `docs/workflows/contracts.md`.
 - Keep existing review prompts, finding grammar, quality schemas, and blocking thresholds unchanged.
 - Preserve historical releases; the new local action is required only for `v1.51+`.
 - Do not move or recreate an immutable release tag.

--- a/docs/superpowers/specs/2026-08-31-review-mode-command-control-design.md
+++ b/docs/superpowers/specs/2026-08-31-review-mode-command-control-design.md
@@ -25,6 +25,12 @@ Repository-managed PR workflows use two GitHub labels as the durable override co
 | neither | Use each workflow's existing `workflows.<name>.auto`, then `review.auto`, then compatibility default |
 | both | Configuration error; fail closed without invoking a model |
 
+> **Superseded 2026-09-03 (issue #109):** the compatibility default in the `neither` row is now
+> `false`. From `v1.59` the managed-workflow precedence is
+> `workflows.<name>.auto -> review.auto -> false`, so the absent-key case does not invoke a model.
+> This also supersedes the compatibility-default paragraph and precedence block in section 3.
+> Current policy: `docs/workflows/contracts.md`.
+
 The labels control repository-managed workflows. `/jhw:pr` applies the same effective policy to
 external GitHub Apps by posting their documented manual commands when review is requested. App
 automatic-review settings are disabled separately so PR-open events do not bypass the command

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -148,6 +148,10 @@ review:
 ```
 
 For auto-review callers, `workflows.<name>.auto` takes precedence over `review.auto`.
+Beginning with `v1.59`, a repository that sets neither key resolves to `default_auto_false`, so
+the managed reviewers stay off until a pull request opts in. A repository that never adds the key
+therefore behaves exactly like one that copied the baseline above. Releases through `v1.58`
+resolved that same absent-key case to `default_auto_true`.
 Manual mention/comment and manual-dispatch behavior remains available when the applicable
 caller is enabled. The disabled bootstrap template uses `workflows.<name>.enabled: false`
 for every common caller; enabling any of them is a later repository-owned PR.
@@ -161,7 +165,8 @@ order: both labels are `conflict`; only `review:request` is `request`; only `rev
 `force_review` change `auto` to `request`. `conflict` fails before a model is invoked. Draft
 PRs, `skip`, unsafe forks, and closed PRs succeed without invoking a model. `request` never overrides
 `workflows.<name>.enabled: false`, and `workflows.<name>.auto` still takes precedence over the
-baseline `review.auto: false`.
+baseline `review.auto: false`. With neither label and neither configuration key, `auto` resolves
+to `default_auto_false` and no model is invoked; `review:request` is the per-pull-request opt-in.
 
 Beginning with `v1.51`, the closed release inventory also contains exactly these regular,
 non-executable `100644` files:
@@ -196,6 +201,26 @@ To roll back the external-App opt-in, restore only Gemini's
 `pull_request_opened.code_review` value to `true` and re-enable Automatic reviews in ChatGPT
 Codex settings; keep Codex Code review enabled. No label or managed-workflow policy changes are
 needed for this rollback.
+
+### Opt-in per review channel
+
+Every review channel is off by default and requires an explicit opt-in:
+
+| Channel | Default | Opt-in |
+| --- | --- | --- |
+| Managed Actions reviewers (Claude, Gemini, OpenCode) | off, from `default_auto_false` or the baseline `review.auto: false` | the `review:request` label, `workflows.<name>.auto: true`, or `review.auto: true` |
+| Codex Code review | off, because Automatic reviews stays disabled in ChatGPT Codex settings | a `@codex review` pull-request comment |
+| Gemini Code Assist App | off, from `pull_request_opened.code_review: false` | a `/gemini review` pull-request comment |
+
+`/jhw:pr --review` applies the label and posts both mentions, so opting one pull request into all
+three channels is a single command.
+
+`review:skip` and `review:request` steer only the managed Actions reviewers. They never reach
+Codex, whose automatic review is decided entirely in ChatGPT Codex settings, so neither label
+changes Codex behavior. Codex does require the repository to be registered under Codex code-review
+settings; a custom cloud environment is not required, because the default `universal` image serves
+review. An unregistered repository either answers a mention with "create an environment for this
+repo" or stays silent, and no review appears.
 
 ## Deterministic automated-review input
 

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -215,6 +215,15 @@ Every review channel is off by default and requires an explicit opt-in:
 `/jhw:pr --review` applies the label and posts both mentions, so opting one pull request into all
 three channels is a single command.
 
+Managed-reviewer opt-in must be in place before the run starts. The callers subscribe to `opened`,
+`synchronize`, and `ready_for_review`, never `labeled`, so adding `review:request` to an
+already-open pull request starts no run by itself; and adding it while a run is already resolving
+fails that run closed with `review_mode_label_mismatch`, because the caller's `review_mode` input
+was read from an event payload that predates the label. Apply the label before the final ready
+head — `/jhw:pr --review` labels the draft and then marks it ready — or, on a pull request that is
+already open, start one authorized same-head review through a `workflow_dispatch` carrying
+`force_review: true`.
+
 `review:skip` and `review:request` steer only the managed Actions reviewers. They never reach
 Codex, whose automatic review is decided entirely in ChatGPT Codex settings, so neither label
 changes Codex behavior. Codex does require the repository to be registered under Codex code-review

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -46,6 +46,7 @@ from scripts.workflow_release_inventory import (
     release_supports_canonicalize_review,
     release_supports_prepare_review_diff,
     release_supports_review_invocation_budget,
+    release_supports_review_optin,
     release_supports_review_policy,
     validate_release_listing,
 )
@@ -674,6 +675,9 @@ EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256 = {
 EXPECTED_REVIEW_POLICY_HELPER_SHA256 = (
     "3e0fd3c86b1dc40dc35213ca41c3d63122c9ebf757042f5a2c86f4fc1e99ac8a"
 )
+EXPECTED_REVIEW_POLICY_HELPER_SHA256_V159 = (
+    "50a4cbaf364e326201c2572435ab4dc9dcac5e14ff4349cfd790a1b26f4092b7"
+)
 EXPECTED_REVIEW_POLICY_RECORDS = {
     "PolicyRequest": (
         ("workflow_name", "str"),
@@ -707,6 +711,11 @@ EXPECTED_REVIEW_POLICY_LITERALS = frozenset(
         "default_auto_true",
     }
 )
+# v1.59 flipped the unconfigured automatic decision to opt-in; every other
+# literal is unchanged, so the delta is stated rather than duplicated.
+EXPECTED_REVIEW_POLICY_LITERALS_V159 = (
+    EXPECTED_REVIEW_POLICY_LITERALS - {"default_auto_true"}
+) | {"default_auto_false"}
 EXPECTED_REVIEW_POLICY_ACTION = yaml.load(
     r"""name: Resolve Review Policy
 description: Resolve a deterministic review policy before model invocation.
@@ -2847,14 +2856,21 @@ def _class_function_headers(node: ast.ClassDef) -> dict[str, str]:
     return functions
 
 
-def require_review_policy_helper_contract(source: str) -> None:
+def require_review_policy_helper_contract(source: str, optin: bool) -> None:
     """Authenticate and statically validate the public policy-helper surface."""
 
+    expected_digest = (
+        EXPECTED_REVIEW_POLICY_HELPER_SHA256_V159
+        if optin
+        else EXPECTED_REVIEW_POLICY_HELPER_SHA256
+    )
+    expected_literals = (
+        EXPECTED_REVIEW_POLICY_LITERALS_V159
+        if optin
+        else EXPECTED_REVIEW_POLICY_LITERALS
+    )
     try:
-        if (
-            hashlib.sha256(source.encode("utf-8")).hexdigest()
-            != EXPECTED_REVIEW_POLICY_HELPER_SHA256
-        ):
+        if hashlib.sha256(source.encode("utf-8")).hexdigest() != expected_digest:
             raise ValueError("helper source digest differs")
         compile(
             source,
@@ -2886,7 +2902,7 @@ def require_review_policy_helper_contract(source: str) -> None:
             "def resolve_policy(request: PolicyRequest) -> PolicyDecision"
         ):
             raise ValueError("policy function differs")
-        direct_literals = EXPECTED_REVIEW_POLICY_LITERALS - {
+        direct_literals = expected_literals - {
             "workflow_auto_false",
             "review_auto_false",
         }
@@ -2951,7 +2967,7 @@ def _verify_review_policy_action(
         raise ReleaseVerificationError(
             "review-policy helper contract is invalid"
         ) from None
-    require_review_policy_helper_contract(helper)
+    require_review_policy_helper_contract(helper, release_supports_review_optin(ref))
 
 
 def _verify_canonicalize_review_helpers(tree: VerifiedCommitTree) -> None:

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -147,6 +147,7 @@ PREPARE_REVIEW_DIFF_RELEASE = (1, 45)
 CANONICALIZE_REVIEW_RELEASE = (1, 46)
 REVIEW_INVOCATION_BUDGET_RELEASE = (1, 47)
 REVIEW_POLICY_RELEASE = (1, 51)
+REVIEW_OPTIN_RELEASE = (1, 59)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -177,6 +178,12 @@ def release_supports_review_policy(ref: str) -> bool:
     """Return whether ``ref`` owns the deterministic review-policy action."""
 
     return _release_version(ref) >= REVIEW_POLICY_RELEASE
+
+
+def release_supports_review_optin(ref: str) -> bool:
+    """Return whether ``ref`` resolves an unconfigured automatic review to ``false``."""
+
+    return _release_version(ref) >= REVIEW_OPTIN_RELEASE
 
 
 def release_roots_for(ref: str) -> tuple[ReleaseRoot, ...]:

--- a/tests/test_review_policy_action.py
+++ b/tests/test_review_policy_action.py
@@ -115,9 +115,34 @@ def test_request_does_not_override_disabled_workflow():
     assert (decision.run_review, decision.reason) == (False, "workflow_disabled")
 
 
-def test_automatic_mode_defaults_to_true_when_not_configured():
-    decision = resolve_policy(request())
-    assert (decision.run_review, decision.reason) == (True, "default_auto_true")
+@pytest.mark.parametrize(
+    "workflow_name",
+    ("claude-code-review", "gemini-auto-review", "opencode-auto-review"),
+)
+def test_automatic_mode_defaults_to_false_when_not_configured(workflow_name):
+    decision = resolve_policy(
+        PolicyRequest(
+            workflow_name=workflow_name,
+            review_mode="auto",
+            force_run=False,
+            force_review=False,
+            event_name="pull_request",
+            repository="jhw7500/example",
+            pr=base_pr(),
+            config={},
+        )
+    )
+    assert (decision.run_review, decision.reason) == (False, "default_auto_false")
+
+
+def test_request_label_opts_in_when_config_omits_review_auto():
+    decision = resolve_policy(request(labels=["review:request"], mode="request"))
+    assert (decision.run_review, decision.reason) == (True, "request")
+
+
+def test_skip_label_still_skips_when_config_omits_review_auto():
+    decision = resolve_policy(request(labels=["review:skip"], mode="skip"))
+    assert (decision.run_review, decision.reason) == (False, "skip")
 
 
 def test_action_uses_file_transport_with_expected_interface():

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -99,6 +99,7 @@ REVIEW_POLICY_RELEASE_FILES = (
     ".github/actions/resolve-review-policy/resolve_review_policy.py",
 )
 V1462_WORKFLOW_FIXTURE_COMMIT = "d42c28ddd827554e6e46a2ab49dfe34c838c0425"
+V158_REVIEW_POLICY_HELPER_COMMIT = "1b98172325533ef6ad37f3d2cfc3870073fac26d"
 V1462_WORKFLOW_FIXTURE_SHA256 = {
     "claude-code-review.yml": (
         "008bbdcdeacdaf7796c1e3b59d22194d3f1ce380735d36dada5efab8ff52d112"
@@ -294,7 +295,26 @@ def prepare_v147(repo: Path) -> str:
     )
 
 
-def prepare_v151(repo: Path) -> str:
+def restore_pre_v159_review_policy_helper(repo: Path) -> None:
+    """Restore the authenticated v1.51-v1.58 policy-helper bytes.
+
+    v1.59 flipped the unconfigured automatic decision to opt-in, so the worktree
+    helper no longer satisfies the earlier release line's pinned digest.
+    """
+
+    relative = ".github/actions/resolve-review-policy/resolve_review_policy.py"
+    tree = release_verifier.VerifiedCommitTree.open(
+        ROOT, V158_REVIEW_POLICY_HELPER_COMMIT
+    )
+    payload = tree.read_file(relative)
+    assert (
+        hashlib.sha256(payload).hexdigest()
+        == release_verifier.EXPECTED_REVIEW_POLICY_HELPER_SHA256
+    )
+    (repo / relative).write_bytes(payload)
+
+
+def copy_review_policy_release_files(repo: Path) -> None:
     for relative in (
         ".github/actions/resolve-review-policy/action.yml",
         ".github/actions/resolve-review-policy/resolve_review_policy.py",
@@ -317,7 +337,17 @@ def prepare_v151(repo: Path) -> str:
         else:
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source, target)
+
+
+def prepare_v151(repo: Path) -> str:
+    copy_review_policy_release_files(repo)
+    restore_pre_v159_review_policy_helper(repo)
     return commit(repo, "v1.51 candidate")
+
+
+def prepare_v159(repo: Path) -> str:
+    copy_review_policy_release_files(repo)
+    return commit(repo, "v1.59 candidate")
 
 
 def verify_v147(repo: Path, message: str) -> str:
@@ -1714,6 +1744,35 @@ def test_v151_accepts_current_review_policy_release_contract(
     candidate = prepare_v151(repo)
 
     assert release_verifier.verify_commit_content(repo, "v1.51", candidate) == candidate
+
+
+def test_v159_accepts_current_review_policy_release_contract(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v159(repo)
+
+    assert release_verifier.verify_commit_content(repo, "v1.59", candidate) == candidate
+
+
+def test_v159_opt_in_helper_is_rejected_on_the_v151_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v159(repo)
+
+    with pytest.raises(ReleaseVerificationError, match="review-policy helper"):
+        release_verifier.verify_commit_content(repo, "v1.51", candidate)
+
+
+def test_pre_v159_helper_is_rejected_on_the_v159_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v151(repo)
+
+    with pytest.raises(ReleaseVerificationError, match="review-policy helper"):
+        release_verifier.verify_commit_content(repo, "v1.59", candidate)
 
 
 @pytest.mark.parametrize("relative", REVIEW_POLICY_RELEASE_FILES)


### PR DESCRIPTION
이슈 #109 의 구현 범위 1~4 를 다룬다. 워크플로 바이트는 바뀌지 않으므로 이 PR 자체는 릴리스를 포함하지 않는다 — v1.59 릴리스 + 17타깃 롤아웃은 머지 뒤 별도 단계다.

## 무엇을 바꿨나

**리졸버 기본값** — `_automatic_decision` 이 `workflows.<name>.auto` 와 `review.auto` 가 모두 없을 때 `PolicyDecision(True, "auto", "default_auto_true", ...)` 를 돌려주던 것을 `False` / `default_auto_false` 로 바꿨다. 정본 baseline (`examples/baseline-workflows/.github/workflow-config.yml` = `review.auto: false`) 과 같은 정책을 말하게 된다. `review:request` 는 `_automatic_decision` 이전에 단락되므로 옵트인 경로는 그대로다.

## 왜 핀을 버전 게이팅했나 (이슈 본문에 없던 부분)

헬퍼는 닫힌 릴리스 인벤토리에 들어 있어서, 그 핀은 **이미 발행된 v1.51~v1.58 도 인증**한다. `EXPECTED_REVIEW_POLICY_HELPER_SHA256` 를 새 해시로 그냥 교체하고 v1.58 을 검증해 보면 이렇게 깨진다.

```
FAIL: review-policy helper contract is invalid
```

그래서 `upsert_sha256` / `upsert_sha256_v147` 과 같은 방식으로 처리했다. `release_supports_review_optin(ref)`(v1.59 임계)가 다이제스트와 리터럴 집합을 고른다. 역사 핀은 그대로 남는다.

워크플로 바이트는 그대로라 `EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256` · `EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256` · `upsert_sha256_v147` 은 갱신하지 않았다 (세 워크플로의 실측 해시가 현재 핀과 그대로 일치).

## 문서

- `docs/workflows/contracts.md` — 키가 없을 때의 기본값을 명시하고, 세 채널(관리 리뷰어 · Codex · Gemini App)의 옵트인 방법을 표로 넣었다. `review:skip`/`review:request` 가 Codex 에 닿지 않는다는 점, Codex 는 code-review settings 등록만 필요하고 **environment 는 불필요**하다는 점(#83 실측)을 함께 적었다.
- 계획·설계 문서 3건 — 원문은 보존하고 supersede 주석만 덧붙였다. `jhw-commands.md` 는 **jhw-notion 쪽 서술**이라 "롤아웃 착지 전까지는 `true` 를 유지해야 한다"는 순서 제약을 명시한 pending 주석으로 달았다.

## 검증

| 확인 | 결과 |
|---|---|
| 라벨·설정 없는 PR 에서 관리 리뷰어 3종 | `(False, "default_auto_false")` — 리졸버를 되돌리면 3건 모두 빨개짐 (RED 확인) |
| `review:request` / `review:skip` | 변화 없음 |
| 발행된 v1.58 검증 | `PASS: v1.58 resolves to secure commit 1b98172` |
| 핀 게이팅 회귀 | `test_v159_opt_in_helper_is_rejected_on_the_v151_release_line` · `test_pre_v159_helper_is_rejected_on_the_v159_release_line` — 핀을 하나로 합치면 실패 |
| 전체 스위트 | 2899 passed, 48 subtests passed, 2 failed |

실패 2건은 `test_v145_review_fixtures_match_the_immutable_release_blobs` 로, 로컬 `umask 0002` 때문에 체크아웃 파일 모드가 `664` 로 나오는 기존 환경 실패다 (`git ls-files -s` 는 `100644`, blob OID 일치). HANDOFF.md 에 상시 실패로 기록돼 있다.

## 남은 일

1. 머지 → **v1.59 릴리스** → 17타깃 롤아웃 → audit `current=17 drift=0 blocked=0`
2. **그 다음** jhw-notion `issue.md:10` · `pr.md` 갱신 (별도 저장소, 별도 PR)

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su9whB4FRuyxEijrq2bLWk