### PR TITLE
chore(workflows): default rollout to v1.60

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.59",
+  "automation_ref": "v1.60",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.59"
+    assert config.automation_ref == "v1.60"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
17타깃이 모두 v1.60 으로 통일돼 기본 `automation_ref` 를 범프한다.

```
SUMMARY ref=v1.60 commit=a2c3ca4c6de37150ec174e897cce3dfb2e0c370c total=17 current=17 drift=0 blocked=0
```

## 이번 롤아웃의 결과

`REVIEW_MAX_ROUNDS=5` 를 **17/17 저장소**에 설정했다. 따라서 자동 리뷰 라운드 상한이 5 가 되고, 이후 조정은 저장소 설정에서 바로 되며 릴리스가 필요 없다.

v1.59 에서 소비자 config 의 `auto: true` 를 이미 내렸기 때문에 이번 롤아웃 PR 들은 `opened` 시점 리뷰 물결을 만들지 않았다 — Gemini 쿼터 실패 0건.

## 검증

- `python3 -m scripts.verify_workflow_release --ref v1.60 --expected-commit a2c3ca4` → PASS
- `--ref v1.59 --expected-commit 49cd25b` → PASS (역사 라인 유지)
- 태그 발행 전 `verify_commit_content` 선검증: v1.60 수용 · 같은 커밋을 v1.59 로 넣으면 `invocation-budget action contract is invalid` 로 거부
- `test_workflow_catalog` → 20 passed

Refs #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su9whB4FRuyxEijrq2bLWk