### PR TITLE
feat(budget): read the automatic round budget from REVIEW_MAX_ROUNDS

### DIFF
--- a/.github/actions/review-invocation-budget/action.yml
+++ b/.github/actions/review-invocation-budget/action.yml
@@ -43,6 +43,9 @@ inputs:
   remaining-finding-ids-json:
     required: false
     default: '[]'
+  max-rounds:
+    required: false
+    default: ''
 outputs:
   allow-invocation:
     value: ${{ steps.budget.outputs.allow-invocation }}
@@ -76,6 +79,7 @@ runs:
         EFFORT: ${{ inputs.effort }}
         ACTUAL_CALL_COUNT: ${{ inputs.actual-call-count }}
         ELAPSED_SECONDS: ${{ inputs.elapsed-seconds }}
+        REVIEW_MAX_ROUNDS: ${{ inputs.max-rounds }}
         REVIEW_OUTCOME: ${{ inputs.outcome }}
         STOP_REASON: ${{ inputs.stop-reason }}
         REMAINING_FINDING_IDS_JSON: ${{ inputs.remaining-finding-ids-json }}

--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -85,14 +85,15 @@ def configured_max_rounds() -> int:
     """Read the automatic-round budget from the repository variable, fail-safe.
 
     An absent or empty variable keeps the authenticated default. Anything else that
-    is not a plain decimal integer inside 1..MAX_ROUNDS_CEILING is reported and
-    discarded, so a typo lowers cost rather than raising it.
+    is not a plain ASCII decimal integer inside 1..MAX_ROUNDS_CEILING is reported
+    and discarded, so a typo lowers cost rather than raising it. str.isdigit() alone
+    would accept superscripts and other scripts that int() then rejects.
     """
 
     raw = os.environ.get(MAX_ROUNDS_VARIABLE, "")
     if raw == "":
         return MAX_ROUNDS_DEFAULT
-    value = int(raw) if raw.isdigit() else None
+    value = int(raw) if raw.isascii() and raw.isdigit() else None
     if value is None or not 1 <= value <= MAX_ROUNDS_CEILING:
         print(
             f"{MAX_ROUNDS_VARIABLE}={raw!r} is not an integer in "
@@ -603,9 +604,9 @@ def _validate_state_shape(state: LedgerState) -> None:
     if overrides:
         item = overrides[0]
         expected_automatic_rounds = (
-            range(0, budgets.max_rounds + 1)
+            range(0, state.budgets.max_rounds + 1)
             if item.caller_event == "workflow_dispatch"
-            else (budgets.max_rounds,)
+            else (state.budgets.max_rounds,)
         )
         if (len(automatic) not in expected_automatic_rounds or state.invocations[-1] != item or
                 item.round_number != len(automatic) + 1 or
@@ -849,7 +850,6 @@ def validate_or_initialize(state: LedgerState | None, request: ClaimRequest,
     _validate_request(request)
     validated = LedgerState.initial(request.repository, request.pr, request.reviewer) if state is None else state
     _validate_state_shape(validated)
-    validated = replace(validated, budgets=effective_budgets(validated))
     if (validated.repository, validated.pr, validated.reviewer) != (request.repository, request.pr, request.reviewer):
         raise BudgetStateError("identity_mismatch")
     _validate_provenance(validated, request, provenances)
@@ -1013,7 +1013,7 @@ def claim(state: LedgerState | None, request: ClaimRequest,
         override = choose_override(validated, request.override_events)
         if override is None:
             return refuse(validated, request, "round_budget_exhausted")
-    elif automatic_rounds(validated) >= validated.budgets.max_rounds:
+    elif automatic_rounds(validated) >= effective_budgets(validated).max_rounds:
         override = choose_override(validated, request.override_events)
         if override is None:
             return refuse(validated, request, "round_budget_exhausted")

--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -9,6 +9,7 @@ import math
 import os
 import re
 import stat
+import sys
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Literal, Mapping, Sequence
@@ -75,6 +76,33 @@ def _exact_keys(value: object, keys: set[str], name: str) -> Mapping[str, object
     return value
 
 
+MAX_ROUNDS_VARIABLE = "REVIEW_MAX_ROUNDS"
+MAX_ROUNDS_DEFAULT = 2
+MAX_ROUNDS_CEILING = 5
+
+
+def configured_max_rounds() -> int:
+    """Read the automatic-round budget from the repository variable, fail-safe.
+
+    An absent or empty variable keeps the authenticated default. Anything else that
+    is not a plain decimal integer inside 1..MAX_ROUNDS_CEILING is reported and
+    discarded, so a typo lowers cost rather than raising it.
+    """
+
+    raw = os.environ.get(MAX_ROUNDS_VARIABLE, "")
+    if raw == "":
+        return MAX_ROUNDS_DEFAULT
+    value = int(raw) if raw.isdigit() else None
+    if value is None or not 1 <= value <= MAX_ROUNDS_CEILING:
+        print(
+            f"{MAX_ROUNDS_VARIABLE}={raw!r} is not an integer in "
+            f"1..{MAX_ROUNDS_CEILING}; using {MAX_ROUNDS_DEFAULT}",
+            file=sys.stderr,
+        )
+        return MAX_ROUNDS_DEFAULT
+    return value
+
+
 @dataclass(frozen=True)
 class BudgetPolicy:
     max_rounds: int = 2
@@ -89,6 +117,7 @@ class BudgetPolicy:
         if reviewer not in MARKERS:
             raise BudgetStateError("reviewer_invalid")
         return cls(
+            max_rounds=configured_max_rounds(),
             max_calls_per_round={"claude": 1, "gemini": 3, "opencode": 2}[reviewer],
             max_wall_seconds_per_round={
                 "claude": 1080, "gemini": 600, "opencode": 600,
@@ -500,14 +529,30 @@ class Transition:
     mutate_comment: bool
 
 
+def effective_budgets(state: LedgerState) -> BudgetPolicy:
+    """Take the higher of the recorded and configured round budgets.
+
+    Raising the variable therefore reaches pull requests that are already open, and
+    lowering it never invalidates a ledger that already spent more rounds.
+    """
+
+    return replace(
+        state.budgets,
+        max_rounds=max(state.budgets.max_rounds, configured_max_rounds()),
+    )
+
+
 def _validate_state_shape(state: LedgerState) -> None:
     if state.reviewer not in MARKERS or not isinstance(state.repository, str) or not state.repository:
         raise BudgetStateError("identity_invalid")
     _integer(state.pr, "pr", positive=True)
     BudgetPolicy.from_dict(state.budgets.to_dict())
-    if state.budgets != BudgetPolicy.for_reviewer(state.reviewer):
+    budgets = effective_budgets(state)
+    recorded = {key: value for key, value in state.budgets.to_dict().items() if key != "max_rounds"}
+    expected = {key: value for key, value in BudgetPolicy.for_reviewer(state.reviewer).to_dict().items() if key != "max_rounds"}
+    if recorded != expected or not 1 <= state.budgets.max_rounds <= MAX_ROUNDS_CEILING:
         raise BudgetStateError("budgets_invalid")
-    if len(state.invocations) > 3 or len(state.consumed_override_event_ids) != len(set(state.consumed_override_event_ids)):
+    if len(state.invocations) > budgets.max_rounds + budgets.max_override_rounds or len(state.consumed_override_event_ids) != len(set(state.consumed_override_event_ids)):
         raise BudgetStateError("ledger_invalid")
     if any(isinstance(item, bool) or not isinstance(item, int) or item <= 0 for item in state.consumed_override_event_ids):
         raise BudgetStateError("consumed_override_event_ids_invalid")
@@ -551,16 +596,16 @@ def _validate_state_shape(state: LedgerState) -> None:
             or all(getattr(item, attribute) not in duplicates for item in automatic)
         ):
             raise BudgetStateError(reason)
-    if len(automatic) > state.budgets.max_rounds or len(overrides) > state.budgets.max_override_rounds:
+    if len(automatic) > budgets.max_rounds or len(overrides) > budgets.max_override_rounds:
         raise BudgetStateError("rounds_invalid")
     if [item.round_number for item in automatic] != list(range(1, len(automatic) + 1)):
         raise BudgetStateError("rounds_invalid")
     if overrides:
         item = overrides[0]
         expected_automatic_rounds = (
-            range(0, state.budgets.max_rounds + 1)
+            range(0, budgets.max_rounds + 1)
             if item.caller_event == "workflow_dispatch"
-            else (state.budgets.max_rounds,)
+            else (budgets.max_rounds,)
         )
         if (len(automatic) not in expected_automatic_rounds or state.invocations[-1] != item or
                 item.round_number != len(automatic) + 1 or
@@ -804,6 +849,7 @@ def validate_or_initialize(state: LedgerState | None, request: ClaimRequest,
     _validate_request(request)
     validated = LedgerState.initial(request.repository, request.pr, request.reviewer) if state is None else state
     _validate_state_shape(validated)
+    validated = replace(validated, budgets=effective_budgets(validated))
     if (validated.repository, validated.pr, validated.reviewer) != (request.repository, request.pr, request.reviewer):
         raise BudgetStateError("identity_mismatch")
     _validate_provenance(validated, request, provenances)

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -466,6 +466,7 @@ jobs:
           model-route-json: ${{ steps.claude-budget-config.outputs.model_route_json }}
           effort: final-review/default
           checkpoint-file: ${{ runner.temp }}/claude-review-budget-claim.json
+          max-rounds: ${{ vars.REVIEW_MAX_ROUNDS }}
 
       - name: Clean Claude budget input
         if: ${{ always() }}
@@ -1137,6 +1138,7 @@ jobs:
           stop-reason: ${{ steps.review-budget-outcome.outputs.stop_reason }}
           remaining-finding-ids-json: ${{ steps.review-budget-outcome.outputs.remaining_finding_ids_json }}
           checkpoint-file: ${{ runner.temp }}/claude-review-budget-final.json
+          max-rounds: ${{ vars.REVIEW_MAX_ROUNDS }}
 
       - name: Upload Claude review budget final checkpoint
         if: ${{ always() && !cancelled() && steps.review-budget-finalize.outcome != 'skipped' }}

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -517,6 +517,7 @@ jobs:
           model-route-json: ${{ steps.gemini-budget-config.outputs.model_route_json }}
           effort: ${{ steps.gemini-budget-config.outputs.effort }}
           checkpoint-file: ${{ runner.temp }}/gemini-review-budget-claim.json
+          max-rounds: ${{ vars.REVIEW_MAX_ROUNDS }}
 
       - name: Clean Gemini budget input
         if: ${{ always() }}
@@ -1941,6 +1942,7 @@ jobs:
           stop-reason: ${{ steps.review-budget-outcome.outputs.stop_reason }}
           remaining-finding-ids-json: ${{ steps.review-budget-outcome.outputs.remaining_finding_ids_json }}
           checkpoint-file: ${{ runner.temp }}/gemini-review-budget-final.json
+          max-rounds: ${{ vars.REVIEW_MAX_ROUNDS }}
 
       - name: Upload Gemini review budget final checkpoint
         if: ${{ always() && !cancelled() && steps.review-budget-finalize.outcome != 'skipped' }}

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -478,6 +478,7 @@ jobs:
           model-route-json: '["zai-coding-plan/glm-4.7"]'
           effort: final-review/default
           checkpoint-file: ${{ runner.temp }}/opencode-review-budget-claim.json
+          max-rounds: ${{ vars.REVIEW_MAX_ROUNDS }}
 
       - name: Enforce force-review claim
         if: ${{ always() && !cancelled() && inputs.force_review && steps.review-budget-claim.outputs.allow-invocation != 'true' }}
@@ -5120,6 +5121,7 @@ jobs:
           stop-reason: ${{ steps.opencode-budget-outcome.outputs.stop_reason }}
           remaining-finding-ids-json: ${{ steps.opencode-budget-outcome.outputs.remaining_finding_ids_json }}
           checkpoint-file: ${{ runner.temp }}/opencode-review-budget-final.json
+          max-rounds: ${{ vars.REVIEW_MAX_ROUNDS }}
 
       - name: Upload OpenCode review budget final checkpoint
         if: ${{ always() && !cancelled() && steps.review-budget-finalize.outcome != 'skipped' }}

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -47,6 +47,7 @@ from scripts.workflow_release_inventory import (
     release_supports_prepare_review_diff,
     release_supports_review_invocation_budget,
     release_supports_review_optin,
+    release_supports_review_rounds_variable,
     release_supports_review_policy,
     validate_release_listing,
 )
@@ -659,8 +660,14 @@ REVIEWER_WORKFLOWS = {
 EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256 = (
     "70b50ce482ff0e54df9fff88d5126cd8e760ed8bdabfefcc2f2ccdc639cb693b"
 )
+EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256_V160 = (
+    "d9cb26a5c340abd20707483f05f4e071b436dac17a900f670aacbd05140b981e"
+)
 EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256 = (
     "43f15d59df0f529e2fa4f06488e49dc5ff78280762ee8d7248dbecb45cbb609d"
+)
+EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V160 = (
+    "ec3bbc3277acda9ca34dab0785656e17e65019f44ce0835a6f1e92c8aba7268b"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
     "claude": "d4db53b86603a3a113999409e2e4e35c397adf276981e7f68c0ea57a6198faa2",
@@ -671,6 +678,13 @@ EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256 = {
     "claude": "8e16c59b04aeaaf7419571b0bda3fb1e46a29da3b847bbb0409ab0437a1027d7",
     "gemini": "ac48c84dbc60071e88f89d6ecadebb781b50d5beb7da0e0a1ec363fab5599ce8",
     "opencode": "08f2c4cc96d6ac6753fcde8ec9fda9778ed396b9546dd7f69273423940752b9e",
+}
+# v1.60 reads the automatic-round budget from REVIEW_MAX_ROUNDS, so the three
+# reusable review workflows changed bytes again.
+EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256 = {
+    "claude": "939d8ec9dab85d670881d93681d428af4486b410112a9e9af032a473923430ea",
+    "gemini": "a33c941b20dc1d9d14a221ee9360dd6cda90801c3c7dba2347971840df87b326",
+    "opencode": "caaefcdc244444718302cc230d4bb868651e697abc503afab3d75d786c6d29c0",
 }
 EXPECTED_REVIEW_POLICY_HELPER_SHA256 = (
     "3e0fd3c86b1dc40dc35213ca41c3d63122c9ebf757042f5a2c86f4fc1e99ac8a"
@@ -1125,6 +1139,27 @@ runs:
         publish_outputs "$mutation_response"
 """,
     Loader=yaml.BaseLoader,
+)
+def _budget_action_with_round_variable(action: dict) -> dict:
+    """Derive the v1.60 budget action: one optional input bridged to the helper env.
+
+    Stating the delta keeps the two expectations from drifting apart, which a second
+    verbatim copy of the action document would invite.
+    """
+
+    updated = deepcopy(action)
+    updated["inputs"]["max-rounds"] = {"required": "false", "default": ""}
+    for step in updated["runs"]["steps"]:
+        if isinstance(step, dict) and isinstance(step.get("env"), dict):
+            step["env"]["REVIEW_MAX_ROUNDS"] = "${{ inputs.max-rounds }}"
+            break
+    else:
+        raise ValueError("budget action has no environment block")
+    return updated
+
+
+EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_V160 = _budget_action_with_round_variable(
+    EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION
 )
 REVIEW_DIFF_DEPENDENCY_WORKFLOWS = (
     "claude-code-review.yml",
@@ -2305,6 +2340,7 @@ def verify_opencode_runtime(
     current_diagnostics_contract = workflow_sha256 in {
         EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256["opencode"],
         EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256["opencode"],
+        EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256["opencode"],
     }
     initial_validation_argument = " initial" if current_diagnostics_contract else ""
     repair_validation_argument = " repair" if current_diagnostics_contract else ""
@@ -2336,6 +2372,7 @@ def verify_opencode_runtime(
             OPENCODE_AUTO_REVIEW_SHA256,
             EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256["opencode"],
             EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256["opencode"],
+            EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256["opencode"],
         }
         and run_step.get("shell") == "bash"
         and run_env.get("CANDIDATE_NONCE")
@@ -4059,9 +4096,13 @@ def _local_literal(function: ast.FunctionDef, name: str) -> object:
     return ast.literal_eval(matches[0])
 
 
-def require_budget_helper_contract(source: str) -> None:
+def require_budget_helper_contract(source: str, rounds_variable: bool = False) -> None:
     """Require the authenticated schema-1 helper and every fixed policy gate."""
 
+    # v1.60 resolves the round budget through effective_budgets(), which renames the
+    # owner of the round caps and adds three statements ahead of the ledger checks.
+    rounds_owner = "budgets" if rounds_variable else "state.budgets"
+    shape_offset = 3 if rounds_variable else 0
     try:
         compile(
             source,
@@ -4387,7 +4428,8 @@ def require_budget_helper_contract(source: str) -> None:
             or not _ast_statement_matches(
                 reviewer_policy.body[1],
                 "return cls("
-                "max_calls_per_round={'claude': 1, 'gemini': 3, "
+                + ("max_rounds=configured_max_rounds(), " if rounds_variable else "")
+                + "max_calls_per_round={'claude': 1, 'gemini': 3, "
                 "'opencode': 2}[reviewer], "
                 "max_wall_seconds_per_round={'claude': 1080, "
                 "'gemini': 600, 'opencode': 600}[reviewer])",
@@ -4581,8 +4623,8 @@ def require_budget_helper_contract(source: str) -> None:
             "all(getattr(item, attribute) not in duplicates "
             "for item in automatic)):\n"
             "        raise BudgetStateError(reason)\n"
-            "if len(automatic) > state.budgets.max_rounds or "
-            "len(overrides) > state.budgets.max_override_rounds:\n"
+            f"if len(automatic) > {rounds_owner}.max_rounds or "
+            f"len(overrides) > {rounds_owner}.max_override_rounds:\n"
             "    raise BudgetStateError('rounds_invalid')\n"
             "if [item.round_number for item in automatic] != "
             "list(range(1, len(automatic) + 1)):\n"
@@ -4590,9 +4632,9 @@ def require_budget_helper_contract(source: str) -> None:
             "if overrides:\n"
             "    item = overrides[0]\n"
             "    expected_automatic_rounds = ("
-            "range(0, state.budgets.max_rounds + 1) "
+            f"range(0, {rounds_owner}.max_rounds + 1) "
             "if item.caller_event == 'workflow_dispatch' "
-            "else (state.budgets.max_rounds,))\n"
+            f"else ({rounds_owner}.max_rounds,))\n"
             "    if (len(automatic) not in expected_automatic_rounds or "
             "state.invocations[-1] != item or "
             "item.round_number != len(automatic) + 1 or "
@@ -4602,7 +4644,7 @@ def require_budget_helper_contract(source: str) -> None:
             "    raise BudgetStateError('override_invalid')\n"
         ).body
         if ast.dump(
-            ast.Module(body=state_shape.body[9:17], type_ignores=[]),
+            ast.Module(body=state_shape.body[9 + shape_offset:17 + shape_offset], type_ignores=[]),
             include_attributes=False,
         ) != ast.dump(
             ast.Module(body=expected_duplicate_policy, type_ignores=[]),
@@ -4611,8 +4653,8 @@ def require_budget_helper_contract(source: str) -> None:
             raise ValueError("forced duplicate policy differs")
         for expression, reason in (
             (
-                "len(automatic) > state.budgets.max_rounds or "
-                "len(overrides) > state.budgets.max_override_rounds",
+                f"len(automatic) > {rounds_owner}.max_rounds or "
+                f"len(overrides) > {rounds_owner}.max_override_rounds",
                 "rounds_invalid",
             ),
             (
@@ -5534,7 +5576,12 @@ def _verify_review_invocation_budget(
             action_payload,
             reject_duplicate_keys=release_supports_review_policy(ref),
         )
-        if action != EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION:
+        expected_action = (
+            EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_V160
+            if release_supports_review_rounds_variable(ref)
+            else EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION
+        )
+        if action != expected_action:
             raise ValueError("action differs")
     except (AttributeError, ReleaseVerificationError, TypeError, ValueError, yaml.YAMLError):
         raise ReleaseVerificationError(
@@ -5547,7 +5594,7 @@ def _verify_review_invocation_budget(
         raise ReleaseVerificationError(
             "invocation-budget helper contract is invalid"
         ) from None
-    require_budget_helper_contract(helper)
+    require_budget_helper_contract(helper, release_supports_review_rounds_variable(ref))
     for reviewer, workflow in REVIEWER_WORKFLOWS.items():
         require_budget_workflow_contract(
             tree,
@@ -5555,18 +5602,25 @@ def _verify_review_invocation_budget(
             reviewer,
             review_policy=release_supports_review_policy(ref),
         )
+    rounds_variable = release_supports_review_rounds_variable(ref)
     authenticated_digests = {
         action_path: (
             action_payload,
-            EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256,
+            EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256_V160
+            if rounds_variable
+            else EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256,
         ),
         REVIEW_INVOCATION_BUDGET_HELPER_ROOT.path.as_posix(): (
             helper_payload,
-            EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256,
+            EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V160
+            if rounds_variable
+            else EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256,
         ),
     }
     workflow_digests = (
-        EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256
+        EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256
+        if rounds_variable
+        else EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256
         if release_supports_review_policy(ref)
         else EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256
     )

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -667,7 +667,7 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256 = (
     "43f15d59df0f529e2fa4f06488e49dc5ff78280762ee8d7248dbecb45cbb609d"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V160 = (
-    "ec3bbc3277acda9ca34dab0785656e17e65019f44ce0835a6f1e92c8aba7268b"
+    "d6a9dc0af9b6e340b6528911ac60a48e21fd8960e515167e2c6be4536f33f1a3"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
     "claude": "d4db53b86603a3a113999409e2e4e35c397adf276981e7f68c0ea57a6198faa2",
@@ -4102,6 +4102,11 @@ def require_budget_helper_contract(source: str, rounds_variable: bool = False) -
     # v1.60 resolves the round budget through effective_budgets(), which renames the
     # owner of the round caps and adds three statements ahead of the ledger checks.
     rounds_owner = "budgets" if rounds_variable else "state.budgets"
+    claim_rounds = (
+        "effective_budgets(validated).max_rounds"
+        if rounds_variable
+        else "validated.budgets.max_rounds"
+    )
     shape_offset = 3 if rounds_variable else 0
     try:
         compile(
@@ -4530,7 +4535,7 @@ def require_budget_helper_contract(source: str, rounds_variable: bool = False) -
             "        override = choose_override(validated, request.override_events)\n"
             "        if override is None:\n"
             "            return refuse(validated, request, 'round_budget_exhausted')\n"
-            "    elif automatic_rounds(validated) >= validated.budgets.max_rounds:\n"
+            f"    elif automatic_rounds(validated) >= {claim_rounds}:\n"
             "        override = choose_override(validated, request.override_events)\n"
             "        if override is None:\n"
             "            return refuse(validated, request, 'round_budget_exhausted')\n"
@@ -4632,9 +4637,9 @@ def require_budget_helper_contract(source: str, rounds_variable: bool = False) -
             "if overrides:\n"
             "    item = overrides[0]\n"
             "    expected_automatic_rounds = ("
-            f"range(0, {rounds_owner}.max_rounds + 1) "
+            "range(0, state.budgets.max_rounds + 1) "
             "if item.caller_event == 'workflow_dispatch' "
-            f"else ({rounds_owner}.max_rounds,))\n"
+            "else (state.budgets.max_rounds,))\n"
             "    if (len(automatic) not in expected_automatic_rounds or "
             "state.invocations[-1] != item or "
             "item.round_number != len(automatic) + 1 or "

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -148,6 +148,7 @@ CANONICALIZE_REVIEW_RELEASE = (1, 46)
 REVIEW_INVOCATION_BUDGET_RELEASE = (1, 47)
 REVIEW_POLICY_RELEASE = (1, 51)
 REVIEW_OPTIN_RELEASE = (1, 59)
+REVIEW_ROUNDS_VARIABLE_RELEASE = (1, 60)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -184,6 +185,12 @@ def release_supports_review_optin(ref: str) -> bool:
     """Return whether ``ref`` resolves an unconfigured automatic review to ``false``."""
 
     return _release_version(ref) >= REVIEW_OPTIN_RELEASE
+
+
+def release_supports_review_rounds_variable(ref: str) -> bool:
+    """Return whether ``ref`` reads the automatic-round budget from a repository variable."""
+
+    return _release_version(ref) >= REVIEW_ROUNDS_VARIABLE_RELEASE
 
 
 def release_roots_for(ref: str) -> tuple[ReleaseRoot, ...]:

--- a/tests/test_review_invocation_budget.py
+++ b/tests/test_review_invocation_budget.py
@@ -1022,3 +1022,83 @@ def test_stored_automatic_and_override_aggregate_boundaries():
         ),
     )
     assert_stored_state_rejected(above_override_limit, "input_budget_exhausted")
+
+
+# --- configurable automatic round budget (issue #114) ---
+
+
+@pytest.fixture(autouse=True)
+def isolate_round_budget_variable(monkeypatch):
+    """The round budget reads a repository variable, so keep it out of every other test."""
+
+    monkeypatch.delenv(budget.MAX_ROUNDS_VARIABLE, raising=False)
+
+
+def rounds(count):
+    return tuple(
+        invocation(
+            head=chr(ord("a") + index) * 40,
+            full_hash=str(index + 1) * 64,
+            run_id=600 + index,
+            round_number=index + 1,
+        )
+        for index in range(count)
+    )
+
+
+def test_round_budget_defaults_to_two_without_the_variable():
+    assert budget.BudgetPolicy.for_reviewer("claude").max_rounds == 2
+
+
+@pytest.mark.parametrize("reviewer", ("claude", "gemini", "opencode"))
+@pytest.mark.parametrize("raw", ("1", "3", "5"))
+def test_round_budget_honours_the_configured_variable(monkeypatch, reviewer, raw):
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, raw)
+
+    assert budget.BudgetPolicy.for_reviewer(reviewer).max_rounds == int(raw)
+
+
+def test_round_budget_ignores_an_empty_variable_without_warning(monkeypatch, capsys):
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, "")
+
+    assert budget.BudgetPolicy.for_reviewer("claude").max_rounds == 2
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.parametrize("raw", ("0", "6", "-1", "two", "3.0", " 3", "+3", "0x3"))
+def test_round_budget_falls_back_and_warns_on_an_unusable_variable(monkeypatch, capsys, raw):
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, raw)
+
+    assert budget.BudgetPolicy.for_reviewer("claude").max_rounds == 2
+    assert budget.MAX_ROUNDS_VARIABLE in capsys.readouterr().err
+
+
+def test_ledger_capacity_follows_the_configured_round_budget(monkeypatch):
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, "5")
+    state = budget.LedgerState.initial(REPOSITORY, PR, "claude", invocations=rounds(4))
+
+    budget._validate_state_shape(state)
+
+
+def test_ledger_capacity_still_rejects_more_rounds_than_budgeted():
+    state = budget.LedgerState.initial(REPOSITORY, PR, "claude", invocations=rounds(4))
+
+    with pytest.raises(budget.BudgetStateError):
+        budget._validate_state_shape(state)
+
+
+@pytest.mark.parametrize(
+    ("recorded", "configured", "effective"), ((2, 5, 5), (5, 2, 5), (2, 2, 2))
+)
+def test_effective_round_budget_is_the_higher_of_recorded_and_configured(
+    monkeypatch, recorded, configured, effective
+):
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, str(configured))
+    state = replace(
+        budget.LedgerState.initial(REPOSITORY, PR, "claude"),
+        budgets=replace(budget.BudgetPolicy.for_reviewer("claude"), max_rounds=recorded),
+    )
+
+    budget._validate_state_shape(state)
+
+    assert budget.effective_budgets(state).max_rounds == effective

--- a/tests/test_review_invocation_budget.py
+++ b/tests/test_review_invocation_budget.py
@@ -1102,3 +1102,42 @@ def test_effective_round_budget_is_the_higher_of_recorded_and_configured(
     budget._validate_state_shape(state)
 
     assert budget.effective_budgets(state).max_rounds == effective
+
+
+@pytest.mark.parametrize("raw", ("²", "٣", "１"))
+def test_round_budget_rejects_non_ascii_digits(monkeypatch, capsys, raw):
+    """str.isdigit() accepts superscripts and other scripts that int() may reject."""
+
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, raw)
+
+    assert budget.BudgetPolicy.for_reviewer("claude").max_rounds == 2
+    assert budget.MAX_ROUNDS_VARIABLE in capsys.readouterr().err
+
+
+def overridden_state():
+    """Two automatic rounds recorded under a budget of two, then a label override."""
+
+    automatic = rounds(2)
+    override = invocation(
+        head=HEAD_C, full_hash=HASH_3, run_id=700, round_number=3, override_event_id=9001
+    )
+    return budget.LedgerState.initial(
+        REPOSITORY,
+        PR,
+        "claude",
+        invocations=automatic + (override,),
+        consumed_override_event_ids=(9001,),
+    )
+
+
+def test_recorded_override_stays_valid_without_a_raised_round_budget():
+    budget._validate_state_shape(overridden_state())
+
+
+def test_recorded_override_survives_a_raised_round_budget(monkeypatch):
+    """A raise must not retroactively change when the override became eligible."""
+
+    state = overridden_state()
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, "5")
+
+    budget._validate_state_shape(state)

--- a/tests/test_review_invocation_budget_action.py
+++ b/tests/test_review_invocation_budget_action.py
@@ -342,6 +342,7 @@ def test_action_metadata_has_one_inert_environment_bridge():
         "force-review",
         "model-route-json", "effort", "checkpoint-file", "actual-call-count",
         "elapsed-seconds", "outcome", "stop-reason", "remaining-finding-ids-json",
+        "max-rounds",
     }
     assert {name for name, value in document["inputs"].items() if value["required"] == "true"} == {
         "github-token", "mode", "reviewer", "pr-number", "expected-head-sha",
@@ -355,6 +356,7 @@ def test_action_metadata_has_one_inert_environment_bridge():
         "outcome": "checkpoint_failure",
         "stop-reason": "",
         "remaining-finding-ids-json": "[]",
+        "max-rounds": "",
     }
     assert set(document["outputs"]) == {
         "allow-invocation", "decision", "round", "invocation-key", "checkpoint-sha256",
@@ -366,6 +368,7 @@ def test_action_metadata_has_one_inert_environment_bridge():
     assert step["id"] == "budget"
     assert step["shell"] == "bash"
     assert step["env"]["GH_TOKEN"] == "${{ inputs.github-token }}"
+    assert step["env"]["REVIEW_MAX_ROUNDS"] == "${{ inputs.max-rounds }}"
     assert "${{ inputs." not in step["run"]
     assert step["run"].index('cat -- "$budget_dir/summary.md" >> "$GITHUB_STEP_SUMMARY"') < step[
         "run"

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -1460,6 +1460,7 @@ def test_claude_budget_claim_is_durable_before_provider_and_every_model_path_is_
         ),
         "model-route-json": "${{ steps.claude-budget-config.outputs.model_route_json }}",
         "effort": "final-review/default",
+        "max-rounds": "${{ vars.REVIEW_MAX_ROUNDS }}",
         "checkpoint-file": "${{ runner.temp }}/claude-review-budget-claim.json",
     }
     record = _step(
@@ -1727,6 +1728,7 @@ def test_claude_budget_finalizes_after_review_state_upsert_and_uploads_both_chec
         "remaining-finding-ids-json": (
             "${{ steps.review-budget-outcome.outputs.remaining_finding_ids_json }}"
         ),
+        "max-rounds": "${{ vars.REVIEW_MAX_ROUNDS }}",
         "checkpoint-file": "${{ runner.temp }}/claude-review-budget-final.json",
     }
 
@@ -1999,6 +2001,7 @@ def test_gemini_budget_claim_precedes_provider_and_guards_every_new_diff_path():
             "${{ steps.gemini-budget-config.outputs.model_route_json }}"
         ),
         "effort": "${{ steps.gemini-budget-config.outputs.effort }}",
+        "max-rounds": "${{ vars.REVIEW_MAX_ROUNDS }}",
         "checkpoint-file": "${{ runner.temp }}/gemini-review-budget-claim.json",
     }
 
@@ -8545,6 +8548,7 @@ def test_opencode_budget_claim_is_sealed_before_tokenless_model_job():
         "authenticated-review-json": "${{ steps.ctx.outputs.authenticated_review_json }}",
         "model-route-json": '["zai-coding-plan/glm-4.7"]',
         "effort": "final-review/default",
+        "max-rounds": "${{ vars.REVIEW_MAX_ROUNDS }}",
         "checkpoint-file": "${{ runner.temp }}/opencode-review-budget-claim.json",
     }
     assert review["permissions"] == {}
@@ -8724,6 +8728,7 @@ def test_opencode_budget_finalize_uses_only_attested_publication_outcome():
         "outcome": "${{ steps.opencode-budget-outcome.outputs.outcome }}",
         "stop-reason": "${{ steps.opencode-budget-outcome.outputs.stop_reason }}",
         "remaining-finding-ids-json": "${{ steps.opencode-budget-outcome.outputs.remaining_finding_ids_json }}",
+        "max-rounds": "${{ vars.REVIEW_MAX_ROUNDS }}",
         "checkpoint-file": "${{ runner.temp }}/opencode-review-budget-final.json",
     }
     assert any(step.get("name") == "Upload OpenCode review budget final checkpoint" for step in job["steps"])

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -100,6 +100,7 @@ REVIEW_POLICY_RELEASE_FILES = (
 )
 V1462_WORKFLOW_FIXTURE_COMMIT = "d42c28ddd827554e6e46a2ab49dfe34c838c0425"
 V158_REVIEW_POLICY_HELPER_COMMIT = "1b98172325533ef6ad37f3d2cfc3870073fac26d"
+V159_ROUND_BUDGET_COMMIT = "96d66e1d17952f01b19bb957057830a2b2a6318b"
 V1462_WORKFLOW_FIXTURE_SHA256 = {
     "claude-code-review.yml": (
         "008bbdcdeacdaf7796c1e3b59d22194d3f1ce380735d36dada5efab8ff52d112"
@@ -230,6 +231,7 @@ def current_release_repo(tmp_path: Path) -> tuple[Path, str]:
         else:
             shutil.copy2(source, target)
     restore_pre_v151_review_policy(repo)
+    restore_pre_v160_round_budget(repo)
     git(repo, "init", "-q")
     git(repo, "config", "user.name", "Test")
     git(repo, "config", "user.email", "test@example.com")
@@ -314,6 +316,47 @@ def restore_pre_v159_review_policy_helper(repo: Path) -> None:
     (repo / relative).write_bytes(payload)
 
 
+def restore_pre_v160_round_budget(repo: Path) -> None:
+    """Restore the authenticated pre-v1.60 invocation-budget wiring.
+
+    v1.60 reads the automatic-round budget from REVIEW_MAX_ROUNDS, which changed the
+    budget action, its helper, and the three reusable review workflows.
+    """
+
+    tree = release_verifier.VerifiedCommitTree.open(ROOT, V159_ROUND_BUDGET_COMMIT)
+    for relative, expected in (
+        (
+            ".github/actions/review-invocation-budget/action.yml",
+            release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256,
+        ),
+        (
+            ".github/actions/review-invocation-budget/review_invocation_budget.py",
+            release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256,
+        ),
+    ):
+        payload = tree.read_file(relative)
+        assert hashlib.sha256(payload).hexdigest() == expected
+        (repo / relative).write_bytes(payload)
+    for filename in release_verifier.REVIEWER_WORKFLOWS.values():
+        path = repo / ".github/workflows" / filename
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text.replace("          max-rounds: ${{ vars.REVIEW_MAX_ROUNDS }}\n", ""),
+            encoding="utf-8",
+        )
+
+
+def assert_pre_v160_workflow_bytes(repo: Path) -> None:
+    """The stripped workflows must be exactly the published v1.51-v1.59 bytes."""
+
+    for reviewer, filename in release_verifier.REVIEWER_WORKFLOWS.items():
+        payload = (repo / ".github/workflows" / filename).read_bytes()
+        assert (
+            hashlib.sha256(payload).hexdigest()
+            == release_verifier.EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256[reviewer]
+        )
+
+
 def copy_review_policy_release_files(repo: Path) -> None:
     for relative in (
         ".github/actions/resolve-review-policy/action.yml",
@@ -342,12 +385,25 @@ def copy_review_policy_release_files(repo: Path) -> None:
 def prepare_v151(repo: Path) -> str:
     copy_review_policy_release_files(repo)
     restore_pre_v159_review_policy_helper(repo)
+    restore_pre_v160_round_budget(repo)
     return commit(repo, "v1.51 candidate")
 
 
 def prepare_v159(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v160_round_budget(repo)
+    assert_pre_v160_workflow_bytes(repo)
     return commit(repo, "v1.59 candidate")
+
+
+def prepare_v160(repo: Path) -> str:
+    copy_review_policy_release_files(repo)
+    for relative in (
+        ".github/actions/review-invocation-budget/action.yml",
+        ".github/actions/review-invocation-budget/review_invocation_budget.py",
+    ):
+        shutil.copy2(ROOT / relative, repo / relative)
+    return commit(repo, "v1.60 candidate")
 
 
 def verify_v147(repo: Path, message: str) -> str:
@@ -1763,6 +1819,35 @@ def test_v159_opt_in_helper_is_rejected_on_the_v151_release_line(
 
     with pytest.raises(ReleaseVerificationError, match="review-policy helper"):
         release_verifier.verify_commit_content(repo, "v1.51", candidate)
+
+
+def test_v160_accepts_current_round_budget_release_contract(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v160(repo)
+
+    assert release_verifier.verify_commit_content(repo, "v1.60", candidate) == candidate
+
+
+def test_v160_round_budget_wiring_is_rejected_on_the_v159_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v160(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.59", candidate)
+
+
+def test_pre_v160_round_budget_wiring_is_rejected_on_the_v160_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v159(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.60", candidate)
 
 
 def test_pre_v159_helper_is_rejected_on_the_v159_release_line(

--- a/tests/test_workflow_release_bundle.py
+++ b/tests/test_workflow_release_bundle.py
@@ -423,9 +423,9 @@ def test_review_invocation_budget_action_has_exact_safe_contract() -> None:
     document = yaml.load(payload, Loader=yaml.BaseLoader)
 
     assert hashlib.sha256(payload).hexdigest() == (
-        "70b50ce482ff0e54df9fff88d5126cd8e760ed8bdabfefcc2f2ccdc639cb693b"
+        "d9cb26a5c340abd20707483f05f4e071b436dac17a900f670aacbd05140b981e"
     )
-    assert document == release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION
+    assert document == release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_V160
 
 
 def git(repo: Path, *args: str) -> str:


### PR DESCRIPTION
자동 리뷰 라운드 상한을 `vars.REVIEW_MAX_ROUNDS` 로 설정 가능하게 한다. 기본값은 인증된 `2` 를 유지하고 변수가 1~5 범위에서 올린다.

## 왜 상수 하나로 안 끝났나

이슈 #114 에 적은 두 제약이다.

**① 원장 상한 `3` 이 하드코딩** — `len(state.invocations) > 3` 은 현재 예산 `2 + 1` 에서 유도된 값이다. 라운드를 3 으로만 올려도 4 가 되어 `ledger_invalid` 로 걸린다. `max_rounds + max_override_rounds` 로 유도하게 바꿨다.

**② sticky state 가 예산의 정확 일치를 요구** — `state.budgets != BudgetPolicy.for_reviewer(...)` 라서, 변수를 올리면 **이미 열린 PR 이 전부 `budgets_invalid` 로 거부**된다. 목적과 정반대다. `max_rounds` 를 동등성 비교에서 제외하고 실효 예산을 **`max(기록값, 설정값)`** 으로 정의했다. 올리면 열린 PR 도 즉시 혜택을 보고, 내려도 이미 소비한 라운드가 있는 원장이 무효화되지 않는다(에러 경로 자체가 사라진다).

## 핀 버전 게이팅

budget 액션·헬퍼·재사용 워크플로 3종이 모두 바이트가 바뀌었고, 그 핀들은 **발행된 v1.47~v1.59 도 인증**한다. v1.59 에서 review-policy 헬퍼에 했던 것과 같은 방식으로 `release_supports_review_rounds_variable(ref)`(v1.60 임계)로 게이팅했다.

- v1.60 액션 문서는 320줄을 복제하는 대신 **델타를 서술해 파생**한다(`_budget_action_with_round_variable`).
- `require_budget_helper_contract` 도 게이트를 받는다 — v1.60 은 라운드 캡의 소유자 이름이 바뀌고(`state.budgets` → `budgets`) 원장 검사 앞에 문장 3개가 늘어 **고정된 문장 슬라이스가 밀린다**.

계약 검사 4건(`action contract` · `reviewer execution caps` · `forced duplicate policy` · `live guard rounds_invalid`)은 예외를 일시적으로 노출시켜 하나씩 실측했다.

`upsert_sha256_v147` 과 `EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256` 은 **갱신이 불필요**했다 — 픽스처가 v1.60 이전 워크플로 바이트를 복원하므로 역사 핀이 그대로 맞는다.

## 검증

| 확인 | 결과 |
|---|---|
| 변수 없음 | 현행과 동일(2) — 되돌리면 실패하는 회귀로 고정 |
| `1`/`3`/`5` | 그대로 반영 (3 리뷰어 전부) |
| `0` `6` `-1` `two` `3.0` `" 3"` `+3` `0x3` | 경고 후 2 로 폴백 |
| 빈 문자열 | 조용히 기본값(경고 없음) |
| 원장 4라운드 | 예산 5 에서 통과, 없으면 거부 |
| 실효 예산 | `max(기록, 설정)` 양방향 확인 |
| 릴리스 게이팅 | v1.60 수용 · v1.60 배선을 v1.59 로 검증하면 거부 · v1.59 배선을 v1.60 으로 검증하면 거부 |
| 전체 스위트 | 2925 passed, 48 subtests passed |

실패 2건은 로컬 `umask 0002` 로 인한 `test_v145_review_fixtures_match_the_immutable_release_blobs` 모드 비교이며 CI 는 통과한다.

## 머지 후

v1.60 릴리스 → 17타깃 롤아웃 → 16저장소에 `REVIEW_MAX_ROUNDS=5` 설정(`APP_ID` 처럼 전 저장소에 뿌린 선례가 있다). 이후 라운드 조정은 릴리스 없이 저장소 설정에서 가능하다.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su9whB4FRuyxEijrq2bLWk