### PR TITLE
fix(review): refuse the OpenCode override and surface filtered reasons

### DIFF
--- a/.github/actions/canonicalize-review/action.yml
+++ b/.github/actions/canonicalize-review/action.yml
@@ -32,6 +32,8 @@ outputs:
     value: ${{ steps.canonicalize.outputs.normalized_count }}
   filtered-max-severity:
     value: ${{ steps.canonicalize.outputs.filtered_max_severity }}
+  filtered-reasons:
+    value: ${{ steps.canonicalize.outputs.filtered_reasons }}
   failure-reason:
     value: ${{ steps.canonicalize.outputs.failure_reason }}
 runs:

--- a/.github/actions/canonicalize-review/canonicalize_review.py
+++ b/.github/actions/canonicalize-review/canonicalize_review.py
@@ -1046,10 +1046,16 @@ def main(argv: list[str] | None = None) -> int:
         _write_atomic(args.result_file, payload)
         if args.github_output is not None:
             scalar = result.to_dict()
-            output = "".join(
+            # Reason codes come from a fixed canonicalizer vocabulary, so surfacing them
+            # carries no untrusted text and lets a reader see why a finding was dropped
+            # without opening the run log.
+            filtered_reasons = ",".join(sorted({
+                item.reason for item in result.candidate_reasons if item.outcome == "filtered"
+            }))
+            output = ("".join(
                 f"{name}={str(scalar[name]).lower() if isinstance(scalar[name], bool) else scalar[name]}\n"
                 for name in ("document_valid", "accepted_count", "filtered_count", "normalized_count", "filtered_max_severity", "failure_reason")
-            ).encode("utf-8")
+            ) + f"filtered_reasons={filtered_reasons}\n").encode("utf-8")
             _write_atomic(args.github_output, output)
     except OSError:
         return 1

--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -908,6 +908,11 @@ def _build_handoff(
 
 
 def choose_override(state: LedgerState, events: Sequence[OverrideEvent]) -> OverrideEvent | None:
+    # The OpenCode canonicalizer only accepts pull_request provenance, so a dispatch
+    # round can never publish. Refusing here keeps the override unspent instead of
+    # consuming it for a verdict that is then thrown away.
+    if state.reviewer == "opencode":
+        return None
     if any(item.override_event_id is not None for item in state.invocations):
         return None
     eligible: list[OverrideEvent] = []

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -697,6 +697,27 @@ jobs:
           previous-sha: ${{ steps.prepare-review-input.outputs.previous_sha }}
           previous-review-file: ${{ steps.prepare-review-input.outputs.previous_sha != '' && format('{0}/claude-previous-review.md', runner.temp) || '' }}
 
+      # 필터된 finding 의 사유가 런 로그에만 남으면 왜 빠졌는지 확인하는 비용이 크다.
+      # 사유 코드는 정규화기 소유의 고정 어휘라 요약에 실어도 비신뢰 텍스트가 아니며,
+      # 아래 정규식이 그 어휘 밖의 값을 fail-closed 로 막는다.
+      - name: Summarize filtered Claude findings
+        if: ${{ always() && steps.canonicalize-review.outcome != 'skipped' && steps.canonicalize-review.outputs.filtered-count != '' && steps.canonicalize-review.outputs.filtered-count != '0' }}
+        shell: bash
+        env:
+          FILTERED_COUNT: ${{ steps.canonicalize-review.outputs.filtered-count }}
+          FILTERED_MAX_SEVERITY: ${{ steps.canonicalize-review.outputs.filtered-max-severity }}
+          FILTERED_REASONS: ${{ steps.canonicalize-review.outputs.filtered-reasons }}
+        run: |
+          set -euo pipefail
+          [[ "$FILTERED_COUNT" =~ ^[0-9]+$ ]]
+          [[ "$FILTERED_MAX_SEVERITY" =~ ^(none|MEDIUM|HIGH|CRITICAL)$ ]]
+          [[ "$FILTERED_REASONS" =~ ^[a-z_]+(,[a-z_]+)*$ ]]
+          {
+            printf '### Claude filtered findings\n\n'
+            printf -- '- Filtered: `%s` (max severity `%s`)\n' "$FILTERED_COUNT" "$FILTERED_MAX_SEVERITY"
+            printf -- '- Reasons: `%s`\n' "$FILTERED_REASONS"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # 거부된 후보의 원문이 없으면 프롬프트/포맷 회귀와 검증기 과잉을 구분할 수 없다.
       # 노출을 최소화하기 위해 거부된 라운드에서만, 원문이 실제로 있을 때만 보존한다.
       - name: Upload Claude review candidate

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -1418,6 +1418,27 @@ jobs:
           previous-sha: ${{ steps.pr-details.outputs.previous_sha }}
           previous-review-file: ${{ steps.pr-details.outputs.previous_sha != '' && format('{0}/gemini-previous-review.md', runner.temp) || '' }}
 
+      # 필터된 finding 의 사유가 런 로그에만 남으면 왜 빠졌는지 확인하는 비용이 크다.
+      # 사유 코드는 정규화기 소유의 고정 어휘라 요약에 실어도 비신뢰 텍스트가 아니며,
+      # 아래 정규식이 그 어휘 밖의 값을 fail-closed 로 막는다.
+      - name: Summarize filtered Gemini findings
+        if: ${{ always() && steps.canonicalize-review.outcome != 'skipped' && steps.canonicalize-review.outputs.filtered-count != '' && steps.canonicalize-review.outputs.filtered-count != '0' }}
+        shell: bash
+        env:
+          FILTERED_COUNT: ${{ steps.canonicalize-review.outputs.filtered-count }}
+          FILTERED_MAX_SEVERITY: ${{ steps.canonicalize-review.outputs.filtered-max-severity }}
+          FILTERED_REASONS: ${{ steps.canonicalize-review.outputs.filtered-reasons }}
+        run: |
+          set -euo pipefail
+          [[ "$FILTERED_COUNT" =~ ^[0-9]+$ ]]
+          [[ "$FILTERED_MAX_SEVERITY" =~ ^(none|MEDIUM|HIGH|CRITICAL)$ ]]
+          [[ "$FILTERED_REASONS" =~ ^[a-z_]+(,[a-z_]+)*$ ]]
+          {
+            printf '### Gemini filtered findings\n\n'
+            printf -- '- Filtered: `%s` (max severity `%s`)\n' "$FILTERED_COUNT" "$FILTERED_MAX_SEVERITY"
+            printf -- '- Reasons: `%s`\n' "$FILTERED_REASONS"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # 거부된 후보의 원문이 없으면 프롬프트/포맷 회귀와 검증기 과잉을 구분할 수 없다.
       # 노출을 최소화하기 위해 거부된 라운드에서만, 진단과 같은 조건으로 보존한다.
       - name: Upload Gemini review candidate

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -224,6 +224,11 @@ head — `/jhw:pr --review` labels the draft and then marks it ready — or, on 
 already open, start one authorized same-head review through a `workflow_dispatch` carrying
 `force_review: true`.
 
+A bounded override round (`review-budget-override` plus a `workflow_dispatch` carrying
+`force_review: true`) is available for Claude and Gemini only. From `v1.62` the budget refuses it
+for OpenCode, because that canonicalizer authenticates `pull_request` provenance throughout and a
+dispatch round can never publish: spending the override there consumed it and lost the verdict.
+
 `review:skip` and `review:request` steer only the managed Actions reviewers. They never reach
 Codex, whose automatic review is decided entirely in ChatGPT Codex settings, so neither label
 changes Codex behavior. Codex does require the repository to be registered under Codex code-review
@@ -279,10 +284,12 @@ The composite interface has exactly nine inputs:
 | `previous-sha` | Optional authenticated prior successful head; default empty on a first round, but it may remain set when delta safely falls back to full. |
 | `previous-review-file` | Optional authenticated prior canonical body; default empty. |
 
-It exposes exactly six scalar outputs: `document-valid`, `accepted-count`, `filtered-count`,
-`normalized-count`, `filtered-max-severity`, and `failure-reason`. The first is `true` or `false`;
-the three counts are non-negative integers; `filtered-max-severity` is `none`, `MEDIUM`, `HIGH`, or
-`CRITICAL`; and `failure-reason` is empty on a document-valid result or one fixed hard reason.
+It exposes exactly seven scalar outputs: `document-valid`, `accepted-count`, `filtered-count`,
+`normalized-count`, `filtered-max-severity`, `failure-reason`, and, from `v1.62`,
+`filtered-reasons`. The first is `true` or `false`; the three counts are non-negative integers;
+`filtered-max-severity` is `none`, `MEDIUM`, `HIGH`, or `CRITICAL`; `failure-reason` is empty on a
+document-valid result or one fixed hard reason; and `filtered-reasons` is the sorted, comma-joined
+set of fixed reason codes for the filtered blocks, empty when none were filtered.
 
 The action captures validated PR base/head metadata, prepares `review-full.diff`, optionally
 prepares `review-delta.diff`, and writes `review-scope.json`. Its composite outputs are
@@ -544,7 +551,11 @@ valid siblings. It is filtered or normalized with exactly one of `invalid_anchor
 `missing_material_impact`, `unsupported_performance_basis`, `non_actionable_category`,
 `unknown_prior_id`, `duplicate_prior_binding`, or `missing_fix_anchor`. Rejected prose is absent
 from canonical Markdown, result JSON, workflow state, and the PR comment; only bounded counts,
-claimed maximum severity, and fixed reason codes are observable. `accepted-count` counts accepted
+claimed maximum severity, and fixed reason codes are observable. From `v1.62` the Claude and
+Gemini workflows write those reason codes to the run summary whenever `filtered-count` is not zero,
+so a reader can see why a block was dropped without opening the run log. The step validates the
+codes against the fixed vocabulary and fails closed on anything else. The sticky comment is
+unchanged; it still carries counts only. `accepted-count` counts accepted
 new and still-open actionable blocks, `filtered-count` counts soft-rejected blocks, and
 `normalized-count` counts carryover blocks omitted without becoming actionable, including an
 unknown or duplicate prior binding or missing transition proof.

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -48,6 +48,7 @@ from scripts.workflow_release_inventory import (
     release_supports_review_invocation_budget,
     release_supports_review_optin,
     release_supports_review_rounds_variable,
+    release_supports_filter_reason_surface,
     release_supports_same_head_cancel_guard,
     release_supports_review_policy,
     validate_release_listing,
@@ -469,6 +470,24 @@ EXPECTED_CANONICALIZE_REVIEW_ACTION = {
         ],
     },
 }
+
+
+def _canonicalize_action_with_filter_reasons(action: dict) -> dict:
+    """Derive the v1.62 canonicalizer action: one added scalar output.
+
+    Stating the delta keeps the two expectations from drifting apart.
+    """
+
+    updated = deepcopy(action)
+    updated["outputs"]["filtered-reasons"] = {
+        "value": "${{ steps.canonicalize.outputs.filtered_reasons }}"
+    }
+    return updated
+
+
+EXPECTED_CANONICALIZE_REVIEW_ACTION_V162 = _canonicalize_action_with_filter_reasons(
+    EXPECTED_CANONICALIZE_REVIEW_ACTION
+)
 EXPECTED_CANONICALIZER_HARD_REASONS = frozenset(
     {
         "candidate_missing",
@@ -495,6 +514,9 @@ EXPECTED_CANONICALIZER_SOFT_REASONS = frozenset(
 )
 EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256 = (
     "eb4ba827d3b03e3c9169cd95e9194d49b2b8b9b6956e7317b5c9cc9b7bb04fc5"
+)
+EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256_V162 = (
+    "d814b42568e38a2f46f1772d00a5a713a467bba067d8865cf4f7657a38ac0739"
 )
 EXPECTED_REVIEW_SCOPE_HELPER_SHA256 = (
     "68779c9038c31aa09a846b643bc0178b147798527e1a34ee5821ab539f10b19a"
@@ -670,6 +692,9 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256 = (
 EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V160 = (
     "d6a9dc0af9b6e340b6528911ac60a48e21fd8960e515167e2c6be4536f33f1a3"
 )
+EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V162 = (
+    "deda9f65bbe853860fa06599ce303b15cd63b15b5dad645896c8c76aae7e9b03"
+)
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
     "claude": "d4db53b86603a3a113999409e2e4e35c397adf276981e7f68c0ea57a6198faa2",
     "gemini": "cbd69aba74ec0f3380591f14d0adcb6543faad5e237a855dbec246750e2b5206",
@@ -689,6 +714,13 @@ EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256 = {
 }
 # v1.61 narrowed cancel-in-progress to superseding commits, changing the three
 # reusable review workflows again.
+# v1.62 writes filtered-finding reasons to the run summary for Claude and Gemini;
+# the OpenCode workflow is unchanged on this line.
+EXPECTED_FILTER_REASON_WORKFLOW_SHA256 = {
+    "claude": "03f2208f44a84e3c726903c5ed707d2b9a5ebab9cf934cf2aa19ddd8182c3f14",
+    "gemini": "07bf3ace69eeeca2bf8243d52b0e35dfafcdd2689f40fe9afd211a597095d1b4",
+    "opencode": "4a173036252929de6320da7e04436d67b9a4759ed4b9f60b6bdf2b3a3ecc1d5a",
+}
 EXPECTED_SAME_HEAD_CANCEL_WORKFLOW_SHA256 = {
     "claude": "b3b7d95cb8e87164470759f4c918f8c317e37a10d2c214ec915ac4a51963f04e",
     "gemini": "3271f4f7dd4d13711b91d65ac191451703ead424fcb67299ff504b8a26b32e0f",
@@ -2350,6 +2382,7 @@ def verify_opencode_runtime(
         EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256["opencode"],
         EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256["opencode"],
         EXPECTED_SAME_HEAD_CANCEL_WORKFLOW_SHA256["opencode"],
+        EXPECTED_FILTER_REASON_WORKFLOW_SHA256["opencode"],
     }
     initial_validation_argument = " initial" if current_diagnostics_contract else ""
     repair_validation_argument = " repair" if current_diagnostics_contract else ""
@@ -2383,6 +2416,7 @@ def verify_opencode_runtime(
             EXPECTED_REVIEW_POLICY_WORKFLOW_SHA256["opencode"],
             EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256["opencode"],
             EXPECTED_SAME_HEAD_CANCEL_WORKFLOW_SHA256["opencode"],
+            EXPECTED_FILTER_REASON_WORKFLOW_SHA256["opencode"],
         }
         and run_step.get("shell") == "bash"
         and run_env.get("CANDIDATE_NONCE")
@@ -3017,7 +3051,7 @@ def _verify_review_policy_action(
     require_review_policy_helper_contract(helper, release_supports_review_optin(ref))
 
 
-def _verify_canonicalize_review_helpers(tree: VerifiedCommitTree) -> None:
+def _verify_canonicalize_review_helpers(tree: VerifiedCommitTree, ref: str) -> None:
     canonical_path = CANONICALIZE_REVIEW_HELPER_ROOT.path.as_posix()
     scope_path = REVIEW_SCOPE_HELPER_ROOT.path.as_posix()
     try:
@@ -3025,7 +3059,11 @@ def _verify_canonicalize_review_helpers(tree: VerifiedCommitTree) -> None:
         scope_source = tree.read_file(scope_path)
         if (
             hashlib.sha256(canonical_source).hexdigest()
-            != EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256
+            != (
+                EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256_V162
+                if release_supports_filter_reason_surface(ref)
+                else EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256
+            )
             or hashlib.sha256(scope_source).hexdigest()
             != EXPECTED_REVIEW_SCOPE_HELPER_SHA256
         ):
@@ -3161,11 +3199,16 @@ def _verify_canonicalize_review_action(
         raise ReleaseVerificationError(
             "canonicalize-review action contract is invalid"
         ) from None
-    if document != EXPECTED_CANONICALIZE_REVIEW_ACTION:
+    expected_action = (
+        EXPECTED_CANONICALIZE_REVIEW_ACTION_V162
+        if release_supports_filter_reason_surface(ref)
+        else EXPECTED_CANONICALIZE_REVIEW_ACTION
+    )
+    if document != expected_action:
         raise ReleaseVerificationError(
             "canonicalize-review action contract is invalid"
         )
-    _verify_canonicalize_review_helpers(tree)
+    _verify_canonicalize_review_helpers(tree, ref)
 
 
 def _verify_claude_code_action_pin(
@@ -4106,7 +4149,9 @@ def _local_literal(function: ast.FunctionDef, name: str) -> object:
     return ast.literal_eval(matches[0])
 
 
-def require_budget_helper_contract(source: str, rounds_variable: bool = False) -> None:
+def require_budget_helper_contract(
+    source: str, rounds_variable: bool = False, filter_reasons: bool = False
+) -> None:
     """Require the authenticated schema-1 helper and every fixed policy gate."""
 
     # v1.60 resolves the round budget through effective_budgets(), which renames the
@@ -4899,16 +4944,26 @@ def require_budget_helper_contract(source: str, rounds_variable: bool = False) -
             raise ValueError("run identity manifest differs")
 
         choose_override = _function_node(module, "choose_override")
+        # v1.62 refuses the OpenCode override up front, which adds one guard ahead of
+        # the eligibility loop.
+        override_offset = 1 if rounds_variable and filter_reasons else 0
         if (
-            len(choose_override.body) != 4
-            or not isinstance(choose_override.body[2], ast.For)
-            or not _ast_expression_matches(
-                choose_override.body[2].iter, "events"
+            len(choose_override.body) != 4 + override_offset
+            or (
+                filter_reasons
+                and not _ast_statement_matches(
+                    choose_override.body[0],
+                    "if state.reviewer == 'opencode':\n    return None",
+                )
             )
-            or len(choose_override.body[2].body) != 1
-            or not isinstance(choose_override.body[2].body[0], ast.If)
+            or not isinstance(choose_override.body[2 + override_offset], ast.For)
             or not _ast_expression_matches(
-                choose_override.body[2].body[0].test,
+                choose_override.body[2 + override_offset].iter, "events"
+            )
+            or len(choose_override.body[2 + override_offset].body) != 1
+            or not isinstance(choose_override.body[2 + override_offset].body[0], ast.If)
+            or not _ast_expression_matches(
+                choose_override.body[2 + override_offset].body[0].test,
                 "isinstance(event, OverrideEvent) "
                 "and isinstance(event.event_id, int) "
                 "and not isinstance(event.event_id, bool) "
@@ -4920,11 +4975,11 @@ def require_budget_helper_contract(source: str, rounds_variable: bool = False) -
                 "state.consumed_override_event_ids",
             )
             or not _ast_statement_matches(
-                choose_override.body[2].body[0].body[0],
+                choose_override.body[2 + override_offset].body[0].body[0],
                 "eligible.append(event)",
             )
             or not _ast_statement_matches(
-                choose_override.body[3],
+                choose_override.body[3 + override_offset],
                 "return max(eligible, key=lambda item: item.event_id, "
                 "default=None)",
             )
@@ -5609,7 +5664,11 @@ def _verify_review_invocation_budget(
         raise ReleaseVerificationError(
             "invocation-budget helper contract is invalid"
         ) from None
-    require_budget_helper_contract(helper, release_supports_review_rounds_variable(ref))
+    require_budget_helper_contract(
+        helper,
+        release_supports_review_rounds_variable(ref),
+        release_supports_filter_reason_surface(ref),
+    )
     for reviewer, workflow in REVIEWER_WORKFLOWS.items():
         require_budget_workflow_contract(
             tree,
@@ -5627,13 +5686,17 @@ def _verify_review_invocation_budget(
         ),
         REVIEW_INVOCATION_BUDGET_HELPER_ROOT.path.as_posix(): (
             helper_payload,
-            EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V160
+            EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V162
+            if release_supports_filter_reason_surface(ref)
+            else EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V160
             if rounds_variable
             else EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256,
         ),
     }
     workflow_digests = (
-        EXPECTED_SAME_HEAD_CANCEL_WORKFLOW_SHA256
+        EXPECTED_FILTER_REASON_WORKFLOW_SHA256
+        if release_supports_filter_reason_surface(ref)
+        else EXPECTED_SAME_HEAD_CANCEL_WORKFLOW_SHA256
         if release_supports_same_head_cancel_guard(ref)
         else EXPECTED_REVIEW_ROUNDS_VARIABLE_WORKFLOW_SHA256
         if rounds_variable

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -150,6 +150,7 @@ REVIEW_POLICY_RELEASE = (1, 51)
 REVIEW_OPTIN_RELEASE = (1, 59)
 REVIEW_ROUNDS_VARIABLE_RELEASE = (1, 60)
 SAME_HEAD_CANCEL_RELEASE = (1, 61)
+FILTER_REASON_SURFACE_RELEASE = (1, 62)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -198,6 +199,12 @@ def release_supports_same_head_cancel_guard(ref: str) -> bool:
     """Return whether ``ref`` cancels a review only when a new commit supersedes it."""
 
     return _release_version(ref) >= SAME_HEAD_CANCEL_RELEASE
+
+
+def release_supports_filter_reason_surface(ref: str) -> bool:
+    """Return whether ``ref`` surfaces filtered-finding reasons and refuses OpenCode overrides."""
+
+    return _release_version(ref) >= FILTER_REASON_SURFACE_RELEASE
 
 
 def release_roots_for(ref: str) -> tuple[ReleaseRoot, ...]:

--- a/tests/test_canonicalize_review.py
+++ b/tests/test_canonicalize_review.py
@@ -771,7 +771,7 @@ def test_cli_writes_bounded_schema_result_scalar_outputs_and_metadata_only_logs(
     assert secret not in case.result.read_text(encoding="utf-8")
     assert secret not in completed.stdout
     assert completed.stdout == "review-canonicalization: document_valid=true accepted=0 filtered=1 normalized=0 filtered_max=HIGH failure_reason=\ncandidate[0]: section=New findings outcome=filtered reason=invalid_anchor claimed_severity=HIGH\n"
-    assert github_output.read_text(encoding="utf-8") == "document_valid=true\naccepted_count=0\nfiltered_count=1\nnormalized_count=0\nfiltered_max_severity=HIGH\nfailure_reason=\n"
+    assert github_output.read_text(encoding="utf-8") == "document_valid=true\naccepted_count=0\nfiltered_count=1\nnormalized_count=0\nfiltered_max_severity=HIGH\nfailure_reason=\nfiltered_reasons=invalid_anchor\n"
     assert case.canonical.read_text(encoding="utf-8") == "### New findings\n\nNone\n\nNo validated blocking issues found.\n"
 
 
@@ -842,6 +842,7 @@ def test_cli_action_first_round_empty_previous_review_file_writes_runner_outputs
         "normalized_count=0\n"
         "filtered_max_severity=none\n"
         "failure_reason=\n"
+        "filtered_reasons=\n"
     )
     assert case.canonical.is_file() and not case.canonical.is_symlink()
     assert case.result.is_file() and not case.result.is_symlink()

--- a/tests/test_review_invocation_budget.py
+++ b/tests/test_review_invocation_budget.py
@@ -1141,3 +1141,26 @@ def test_recorded_override_survives_a_raised_round_budget(monkeypatch):
     monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, "5")
 
     budget._validate_state_shape(state)
+
+
+# --- OpenCode cannot publish a dispatch round, so it must not spend one (issue #118) ---
+
+
+def override_event(event_id: int = 9101):
+    return budget.OverrideEvent(event_id, "labeled", "review-budget-override", "write")
+
+
+@pytest.mark.parametrize("reviewer", ("claude", "gemini"))
+def test_override_stays_available_for_the_publishing_reviewers(reviewer):
+    state = budget.LedgerState.initial(REPOSITORY, PR, reviewer)
+
+    assert budget.choose_override(state, (override_event(),)) is not None
+
+
+def test_override_is_refused_for_opencode():
+    """OpenCode's canonicalizer only accepts pull_request provenance, so a dispatch
+    round can never publish. Spending the override there loses the verdict."""
+
+    state = budget.LedgerState.initial(REPOSITORY, PR, "opencode")
+
+    assert budget.choose_override(state, (override_event(),)) is None

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -17622,3 +17622,25 @@ def test_opencode_rejected_candidate_preservation_is_symlink_safe():
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+# --- filtered-finding reasons reach the run summary (issue #117) ---
+
+
+@pytest.mark.parametrize(
+    ("workflow", "job", "name"),
+    (
+        ("claude-code-review.yml", "claude-review", "Summarize filtered Claude findings"),
+        ("gemini-auto-review.yml", "gemini-review", "Summarize filtered Gemini findings"),
+    ),
+)
+def test_filtered_findings_reach_the_run_summary(workflow, job, name):
+    step = _step(_load(workflow), job, name)
+
+    assert step["env"]["FILTERED_REASONS"] == (
+        "${{ steps.canonicalize-review.outputs.filtered-reasons }}"
+    )
+    # A fixed canonicalizer vocabulary is the only thing allowed through.
+    assert '[[ "$FILTERED_REASONS" =~ ^[a-z_]+(,[a-z_]+)*$ ]]' in step["run"]
+    assert '>> "$GITHUB_STEP_SUMMARY"' in step["run"]
+    assert "filtered-count != '0'" in step["if"]

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import sys
@@ -101,6 +102,7 @@ REVIEW_POLICY_RELEASE_FILES = (
 V1462_WORKFLOW_FIXTURE_COMMIT = "d42c28ddd827554e6e46a2ab49dfe34c838c0425"
 V158_REVIEW_POLICY_HELPER_COMMIT = "1b98172325533ef6ad37f3d2cfc3870073fac26d"
 V159_ROUND_BUDGET_COMMIT = "96d66e1d17952f01b19bb957057830a2b2a6318b"
+V161_FILTER_SURFACE_COMMIT = "08f96e3244bfe8bdd569fb926b26d3086bab125d"
 V1462_WORKFLOW_FIXTURE_SHA256 = {
     "claude-code-review.yml": (
         "008bbdcdeacdaf7796c1e3b59d22194d3f1ce380735d36dada5efab8ff52d112"
@@ -232,6 +234,7 @@ def current_release_repo(tmp_path: Path) -> tuple[Path, str]:
             shutil.copy2(source, target)
     restore_pre_v151_review_policy(repo)
     restore_pre_v160_round_budget(repo)
+    restore_pre_v162_filter_surface(repo)
     restore_pre_v161_cancel_guard(repo)
     git(repo, "init", "-q")
     git(repo, "config", "user.name", "Test")
@@ -265,6 +268,7 @@ def v1462_release_repo(tmp_path: Path) -> tuple[Path, str]:
         else:
             shutil.copy2(source, target)
     restore_v1462_workflow_fixtures(repo)
+    restore_pre_v162_filter_surface(repo)
     git(repo, "init", "-q")
     git(repo, "config", "user.name", "Test")
     git(repo, "config", "user.email", "test@example.com")
@@ -315,6 +319,46 @@ def restore_pre_v159_review_policy_helper(repo: Path) -> None:
         == release_verifier.EXPECTED_REVIEW_POLICY_HELPER_SHA256
     )
     (repo / relative).write_bytes(payload)
+
+
+def restore_pre_v162_filter_surface(repo: Path, *, budget: bool = False) -> None:
+    """Restore the authenticated pre-v1.62 canonicalizer and review workflows.
+
+    The workflow edit removes the summary step as text so it composes with the other
+    historical restores. ``budget`` re-restores the invocation-budget helper for the
+    prepares that copy the current one back in.
+    """
+
+    tree = release_verifier.VerifiedCommitTree.open(ROOT, V161_FILTER_SURFACE_COMMIT)
+    # The action is authenticated as a parsed document rather than a digest.
+    (repo / ".github/actions/canonicalize-review/action.yml").write_bytes(
+        tree.read_file(".github/actions/canonicalize-review/action.yml")
+    )
+    helper = tree.read_file(".github/actions/canonicalize-review/canonicalize_review.py")
+    assert (
+        hashlib.sha256(helper).hexdigest()
+        == release_verifier.EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256
+    )
+    (repo / ".github/actions/canonicalize-review/canonicalize_review.py").write_bytes(helper)
+    if budget:
+        relative = ".github/actions/review-invocation-budget/review_invocation_budget.py"
+        payload = tree.read_file(relative)
+        assert (
+            hashlib.sha256(payload).hexdigest()
+            == release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V160
+        )
+        (repo / relative).write_bytes(payload)
+    for reviewer in ("claude", "gemini"):
+        path = repo / ".github/workflows" / release_verifier.REVIEWER_WORKFLOWS[reviewer]
+        text = path.read_text(encoding="utf-8")
+        text = re.sub(
+            r"      # 필터된 finding 의 사유가.*?>> \"\$GITHUB_STEP_SUMMARY\"\n\n",
+            "",
+            text,
+            count=1,
+            flags=re.S,
+        )
+        path.write_text(text, encoding="utf-8")
 
 
 def restore_pre_v161_cancel_guard(repo: Path) -> None:
@@ -421,6 +465,7 @@ def copy_review_policy_release_files(repo: Path) -> None:
 
 def prepare_v151(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v162_filter_surface(repo)
     restore_pre_v161_cancel_guard(repo)
     restore_pre_v159_review_policy_helper(repo)
     restore_pre_v160_round_budget(repo)
@@ -429,6 +474,7 @@ def prepare_v151(repo: Path) -> str:
 
 def prepare_v159(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v162_filter_surface(repo)
     restore_pre_v161_cancel_guard(repo)
     restore_pre_v160_round_budget(repo)
     assert_pre_v160_workflow_bytes(repo)
@@ -437,13 +483,14 @@ def prepare_v159(repo: Path) -> str:
 
 def prepare_v160(repo: Path) -> str:
     copy_review_policy_release_files(repo)
-    restore_pre_v161_cancel_guard(repo)
-    assert_pre_v161_workflow_bytes(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v162_filter_surface(repo, budget=True)
+    restore_pre_v161_cancel_guard(repo)
+    assert_pre_v161_workflow_bytes(repo)
     return commit(repo, "v1.60 candidate")
 
 
@@ -1862,6 +1909,47 @@ def test_v159_opt_in_helper_is_rejected_on_the_v151_release_line(
         release_verifier.verify_commit_content(repo, "v1.51", candidate)
 
 
+def prepare_v162(repo: Path) -> str:
+    copy_review_policy_release_files(repo)
+    for relative in (
+        ".github/actions/review-invocation-budget/action.yml",
+        ".github/actions/review-invocation-budget/review_invocation_budget.py",
+        ".github/actions/canonicalize-review/action.yml",
+        ".github/actions/canonicalize-review/canonicalize_review.py",
+    ):
+        shutil.copy2(ROOT / relative, repo / relative)
+    return commit(repo, "v1.62 candidate")
+
+
+def test_v162_accepts_current_filter_surface_release_contract(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v162(repo)
+
+    assert release_verifier.verify_commit_content(repo, "v1.62", candidate) == candidate
+
+
+def test_v162_filter_surface_is_rejected_on_the_v161_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v162(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.61", candidate)
+
+
+def test_pre_v162_filter_surface_is_rejected_on_the_v162_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v161(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.62", candidate)
+
+
 def prepare_v161(repo: Path) -> str:
     copy_review_policy_release_files(repo)
     for relative in (
@@ -1869,6 +1957,7 @@ def prepare_v161(repo: Path) -> str:
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v162_filter_surface(repo, budget=True)
     return commit(repo, "v1.61 candidate")
 
 

--- a/tests/test_workflow_release_bundle.py
+++ b/tests/test_workflow_release_bundle.py
@@ -87,6 +87,9 @@ def test_canonicalize_review_composite_action_has_exact_safe_shell_contract() ->
                 "value": "${{ steps.canonicalize.outputs.filtered_max_severity }}"
             },
             "failure-reason": {"value": "${{ steps.canonicalize.outputs.failure_reason }}"},
+            "filtered-reasons": {
+                "value": "${{ steps.canonicalize.outputs.filtered_reasons }}"
+            },
         },
         "runs": {
             "using": "composite",


### PR DESCRIPTION
리뷰 파이프라인이 **작업은 소비하고 산출은 잃는** 두 지점을 함께 고친다. 워크플로 바이트가 바뀌므로 v1.62 릴리스 + 17타깃 롤아웃 한 사이클로 묶었다.

## #118 — OpenCode override 는 소진되고 판정이 사라졌다

정규화기가 `pull_request` provenance 를 **11곳**에서 요구한다(`196·210·308·326·332·3429·3460·3728·3761·3790·3801`). 특히 `:3790` 은 GitHub API run 목록을 `event=pull_request` 로 필터해 **dispatch 런이 구조적으로 보이지 않는다.**

세 곳만 넓혀 봤더니 게시 시도까지 가고 `canonical attestation exact-byte refetch failed` 에서 막혔다 — **"고쳐진 것처럼 보이는" 상태**라 그 방향은 폐기했다.

대신 `choose_override` 가 OpenCode 를 **선제 거부**한다. override 는 소진되지 않고 호출자는 침묵 대신 `round_budget_exhausted` 를 받는다. provenance 모델 일반화는 여전히 가능하며 #118 에 선택지로 남긴다.

## #117 — 사유는 기록되지만 PR 에 안 보였다

**본문 전제가 틀렸다.** 사유는 `candidate[N]: ... reason=...` 로 로그에 남고 결과 JSON 의 `candidate_reasons` 에도 들어간다. 문제의 그 HIGH 는 `reason=invalid_anchor` — 형식 불량 블록을 품질 게이트가 제대로 거부한 것이었다.

없던 것은 **가시성**이다. 스티키 코멘트는 카운트만 싣는다. 그래서 정규화기가 사유 코드를 `filtered-reasons` 스칼라 출력으로 노출하고, Claude·Gemini 워크플로가 필터가 있을 때만 **run summary** 에 기록한다.

코멘트 문법과 상태 스키마는 **건드리지 않았다** — upsert 다이제스트가 움직이지 않는다. 사유 코드는 정규화기 소유의 고정 어휘이고 스텝이 `^[a-z_]+(,[a-z_]+)*$` 로 fail-closed 검증한다.

## 핀

`release_supports_filter_reason_surface`(v1.62)로 5종을 게이팅했다 — 워크플로 해시 3종(opencode 는 불변), 예산 헬퍼, 정규화기 헬퍼·액션 문서. 액션 문서는 **델타 파생**(`_canonicalize_action_with_filter_reasons`).

`require_budget_helper_contract` 도 새 게이트를 받는다 — OpenCode 가드가 `choose_override` 의 **고정된 문장 인덱스**를 밀기 때문이다(`override_offset`).

## 픽스처에서 배운 것

역사 복원을 **파일 통째 덮어쓰기**로 하면 앞선 복원을 되돌린다. 텍스트 편집으로 바꾸고 **최신→과거 순서**(v1.62→v1.61→v1.60)로 정렬했다. 순서가 어긋났을 때 **무관해 보이는 계약 실패 151건**이 났다. 별도 픽스처 `v1462_release_repo` 도 같은 복원이 필요했다.

## 검증

| 확인 | 결과 |
|---|---|
| v1.62 수용 / v1.61 로 검증 시 거부 / v1.61 배선을 v1.62 로 검증 시 거부 | PASS |
| v1.47 · v1.51 · v1.59 · v1.60 · v1.61 수용 | PASS |
| `test_verify_workflow_release` | 584 passed |
| `test_review_workflow_logic` | 1608 passed |
| `test_workflow_release_bundle` · `test_canonicalize_review` · budget 2종 | 73 · 134 · 138 passed |

실패 2건은 로컬 `umask 0002` 로 인한 기존 `test_v145_review_fixtures_…` 모드 비교다.

Closes #118, closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su9whB4FRuyxEijrq2bLWk