### PR TITLE
fix(review): cancel a running review only when a new commit supersedes it

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -89,9 +89,13 @@ jobs:
   claude-review:
     needs: check-enabled
     if: needs.check-enabled.outputs.enabled == 'true' && needs.check-enabled.outputs.policy_run == 'true'
+    # Cancel only when a new commit supersedes this head. A same-head retrigger
+    # must not cancel an in-flight review: the run has already claimed the head in
+    # the invocation budget, so the replacement is refused as duplicate_head and no
+    # review is produced at all (issue #120).
     concurrency:
       group: automation-claude-review-${{ github.repository }}-${{ inputs.pr_number || github.event.pull_request.number }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.event.action == 'synchronize' }}
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -84,9 +84,13 @@ jobs:
   gemini-review:
     needs: check-enabled
     if: needs.check-enabled.outputs.enabled == 'true' && needs.check-enabled.outputs.policy_run == 'true'
+    # Cancel only when a new commit supersedes this head. A same-head retrigger
+    # must not cancel an in-flight review: the run has already claimed the head in
+    # the invocation budget, so the replacement is refused as duplicate_head and no
+    # review is produced at all (issue #120).
     concurrency:
       group: automation-gemini-auto-review-${{ github.repository }}-${{ inputs.pr_number || github.event.pull_request.number }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.event.action == 'synchronize' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -28,9 +28,13 @@ on:
         description: 'Z.AI API key'
         required: true
 
+# Cancel only when a new commit supersedes this head. A same-head retrigger
+# must not cancel an in-flight review: the run has already claimed the head in
+# the invocation budget, so the replacement is refused as duplicate_head and no
+# review is produced at all (issue #120).
 concurrency:
   group: automation-opencode-auto-review-${{ github.repository }}-${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event.action == 'synchronize' }}
 
 jobs:
   check-enabled:

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -48,6 +48,7 @@ from scripts.workflow_release_inventory import (
     release_supports_review_invocation_budget,
     release_supports_review_optin,
     release_supports_review_rounds_variable,
+    release_supports_same_head_cancel_guard,
     release_supports_review_policy,
     validate_release_listing,
 )
@@ -685,6 +686,13 @@ EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256 = {
     "claude": "939d8ec9dab85d670881d93681d428af4486b410112a9e9af032a473923430ea",
     "gemini": "a33c941b20dc1d9d14a221ee9360dd6cda90801c3c7dba2347971840df87b326",
     "opencode": "caaefcdc244444718302cc230d4bb868651e697abc503afab3d75d786c6d29c0",
+}
+# v1.61 narrowed cancel-in-progress to superseding commits, changing the three
+# reusable review workflows again.
+EXPECTED_SAME_HEAD_CANCEL_WORKFLOW_SHA256 = {
+    "claude": "b3b7d95cb8e87164470759f4c918f8c317e37a10d2c214ec915ac4a51963f04e",
+    "gemini": "3271f4f7dd4d13711b91d65ac191451703ead424fcb67299ff504b8a26b32e0f",
+    "opencode": "4a173036252929de6320da7e04436d67b9a4759ed4b9f60b6bdf2b3a3ecc1d5a",
 }
 EXPECTED_REVIEW_POLICY_HELPER_SHA256 = (
     "3e0fd3c86b1dc40dc35213ca41c3d63122c9ebf757042f5a2c86f4fc1e99ac8a"
@@ -2341,6 +2349,7 @@ def verify_opencode_runtime(
         EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256["opencode"],
         EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256["opencode"],
         EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256["opencode"],
+        EXPECTED_SAME_HEAD_CANCEL_WORKFLOW_SHA256["opencode"],
     }
     initial_validation_argument = " initial" if current_diagnostics_contract else ""
     repair_validation_argument = " repair" if current_diagnostics_contract else ""
@@ -2373,6 +2382,7 @@ def verify_opencode_runtime(
             EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256["opencode"],
             EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256["opencode"],
             EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256["opencode"],
+            EXPECTED_SAME_HEAD_CANCEL_WORKFLOW_SHA256["opencode"],
         }
         and run_step.get("shell") == "bash"
         and run_env.get("CANDIDATE_NONCE")
@@ -5623,7 +5633,9 @@ def _verify_review_invocation_budget(
         ),
     }
     workflow_digests = (
-        EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256
+        EXPECTED_SAME_HEAD_CANCEL_WORKFLOW_SHA256
+        if release_supports_same_head_cancel_guard(ref)
+        else EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256
         if rounds_variable
         else EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256
         if release_supports_review_policy(ref)

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -149,6 +149,7 @@ REVIEW_INVOCATION_BUDGET_RELEASE = (1, 47)
 REVIEW_POLICY_RELEASE = (1, 51)
 REVIEW_OPTIN_RELEASE = (1, 59)
 REVIEW_ROUNDS_VARIABLE_RELEASE = (1, 60)
+SAME_HEAD_CANCEL_RELEASE = (1, 61)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -191,6 +192,12 @@ def release_supports_review_rounds_variable(ref: str) -> bool:
     """Return whether ``ref`` reads the automatic-round budget from a repository variable."""
 
     return _release_version(ref) >= REVIEW_ROUNDS_VARIABLE_RELEASE
+
+
+def release_supports_same_head_cancel_guard(ref: str) -> bool:
+    """Return whether ``ref`` cancels a review only when a new commit supersedes it."""
+
+    return _release_version(ref) >= SAME_HEAD_CANCEL_RELEASE
 
 
 def release_roots_for(ref: str) -> tuple[ReleaseRoot, ...]:

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -4073,7 +4073,7 @@ def test_gemini_canonical_v2_collection_and_shared_action_contract(tmp_path):
     assert action["with"]["context-lines"] == "20"
     assert job["concurrency"] == {
         "group": "automation-gemini-auto-review-${{ github.repository }}-${{ inputs.pr_number || github.event.pull_request.number }}",
-        "cancel-in-progress": "true",
+        "cancel-in-progress": "${{ github.event.action == 'synchronize' }}",
     }
 
 
@@ -6362,7 +6362,7 @@ def test_claude_review_concurrency_is_scoped_to_reviewer_repository_and_pr():
 
     assert job["concurrency"] == {
         "group": "automation-claude-review-${{ github.repository }}-${{ inputs.pr_number || github.event.pull_request.number }}",
-        "cancel-in-progress": "true",
+        "cancel-in-progress": "${{ github.event.action == 'synchronize' }}",
     }
 
 
@@ -17302,7 +17302,7 @@ def test_opencode_concurrency_and_rereview_marker_extraction_accept_v1_and_v2():
     workflow = _load("opencode-auto-review.yml")
     assert workflow["concurrency"] == {
         "group": "automation-opencode-auto-review-${{ github.repository }}-${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}",
-        "cancel-in-progress": "true",
+        "cancel-in-progress": "${{ github.event.action == 'synchronize' }}",
     }
 
 

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -232,6 +232,7 @@ def current_release_repo(tmp_path: Path) -> tuple[Path, str]:
             shutil.copy2(source, target)
     restore_pre_v151_review_policy(repo)
     restore_pre_v160_round_budget(repo)
+    restore_pre_v161_cancel_guard(repo)
     git(repo, "init", "-q")
     git(repo, "config", "user.name", "Test")
     git(repo, "config", "user.email", "test@example.com")
@@ -316,6 +317,42 @@ def restore_pre_v159_review_policy_helper(repo: Path) -> None:
     (repo / relative).write_bytes(payload)
 
 
+def restore_pre_v161_cancel_guard(repo: Path) -> None:
+    """Restore the broad cancel-in-progress the pre-v1.61 release lines pin.
+
+    This edits text rather than rewriting whole files so it composes with the
+    other historical restores, which transform the same workflows.
+    """
+
+    for filename in release_verifier.REVIEWER_WORKFLOWS.values():
+        path = repo / ".github/workflows" / filename
+        text = path.read_text(encoding="utf-8")
+        text = "".join(
+            line
+            for line in text.splitlines(keepends=True)
+            if "(issue #120)" not in line
+            and "Cancel only when a new commit supersedes this head" not in line
+            and "must not cancel an in-flight review" not in line
+            and "the invocation budget, so the replacement is refused" not in line
+        )
+        text = text.replace(
+            "cancel-in-progress: ${{ github.event.action == 'synchronize' }}\n",
+            "cancel-in-progress: true\n",
+        )
+        path.write_text(text, encoding="utf-8")
+
+
+def assert_pre_v161_workflow_bytes(repo: Path) -> None:
+    """The reverted workflows must be exactly the published v1.60 bytes."""
+
+    for reviewer, filename in release_verifier.REVIEWER_WORKFLOWS.items():
+        payload = (repo / ".github/workflows" / filename).read_bytes()
+        assert (
+            hashlib.sha256(payload).hexdigest()
+            == release_verifier.EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256[reviewer]
+        )
+
+
 def restore_pre_v160_round_budget(repo: Path) -> None:
     """Restore the authenticated pre-v1.60 invocation-budget wiring.
 
@@ -384,6 +421,7 @@ def copy_review_policy_release_files(repo: Path) -> None:
 
 def prepare_v151(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v161_cancel_guard(repo)
     restore_pre_v159_review_policy_helper(repo)
     restore_pre_v160_round_budget(repo)
     return commit(repo, "v1.51 candidate")
@@ -391,6 +429,7 @@ def prepare_v151(repo: Path) -> str:
 
 def prepare_v159(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v161_cancel_guard(repo)
     restore_pre_v160_round_budget(repo)
     assert_pre_v160_workflow_bytes(repo)
     return commit(repo, "v1.59 candidate")
@@ -398,6 +437,8 @@ def prepare_v159(repo: Path) -> str:
 
 def prepare_v160(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v161_cancel_guard(repo)
+    assert_pre_v161_workflow_bytes(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
@@ -1819,6 +1860,45 @@ def test_v159_opt_in_helper_is_rejected_on_the_v151_release_line(
 
     with pytest.raises(ReleaseVerificationError, match="review-policy helper"):
         release_verifier.verify_commit_content(repo, "v1.51", candidate)
+
+
+def prepare_v161(repo: Path) -> str:
+    copy_review_policy_release_files(repo)
+    for relative in (
+        ".github/actions/review-invocation-budget/action.yml",
+        ".github/actions/review-invocation-budget/review_invocation_budget.py",
+    ):
+        shutil.copy2(ROOT / relative, repo / relative)
+    return commit(repo, "v1.61 candidate")
+
+
+def test_v161_accepts_current_cancel_guard_release_contract(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v161(repo)
+
+    assert release_verifier.verify_commit_content(repo, "v1.61", candidate) == candidate
+
+
+def test_v161_cancel_guard_is_rejected_on_the_v160_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v161(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.60", candidate)
+
+
+def test_pre_v161_cancel_guard_is_rejected_on_the_v161_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v160(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.61", candidate)
 
 
 def test_v160_accepts_current_round_budget_release_contract(


### PR DESCRIPTION
이슈 #120. 같은 head 에 리뷰 런이 두 번 뜨면 **리뷰가 0건이 되는** 경합을 고친다.

## 결함

세 재사용 워크플로가 concurrency 를 **저장소+PR 단위**로 묶고 `cancel-in-progress: true` 를 쓴다.

```yaml
# claude-code-review.yml:92 (gemini:87 은 잡 수준, opencode:31 은 워크플로 수준)
    concurrency:
      group: automation-claude-review-${{ github.repository }}-${{ inputs.pr_number || github.event.pull_request.number }}
      cancel-in-progress: true
```

같은 PR 의 두 번째 런이 뜨면 진행 중인 첫 런을 취소하는데, **첫 런은 이미 예산에서 그 head 를 claim 한 상태**다. 그래서 두 번째 런은 `duplicate_head` 로 프로바이더를 건너뛴다 → **리뷰 0건**. 자동 라운드는 소비되지도 않았는데 그 head 로는 리뷰를 받을 수 없다.

### 실측 (jhw-notion#111)

```
14:09:12  ready_for_review
14:09:14  run 33765183985  Claim=success,  Run Claude Code Review=cancelled
14:09:26  run 33765201359  Claim=success(decision=duplicate_head), 프로바이더 skipped
```

Claude 스티키 코멘트가 그 head 에 아예 생성되지 않았고, 회복은 새 커밋으로 head 를 바꾸는 것뿐이었다(`351140e` 에서 정상 리뷰).

두 런은 같은 파일·같은 이벤트 타입·같은 head 다. 두 번째 런의 트리거 자체는 특정하지 못했다(캘러는 `labeled` 를 구독하지 않고 push 도 없었다) — 다만 **트리거가 무엇이든 결과는 같으므로** 수정은 동일하다.

## 수정

```yaml
      cancel-in-progress: ${{ github.event.action == 'synchronize' }}
```

새 커밋이 head 를 무효화할 때만 취소하고, **같은 head 재트리거는 취소하지 않는다**. 그러면 첫 런이 정상 게시하고 두 번째는 `duplicate_head` 로 조용히 비켜선다 — `duplicate_head` 가드가 원래 하려던 일 그대로다.

`cancel-in-progress: false` 로 전면 해제하지 않은 이유는, 그러면 push 로 무효화된 head 의 모델 호출이 계속 돌아 concurrency 가 존재하는 이유를 버리게 되기 때문이다. `workflow_dispatch` 에서는 `github.event.action` 이 비어 비교가 `false` 가 되므로 취소하지 않는다(안전한 방향).

## 핀

워크플로 바이트가 바뀌므로 `release_supports_same_head_cancel_guard`(v1.61)로 게이팅했다. opencode 해시는 `current_diagnostics_contract` · `format_repair_contract` 판정에도 쓰이므로 두 집합에 함께 추가했다.

## 픽스처에서 한 번 헛디딘 것

역사 복원을 **파일 통째 덮어쓰기**로 구현했더니 앞선 pre-v1.51 변형을 되돌려 **무관해 보이는 계약 실패 77건**이 났다. 텍스트 변환으로 바꿔 다른 복원과 합성되게 고쳤다.

## 검증

| 확인 | 결과 |
|---|---|
| v1.61 수용 | PASS |
| v1.61 배선을 v1.60 으로 검증 | 거부 |
| v1.60 배선을 v1.61 로 검증 | 거부 |
| v1.47 · v1.51 · v1.59 · v1.60 수용 | PASS |
| `test_verify_workflow_release` | 581 passed |
| `test_review_workflow_logic` | 1603 passed |
| `test_workflow_release_bundle` | 73 passed |

실패 2건은 로컬 `umask 0002` 로 인한 기존 `test_v145_review_fixtures_…` 모드 비교다.

## 머지 후

워크플로 바이트가 바뀌므로 **v1.61 릴리스 + 17타깃 롤아웃**이 따라붙는다.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su9whB4FRuyxEijrq2bLWk