### PR TITLE
chore(workflows): default rollout to v1.59

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.58",
+  "automation_ref": "v1.59",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.58"
+    assert config.automation_ref == "v1.59"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
17타깃이 모두 v1.59 로 통일돼 기본 `automation_ref` 를 범프한다.

```
SUMMARY ref=v1.59 commit=49cd25b554a086e9f8684ee7c45171699ff824e1 total=17 current=17 drift=0 blocked=0
```

## 이번 롤아웃이 기존과 다른 점

롤아웃 PR 에 **핀 범프 + 소비자 config 의 `auto: true` 제거**를 함께 담았다. 카나리(redmine #76)에서 핀만 올려서는 아무것도 달라지지 않는다는 것이 확인됐기 때문이다 — 17타깃 전부가 `workflows.claude-code-review.auto: true` · `workflows.gemini-auto-review.auto: true` 를 명시하고 있었고, `workflow_auto_true` 는 `review.auto` 와 리졸버 기본값보다 우선한다. 즉 이슈 #109 가 근거로 든 "소비자는 `review:` 키가 없어 기본값으로 켜진다"는 **최상위 키에만** 해당했다.

### 프로덕션 증거 (redmine #76)

| head | claude-review | gemini-review |
|---|---|---|
| 핀 범프만 | success (모델 호출) | success (모델 호출) |
| + `auto` 제거 | **skipped** | **skipped** |

머지 직전 17타깃 전수 확인: **프로바이더 잡 전부 skipped, 모델 호출 0건.**

## 검증

- `python3 -m scripts.verify_workflow_release --ref v1.59 --expected-commit 49cd25b` → PASS
- `--ref v1.58 --expected-commit 1b98172` → PASS (역사 라인 유지)
- `test_workflow_catalog` · `test_verify_workflow_release` · `test_workflow_release_bundle` → 668 passed / 2 failed

실패 2건은 로컬 `umask 0002` 로 인한 `test_v145_review_fixtures_match_the_immutable_release_blobs` 모드 비교이며 CI 는 통과한다.

Refs #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su9whB4FRuyxEijrq2bLWk