### PR TITLE
chore(workflows): default rollout to v1.61

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.60",
+  "automation_ref": "v1.61",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.60"
+    assert config.automation_ref == "v1.61"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
17타깃이 모두 v1.61 로 통일돼 기본 `automation_ref` 를 범프한다.

```
SUMMARY ref=v1.61 commit=938c130f3adc4ef9a451e5991f100e1acca63fec total=17 current=17 drift=0 blocked=0
```

## 이번 릴리스의 내용

같은 head 재트리거가 진행 중인 리뷰를 취소하지 않는다(#120). 취소된 런이 이미 head 를 claim 한 상태였기 때문에, 대체 런이 `duplicate_head` 로 비켜서면서 **PR 에 리뷰가 하나도 남지 않는** 경합이 있었다. `cancel-in-progress` 를 `${{ github.event.action == 'synchronize' }}` 로 좁혀, 새 커밋이 head 를 무효화할 때만 취소한다.

## 검증

- `python3 -m scripts.verify_workflow_release --ref v1.61 --expected-commit 938c130` → PASS
- `--ref v1.60 --expected-commit a2c3ca4` → PASS (역사 라인 유지)
- 태그 발행 전 선검증: v1.61 수용 · 같은 커밋을 v1.60 으로 넣으면 거부
- `test_workflow_catalog` → 20 passed
- 롤아웃 PR 17건 모두 실패 체크 0건

Refs #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su9whB4FRuyxEijrq2bLWk