### PR TITLE
chore(workflows): default rollout to v1.62

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.61",
+  "automation_ref": "v1.62",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.61"
+    assert config.automation_ref == "v1.62"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
17타깃이 모두 v1.62 로 통일돼 기본 `automation_ref` 를 범프한다.

```
SUMMARY ref=v1.62 commit=06b0f77baa88e04001fe3f6259a994571dcf5408 total=17 current=17 drift=0 blocked=0
```

## 이번 릴리스의 내용

- **#117** — 필터된 finding 의 사유 코드가 run summary 에 기록된다. 코멘트 문법·상태 스키마는 불변.
- **#118** — 예산이 OpenCode override 를 선제 거부한다. 게시가 불가능한 라운드에 override 를 소진하지 않는다.

## 검증

- `--ref v1.62 --expected-commit 06b0f77` → PASS
- `--ref v1.61 --expected-commit 938c130` → PASS (역사 라인 유지)
- 태그 발행 전 선검증: v1.62 수용 · 같은 커밋을 v1.61 로 넣으면 `canonicalize-review action contract is invalid` 로 거부
- `test_workflow_catalog` → 20 passed
- 롤아웃 PR 17건 모두 실패 체크 0건

Refs #117, #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su9whB4FRuyxEijrq2bLWk