### PR TITLE
feat(review): let a write collaborator dismiss a finding by comment (#112)

### DIFF
--- a/.github/actions/canonicalize-review/action.yml
+++ b/.github/actions/canonicalize-review/action.yml
@@ -21,6 +21,9 @@ inputs:
   previous-review-file:
     required: false
     default: ''
+  dismissed-finding-ids:
+    required: false
+    default: ''
 outputs:
   document-valid:
     value: ${{ steps.canonicalize.outputs.document_valid }}
@@ -51,6 +54,7 @@ runs:
         DIFF_MODE: ${{ inputs.diff-mode }}
         PREVIOUS_SHA: ${{ inputs.previous-sha }}
         PREVIOUS_REVIEW_FILE: ${{ inputs.previous-review-file }}
+        DISMISSED_FINDING_IDS: ${{ inputs.dismissed-finding-ids }}
       run: >-
         python3 "$GITHUB_ACTION_PATH/canonicalize_review.py"
         --reviewer "$REVIEWER"
@@ -62,6 +66,7 @@ runs:
         --diff-mode "$DIFF_MODE"
         --previous-sha "$PREVIOUS_SHA"
         --previous-review-file "$PREVIOUS_REVIEW_FILE"
+        --dismissed-finding-ids "$DISMISSED_FINDING_IDS"
         --repository-root "$GITHUB_WORKSPACE"
         --expected-repository "$GITHUB_REPOSITORY"
         --github-output "$GITHUB_OUTPUT"

--- a/.github/actions/canonicalize-review/canonicalize_review.py
+++ b/.github/actions/canonicalize-review/canonicalize_review.py
@@ -27,6 +27,7 @@ SOFT_REASONS = frozenset({
     "invalid_impact_class", "missing_material_impact",
     "unsupported_performance_basis", "non_actionable_category",
     "unknown_prior_id", "duplicate_prior_binding", "missing_fix_anchor",
+    "dismissed_prior_id",
 })
 SEVERITIES = ("CRITICAL", "HIGH", "MEDIUM")
 IMPACT_CLASSES = frozenset({"runtime", "security", "data-integrity", "user-visible", "performance"})
@@ -35,6 +36,7 @@ MAX_CANONICAL_BYTES = 64_000
 MAX_PREVIOUS_CANONICAL_BYTES = 65_536
 MAX_CANDIDATE_BLOCKS = 512
 MAX_SAFE_INTEGER = (1 << 53) - 1
+FINDING_ID = re.compile(r"RVW-[0-9a-f]{12}\Z")
 PROOF_DEFICIT = re.compile(
     r"\b(?:plausible(?:\s+but)?\s+unconfirmed|cannot\s+(?:confirm|verify)|"
     r"not\s+confirmed|pending\s+confirmation|unverified\s+external)\b",
@@ -91,6 +93,10 @@ class CanonicalizationRequest:
     previous_sha: str
     previous_review_file: Path | None
     expected_repository: str
+    # Finding IDs a collaborator dismissed through the review budget ledger. A dismissed
+    # prior finding leaves the active set, and neither a carryover binding nor a verbatim
+    # re-emission under New findings can bring it back while the dismissal stands.
+    dismissed_finding_ids: frozenset[str]
 
 
 @dataclass(frozen=True)
@@ -840,6 +846,13 @@ def canonicalize(request: CanonicalizationRequest) -> CanonicalizationResult:
                         expected_repository=request.expected_repository,
                     )
                     prior_active = _load_prior_active(request)
+                    dismissed = request.dismissed_finding_ids
+                    # The per-block checks below already stop a dismissed ID from binding
+                    # or re-entering; removing it from the active set as well keeps that
+                    # set authoritative for any later consumer of prior_active.
+                    for finding_id in list(prior_active):
+                        if finding_id in dismissed:
+                            del prior_active[finding_id]
                 except ScopeValidationError:
                     result = _hard("scope_invalid")
                 except ValueError as error:
@@ -891,6 +904,10 @@ def canonicalize(request: CanonicalizationRequest) -> CanonicalizationResult:
                     duplicated = {finding_id for finding_id, blocks in bound.items() if len(blocks) > 1}
                     for section in ("Still open", "Resolved", "Retracted"):
                         for block in sections[section]:
+                            if block.finding_id in dismissed:
+                                normalized += 1
+                                reasons.append(_claim_reason(block, "normalized", "dismissed_prior_id"))
+                                continue
                             prior = prior_active.get(block.finding_id or "")
                             if prior is None:
                                 normalized += 1
@@ -929,6 +946,10 @@ def canonicalize(request: CanonicalizationRequest) -> CanonicalizationResult:
                         finding_id = stable_finding_id(
                             request.reviewer, finding.anchor, finding.severity, finding.title,
                         )
+                        if finding_id in dismissed:
+                            normalized += 1
+                            reasons.append(_claim_reason(block, "normalized", "dismissed_prior_id"))
+                            continue
                         if finding_id in active_ids:
                             normalized += 1
                             reasons.append(_claim_reason(
@@ -1005,6 +1026,16 @@ def _summary(result: CanonicalizationResult) -> list[str]:
     return lines
 
 
+def _dismissed_finding_ids(value: str) -> frozenset[str]:
+    """Parse the workflow-owned comma-separated dismissal list; anything else is a wiring bug."""
+    if value == "":
+        return frozenset()
+    finding_ids = value.split(",")
+    if any(FINDING_ID.fullmatch(item) is None for item in finding_ids):
+        raise argparse.ArgumentTypeError("dismissed finding IDs must be comma-separated RVW-<12 hex> values")
+    return frozenset(finding_ids)
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("--reviewer", required=True, choices=("claude", "gemini"))
@@ -1020,6 +1051,7 @@ def _parser() -> argparse.ArgumentParser:
         "--previous-review-file", type=lambda value: None if value == "" else Path(value)
     )
     parser.add_argument("--expected-repository", required=True)
+    parser.add_argument("--dismissed-finding-ids", type=_dismissed_finding_ids, default=frozenset())
     parser.add_argument("--github-output", type=Path)
     return parser
 
@@ -1030,6 +1062,7 @@ def main(argv: list[str] | None = None) -> int:
         args.reviewer, args.candidate_file, args.canonical_file, args.result_file,
         args.scope_manifest, args.selected_diff, args.repository_root, args.diff_mode,
         args.previous_sha, args.previous_review_file, args.expected_repository,
+        args.dismissed_finding_ids,
     )
     try:
         result = canonicalize(request)

--- a/.github/actions/review-invocation-budget/action.yml
+++ b/.github/actions/review-invocation-budget/action.yml
@@ -59,6 +59,8 @@ outputs:
     value: ${{ steps.budget.outputs.checkpoint-sha256 }}
   comment-id:
     value: ${{ steps.budget.outputs.comment-id }}
+  dismissed-finding-ids:
+    value: ${{ steps.budget.outputs.dismissed-finding-ids }}
 runs:
   using: composite
   steps:
@@ -115,6 +117,7 @@ runs:
             "invocation-key": output["invocation-key"],
             "checkpoint-sha256": output["checkpoint-sha256"],
             "comment-id": comment_id,
+            "dismissed-finding-ids": output["dismissed-finding-ids"],
         }
         patterns = {
             "allow-invocation": r"(?:true|false)",
@@ -123,6 +126,7 @@ runs:
             "invocation-key": r"[0-9:]*",
             "checkpoint-sha256": r"[0-9a-f]{64}",
             "comment-id": r"[0-9]*",
+            "dismissed-finding-ids": r"(?:RVW-[0-9a-f]{12}(?:,RVW-[0-9a-f]{12})*)?",
         }
         with Path(sys.argv[3]).open("a", encoding="utf-8") as stream:
             for key, value in values.items():

--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -41,6 +41,14 @@ _FINDING = re.compile(r"RVW-[0-9a-f]{12}\Z")
 _CALLER_WORKFLOW = re.compile(r"\.github/workflows/[A-Za-z0-9_./-]+\.ya?ml\Z")
 _WORKFLOW_REF = re.compile(r"[^\x00-\x20\x7f]{1,256}\Z")
 _OUTCOMES = {"success", "provider_failure", "quality_filtered", "checkpoint_failure", "wall_time_exhausted"}
+# A collaborator dismisses one finding per comment with this exact grammar. Comment bodies
+# stay outside the trust boundary: nothing but the finding ID is read from them, and only
+# after the author's repository permission has been fetched from the collaborators API.
+_DISMISS_COMMAND = re.compile(r"dismiss (RVW-[0-9a-f]{12}) (\S[^\r\n]*)\Z")
+_DISMISS_PERMISSIONS = frozenset({"admin", "maintain", "write"})
+MAX_DISMISSED_FINDINGS = 16
+# Anyone who can comment can add a permission lookup, so the actor list is bounded too.
+MAX_PERMISSION_ACTORS = 16
 
 
 class BudgetStateError(ValueError):
@@ -159,6 +167,41 @@ class OverrideEvent:
     event: str
     label: str | None
     actor_permission: str | None
+
+
+@dataclass(frozen=True)
+class DismissEvent:
+    event_id: int
+    finding_id: str
+    actor_permission: str | None
+
+
+@dataclass(frozen=True)
+class DismissedFinding:
+    finding_id: str
+    comment_id: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {"comment_id": self.comment_id, "finding_id": self.finding_id}
+
+    @classmethod
+    def from_dict(cls, value: object) -> "DismissedFinding":
+        if not isinstance(value, dict) or set(value) != {"comment_id", "finding_id"}:
+            raise BudgetStateError("dismissed_findings_invalid")
+        finding_id = value["finding_id"]
+        comment_id = value["comment_id"]
+        if (not isinstance(finding_id, str) or _FINDING.fullmatch(finding_id) is None or
+                isinstance(comment_id, bool) or not isinstance(comment_id, int) or comment_id <= 0):
+            raise BudgetStateError("dismissed_findings_invalid")
+        return cls(finding_id, comment_id)
+
+
+def parse_dismiss_command(body: object) -> str | None:
+    """Return the finding ID named by an exact `dismiss RVW-<12 hex> <reason>` comment."""
+    if not isinstance(body, str):
+        return None
+    match = _DISMISS_COMMAND.fullmatch(body.rstrip())
+    return None if match is None else match.group(1)
 
 
 @dataclass(frozen=True)
@@ -443,6 +486,7 @@ class LedgerState:
     consumed_override_event_ids: tuple[int, ...] = ()
     last_decision: DecisionRecord = field(default_factory=DecisionRecord)
     handoff: Handoff = field(default_factory=Handoff)
+    dismissed_findings: tuple[DismissedFinding, ...] = ()
 
     @classmethod
     def initial(cls, repository: str, pr: int, reviewer: Reviewer, *, invocations: tuple[Invocation, ...] = (),
@@ -450,17 +494,28 @@ class LedgerState:
         return cls(repository, pr, reviewer, BudgetPolicy.for_reviewer(reviewer), invocations, consumed_override_event_ids)
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "budgets": self.budgets.to_dict(), "consumed_override_event_ids": list(self.consumed_override_event_ids),
             "handoff": self.handoff.to_dict(), "invocations": [item.to_dict() for item in self.invocations],
             "last_decision": self.last_decision.to_dict(), "pr": self.pr, "repository": self.repository,
             "reviewer": self.reviewer, "schema": SCHEMA,
         }
+        # The key is written only when a dismissal exists, so a ledger without one keeps the
+        # exact pre-v1.63 bytes and every open pull request stays valid across the upgrade.
+        if self.dismissed_findings:
+            payload["dismissed_findings"] = [item.to_dict() for item in self.dismissed_findings]
+        return payload
 
     @classmethod
     def from_dict(cls, value: object) -> "LedgerState":
         keys = {"schema", "repository", "pr", "reviewer", "budgets", "invocations", "consumed_override_event_ids", "last_decision", "handoff"}
-        value = _exact_keys(value, keys, "ledger")
+        if not isinstance(value, dict) or not keys <= set(value) <= keys | {"dismissed_findings"}:
+            raise BudgetStateError("ledger_invalid")
+        dismissed: list[object] = []
+        if "dismissed_findings" in value:
+            dismissed = value["dismissed_findings"]
+            if not isinstance(dismissed, list) or not dismissed:
+                raise BudgetStateError("dismissed_findings_invalid")
         if _integer(value["schema"], "schema", positive=True) != SCHEMA:
             raise BudgetStateError("schema_invalid")
         reviewer = _string(value["reviewer"], "reviewer")
@@ -476,6 +531,7 @@ class LedgerState:
             invocations=tuple(Invocation.from_dict(item) for item in invocations),
             consumed_override_event_ids=tuple(_integer(item, "consumed_override_event_id", positive=True) for item in consumed),
             last_decision=DecisionRecord.from_dict(value["last_decision"]), handoff=Handoff.from_dict(value["handoff"]),
+            dismissed_findings=tuple(DismissedFinding.from_dict(item) for item in dismissed),
         )
         _validate_state_shape(state)
         return state
@@ -498,6 +554,7 @@ class ClaimRequest:
     effort: str
     call_unit: str
     force_review: bool = False
+    dismiss_events: tuple[DismissEvent, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -517,6 +574,7 @@ class FinalizeRequest:
     stop_reason: str
     authenticated_review: AuthenticatedReview
     remaining_finding_ids: tuple[str, ...]
+    dismiss_events: tuple[DismissEvent, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -622,6 +680,7 @@ def _validate_state_shape(state: LedgerState) -> None:
         total_limit += state.budgets.max_estimated_tokens_per_round
     if sum(item.estimated_input_tokens for item in state.invocations) > total_limit:
         raise BudgetStateError("total_usage_budget_exhausted")
+    _validate_dismissed_findings(state.dismissed_findings)
     DecisionRecord.from_dict(state.last_decision.to_dict())
     handoff = Handoff.from_dict(state.handoff.to_dict())
     if handoff.repository is not None:
@@ -658,6 +717,69 @@ def _validate_state_shape(state: LedgerState) -> None:
             handoff.outcome != expected_outcome
         ):
             raise BudgetStateError("handoff_mismatch")
+        if set(handoff.remaining_finding_ids) & _dismissed_ids(state):
+            raise BudgetStateError("handoff_mismatch")
+
+
+def _dismissed_ids(state: LedgerState) -> frozenset[str]:
+    return frozenset(item.finding_id for item in state.dismissed_findings)
+
+
+def _validate_dismissed_findings(entries: object) -> None:
+    if (not isinstance(entries, tuple) or len(entries) > MAX_DISMISSED_FINDINGS or
+            not all(isinstance(item, DismissedFinding) for item in entries)):
+        raise BudgetStateError("dismissed_findings_invalid")
+    for item in entries:
+        DismissedFinding.from_dict(item.to_dict())
+    finding_ids = [item.finding_id for item in entries]
+    comment_ids = [item.comment_id for item in entries]
+    if finding_ids != sorted(set(finding_ids)) or len(comment_ids) != len(set(comment_ids)):
+        raise BudgetStateError("dismissed_findings_invalid")
+
+
+def _validate_dismiss_events(events: object) -> None:
+    if not isinstance(events, tuple):
+        raise BudgetStateError("dismiss_events_invalid")
+    for event in events:
+        if (not isinstance(event, DismissEvent) or isinstance(event.event_id, bool) or
+                not isinstance(event.event_id, int) or event.event_id <= 0 or
+                not isinstance(event.finding_id, str) or _FINDING.fullmatch(event.finding_id) is None or
+                (event.actor_permission is not None and not isinstance(event.actor_permission, str))):
+            raise BudgetStateError("dismiss_events_invalid")
+
+
+def choose_dismissals(
+        state: LedgerState, events: Sequence[DismissEvent]) -> tuple[DismissedFinding, ...]:
+    """Bind each dismissed finding to the earliest authorizing comment, bounded and sorted."""
+    _validate_dismiss_events(tuple(events))
+    # OpenCode assigns no RVW- IDs, so a dismissal can never name one of its findings;
+    # recording one would advertise a path that nothing downstream consumes.
+    if state.reviewer == "opencode":
+        return ()
+    earliest: dict[str, int] = {}
+    for event in events:
+        if event.actor_permission not in _DISMISS_PERMISSIONS:
+            continue
+        if event.finding_id not in earliest or event.event_id < earliest[event.finding_id]:
+            earliest[event.finding_id] = event.event_id
+    chosen = tuple(DismissedFinding(finding_id, earliest[finding_id]) for finding_id in sorted(earliest))
+    _validate_dismissed_findings(chosen)
+    return chosen
+
+
+def _apply_dismissals(state: LedgerState, events: Sequence[DismissEvent]) -> LedgerState:
+    """Replace the recorded snapshot: a deleted dismissal comment revokes its dismissal.
+
+    The recorded handoff drops the newly dismissed IDs at the same time, so a refusal that
+    keeps this state without rebuilding the handoff still satisfies the ledger invariant.
+    """
+    updated = replace(state, dismissed_findings=choose_dismissals(state, events))
+    if updated.handoff.repository is None:
+        return updated
+    return replace(updated, handoff=replace(
+        updated.handoff,
+        remaining_finding_ids=_without_dismissed(updated, updated.handoff.remaining_finding_ids),
+    ))
 
 
 def serialize_ledger(state: LedgerState) -> str:
@@ -733,6 +855,7 @@ def _validate_request(request: ClaimRequest) -> None:
                 not isinstance(event.event, str) or (event.label is not None and not isinstance(event.label, str)) or
                 (event.actor_permission is not None and not isinstance(event.actor_permission, str))):
             raise BudgetStateError("override_events_invalid")
+    _validate_dismiss_events(request.dismiss_events)
     if not isinstance(request.model_route, tuple) or not request.model_route or not all(isinstance(item, str) and item for item in request.model_route):
         raise BudgetStateError("model_route_invalid")
     _string(request.effort, "effort")
@@ -890,6 +1013,7 @@ def _build_handoff(
             remaining_finding_ids = review.remaining_finding_ids
         else:
             remaining_finding_ids = prior.remaining_finding_ids
+    remaining_finding_ids = _without_dismissed(state, remaining_finding_ids)
     return Handoff(
         repository=state.repository, pr=state.pr, reviewer=state.reviewer,
         current_head_sha=request.head_sha, current_full_diff_sha256=request.full_diff_sha256,
@@ -905,6 +1029,11 @@ def _build_handoff(
         authenticated_review_full_diff_sha256=authenticated_hash,
         remaining_finding_ids=remaining_finding_ids,
     )
+
+
+def _without_dismissed(state: LedgerState, finding_ids: Sequence[str]) -> tuple[str, ...]:
+    dismissed = _dismissed_ids(state)
+    return tuple(item for item in finding_ids if item not in dismissed)
 
 
 def choose_override(state: LedgerState, events: Sequence[OverrideEvent]) -> OverrideEvent | None:
@@ -986,6 +1115,7 @@ def claim(state: LedgerState | None, request: ClaimRequest,
           provenances: Mapping[tuple[int, int], RunProvenance]) -> Transition:
     try:
         validated = validate_or_initialize(state, request, provenances)
+        validated = _apply_dismissals(validated, request.dismiss_events)
     except BudgetStateError as exc:
         return _invalid_transition(state, request, str(exc))
     same_run = [item for item in validated.invocations if (item.run_id, item.run_attempt) == (request.run_id, request.run_attempt)]
@@ -1069,6 +1199,7 @@ def _validate_finalize_request(request: FinalizeRequest) -> None:
     if (not isinstance(findings, tuple) or len(findings) > 8 or len(findings) != len(set(findings)) or
             not all(isinstance(item, str) and _FINDING.fullmatch(item) for item in findings)):
         raise BudgetStateError("remaining_finding_ids_invalid")
+    _validate_dismiss_events(request.dismiss_events)
 
 
 def _finalize_remaining_ids(state: LedgerState, request: FinalizeRequest) -> tuple[str, ...]:
@@ -1100,6 +1231,7 @@ def finalize(
                 request.repository, request.pr, request.reviewer):
             raise BudgetStateError("identity_mismatch")
         _validate_provenance(state, request, provenances)
+        state = _apply_dismissals(state, request.dismiss_events)
     except BudgetStateError as exc:
         return _finalization_refusal(state, request, str(exc))
 
@@ -1128,7 +1260,7 @@ def finalize(
         outcome, stop_reason = "checkpoint_failure", "call_budget_exhausted"
     elif request.elapsed_seconds > state.budgets.max_wall_seconds_per_round:
         outcome, stop_reason = "wall_time_exhausted", "wall_time_exhausted"
-    remaining = _finalize_remaining_ids(state, request)
+    remaining = _without_dismissed(state, _finalize_remaining_ids(state, request))
     completed = replace(
         entry, status="finalized", outcome=outcome, stop_reason=stop_reason,
         call_count=request.call_count, elapsed_seconds=request.elapsed_seconds,
@@ -1163,16 +1295,31 @@ def _summary(state: LedgerState, *, server_url: str) -> str:
         raise BudgetStateError("handoff_missing")
     if not isinstance(server_url, str) or not server_url or "\n" in server_url or "\r" in server_url:
         raise BudgetStateError("server_url_invalid")
-    run_url = f"{server_url.rstrip('/')}/{state.repository}/actions/runs/{handoff.current_run_id}"
+    base_url = server_url.rstrip('/')
+    run_url = f"{base_url}/{state.repository}/actions/runs/{handoff.current_run_id}"
+    dismissed_line = ""
+    dismissal_guidance = ""
+    if state.reviewer != "opencode":
+        dismissed = ", ".join(
+            f"[{item.finding_id}]({base_url}/{state.repository}/pull/{state.pr}#issuecomment-{item.comment_id})"
+            for item in state.dismissed_findings
+        ) or "none"
+        dismissed_line = f"- Dismissed findings: {dismissed}\n"
+        dismissal_guidance = (
+            " A collaborator with write permission can dismiss a false positive by commenting "
+            "`dismiss RVW-<12 hex> <reason>` on this pull request; the dismissal takes effect on "
+            "the next review run and is revoked by deleting that comment."
+        )
     return (
         f"## {_REVIEWER_TITLES[state.reviewer]} review invocation budget\n"
         f"- Decision: {handoff.decision}\n"
         f"- Automatic rounds: {handoff.automatic_rounds}/{state.budgets.max_rounds}\n"
         f"- Override rounds: {handoff.override_rounds}/{state.budgets.max_override_rounds}\n"
         f"- Current run: {run_url}\n"
-        f"- Stop reason: {handoff.stop_reason}\n\n"
+        f"- Stop reason: {handoff.stop_reason}\n"
+        f"{dismissed_line}\n"
         "Budget exhaustion is not review approval. Use the authenticated review checkpoint and "
-        "remaining finding IDs before merge."
+        f"remaining finding IDs before merge.{dismissal_guidance}"
     )
 
 
@@ -1393,7 +1540,8 @@ def _remaining_findings(request: Mapping[str, object]) -> tuple[str, ...]:
 
 def _base_claim_request(
         request: Mapping[str, object], *, estimated_input_tokens: int = 0,
-        override_events: tuple[OverrideEvent, ...] = ()) -> ClaimRequest:
+        override_events: tuple[OverrideEvent, ...] = (),
+        dismiss_events: tuple[DismissEvent, ...] = ()) -> ClaimRequest:
     return ClaimRequest(
         repository=request["repository"], pr=request["pr"], reviewer=request["reviewer"],
         run_id=request["run_id"], run_attempt=request["run_attempt"],
@@ -1404,10 +1552,13 @@ def _base_claim_request(
         model_route=_model_route(request), effort=request["effort"],
         call_unit=_CALL_UNITS[request["reviewer"]],
         force_review=request["force_review"],
+        dismiss_events=dismiss_events,
     )
 
 
-def _finalize_request(request: Mapping[str, object]) -> FinalizeRequest:
+def _finalize_request(
+        request: Mapping[str, object], *, dismiss_events: tuple[DismissEvent, ...] = (),
+) -> FinalizeRequest:
     outcome = request["outcome"]
     stop_reason = request["stop_reason"] or outcome
     return FinalizeRequest(
@@ -1420,6 +1571,7 @@ def _finalize_request(request: Mapping[str, object]) -> FinalizeRequest:
         outcome=outcome, stop_reason=stop_reason,
         authenticated_review=_authenticated_review(request),
         remaining_finding_ids=_remaining_findings(request),
+        dismiss_events=dismiss_events,
     )
 
 
@@ -1499,6 +1651,7 @@ def _write_diagnostic(
         "mutate-comment": False,
         "mutation": "none",
         "round": "",
+        "dismissed-finding-ids": "",
     }
     write_private(output_directory / "checkpoint.json", checkpoint)
     write_private(output_directory / "summary.md", summary)
@@ -1566,30 +1719,60 @@ def _ledger_comment(
     return state, comment
 
 
+def _is_override_label(item: Mapping[str, object]) -> bool:
+    label = item.get("label")
+    return (item.get("event") == "labeled" and isinstance(label, dict) and
+            label.get("name") == "review-budget-override")
+
+
+def _dismissed_finding_id(item: Mapping[str, object]) -> str | None:
+    if item.get("event") != "commented":
+        return None
+    return parse_dismiss_command(item.get("body"))
+
+
+def _timeline_actor_login(item: Mapping[str, object], reason: str) -> str:
+    actor = item.get("actor")
+    login = actor.get("login") if isinstance(actor, dict) else None
+    if not isinstance(login, str) or not login:
+        raise TransportError(reason)
+    return login
+
+
 def _timeline_permission_actors(output_directory: Path) -> list[dict[str, object]]:
+    """Name every actor whose repository permission must be fetched before a decision.
+
+    Override labels and dismissal comments share one permission lookup, so a comment
+    author is only ever trusted through the same collaborators API as a label actor.
+    """
     actors: list[dict[str, object]] = []
     seen: set[str] = set()
     for item in _read_pages(output_directory / "timeline.json", "timeline"):
-        if not isinstance(item, dict) or item.get("event") != "labeled":
+        if not isinstance(item, dict):
             continue
-        label = item.get("label")
-        if not isinstance(label, dict) or label.get("name") != "review-budget-override":
+        if _is_override_label(item):
+            login = _timeline_actor_login(item, "override_actor_invalid")
+        elif _dismissed_finding_id(item) is not None:
+            login = _timeline_actor_login(item, "dismiss_actor_invalid")
+        else:
             continue
-        actor = item.get("actor")
-        login = actor.get("login") if isinstance(actor, dict) else None
-        if not isinstance(login, str) or not login:
-            raise TransportError("override_actor_invalid")
         if login in seen:
             continue
+        if len(seen) >= MAX_PERMISSION_ACTORS:
+            raise TransportError("permission_actors_exceeded")
         seen.add(login)
         actors.append({"index": len(actors), "login": login, "encoded_login": quote(login, safe="")})
     return actors
 
 
-def _override_events(output_directory: Path) -> tuple[OverrideEvent, ...]:
+def _actor_permissions(output_directory: Path) -> dict[str, str]:
     manifest = _read_json(output_directory / "run-identities.json", "run_identities")
     if not isinstance(manifest, dict) or not isinstance(manifest.get("permission_actors"), list):
         raise TransportError("run_identities_invalid")
+    # An actor collection that failed closed left no permissions to bind; surface its own
+    # reason instead of the misleading "unknown actor" that would follow.
+    if isinstance(manifest.get("error"), str) and manifest["error"]:
+        raise TransportError(manifest["error"])
     permissions: dict[str, str] = {}
     for actor in manifest["permission_actors"]:
         actor = _exact_keys(actor, {"index", "login", "encoded_login"}, "permission_actor")
@@ -1603,21 +1786,46 @@ def _override_events(output_directory: Path) -> tuple[OverrideEvent, ...]:
                 "admin", "maintain", "write", "triage", "read", "none"}:
             raise TransportError("permission_invalid")
         permissions[actor["login"]] = payload["permission"]
+    return permissions
+
+
+def _timeline_event_id(item: Mapping[str, object], reason: str) -> int:
+    event_id = item.get("id")
+    if isinstance(event_id, bool) or not isinstance(event_id, int) or event_id <= 0:
+        raise TransportError(reason)
+    return event_id
+
+
+def _override_events(output_directory: Path) -> tuple[OverrideEvent, ...]:
+    permissions = _actor_permissions(output_directory)
     events: list[OverrideEvent] = []
     for item in _read_pages(output_directory / "timeline.json", "timeline"):
-        if not isinstance(item, dict) or item.get("event") != "labeled":
-            continue
-        label = item.get("label")
-        if not isinstance(label, dict) or label.get("name") != "review-budget-override":
+        if not isinstance(item, dict) or not _is_override_label(item):
             continue
         actor = item.get("actor")
         login = actor.get("login") if isinstance(actor, dict) else None
-        event_id = item.get("id")
-        if isinstance(event_id, bool) or not isinstance(event_id, int) or event_id <= 0:
-            raise TransportError("override_event_invalid")
+        event_id = _timeline_event_id(item, "override_event_invalid")
         if not isinstance(login, str) or login not in permissions:
             raise TransportError("override_actor_invalid")
         events.append(OverrideEvent(event_id, "labeled", "review-budget-override", permissions[login]))
+    return tuple(events)
+
+
+def _dismiss_events(output_directory: Path) -> tuple[DismissEvent, ...]:
+    permissions = _actor_permissions(output_directory)
+    events: list[DismissEvent] = []
+    for item in _read_pages(output_directory / "timeline.json", "timeline"):
+        if not isinstance(item, dict):
+            continue
+        finding_id = _dismissed_finding_id(item)
+        if finding_id is None:
+            continue
+        actor = item.get("actor")
+        login = actor.get("login") if isinstance(actor, dict) else None
+        event_id = _timeline_event_id(item, "dismiss_event_invalid")
+        if not isinstance(login, str) or login not in permissions:
+            raise TransportError("dismiss_actor_invalid")
+        events.append(DismissEvent(event_id, finding_id, permissions[login]))
     return tuple(events)
 
 
@@ -1768,6 +1976,9 @@ def _write_transition(
         "prior-comment-id": comment_id,
         "prior-comment-body": None if prior_comment is None else prior_comment["body"],
         "marker": MARKERS[request["reviewer"]],
+        "dismissed-finding-ids": ",".join(
+            item.finding_id for item in transition.state.dismissed_findings
+        ),
     }
     write_private(output_directory / "state.json", _json_bytes(transition.state.to_dict()))
     write_private(
@@ -1845,9 +2056,12 @@ def _run_transition(
         _verify_pr(request, output_directory)
         state, comment = _ledger_comment(comments_file, request)
         provenances = _run_provenances(state, request, output_directory)
+        dismissals = _dismiss_events(output_directory)
         if request["operation"] == "claim":
             events = _override_events(output_directory)
-            preliminary_request = _base_claim_request(request, override_events=events)
+            preliminary_request = _base_claim_request(
+                request, override_events=events, dismiss_events=dismissals,
+            )
             preliminary = claim(state, preliminary_request, provenances)
             if preliminary.decision in {
                     "claimed", "round_budget_exhausted", "total_usage_budget_exhausted"}:
@@ -1860,6 +2074,7 @@ def _run_transition(
         else:
             if state is None:
                 raise TransportError("ledger_missing")
+            request_object = _finalize_request(request, dismiss_events=dismissals)
             transition = finalize(state, request_object, provenances)
         if transition.state.handoff.repository is None:
             transition = _recorded_refusal(state, request_object, transition.stop_reason)

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -696,6 +696,7 @@ jobs:
           diff-mode: ${{ steps.prepare-diff.outputs.diff-mode }}
           previous-sha: ${{ steps.prepare-review-input.outputs.previous_sha }}
           previous-review-file: ${{ steps.prepare-review-input.outputs.previous_sha != '' && format('{0}/claude-previous-review.md', runner.temp) || '' }}
+          dismissed-finding-ids: ${{ steps.review-budget-claim.outputs.dismissed-finding-ids }}
 
       # 필터된 finding 의 사유가 런 로그에만 남으면 왜 빠졌는지 확인하는 비용이 크다.
       # 사유 코드는 정규화기 소유의 고정 어휘라 요약에 실어도 비신뢰 텍스트가 아니며,

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -1417,6 +1417,7 @@ jobs:
           diff-mode: ${{ steps.prepare-diff.outputs.diff-mode }}
           previous-sha: ${{ steps.pr-details.outputs.previous_sha }}
           previous-review-file: ${{ steps.pr-details.outputs.previous_sha != '' && format('{0}/gemini-previous-review.md', runner.temp) || '' }}
+          dismissed-finding-ids: ${{ steps.review-budget-claim.outputs.dismissed-finding-ids }}
 
       # 필터된 finding 의 사유가 런 로그에만 남으면 왜 빠졌는지 확인하는 비용이 크다.
       # 사유 코드는 정규화기 소유의 고정 어휘라 요약에 실어도 비신뢰 텍스트가 아니며,

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -1009,7 +1009,9 @@ budget action reads the PR timeline, uses the fixed grammar below only to decide
 repository permission to fetch through the collaborators API, and lets a comment count only
 after that permission has been verified. At most sixteen distinct label or comment actors are
 looked up per timeline; more fails closed with `permission_actors_exceeded`, because anyone who
-can comment can add an actor.
+can comment can add an actor. GitHub serializes a `commented` timeline event with both `actor`
+and `user` naming the comment author; the action reads `actor`, the same field the label path
+already trusts.
 
 A dismissal is one issue comment on the pull request whose whole body is exactly
 

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -500,6 +500,17 @@ The model never assigns authoritative IDs. For each accepted new finding the wor
 reviewer, changed path, changed line, severity, and whitespace-normalized, case-folded title. That
 derivation makes later carryover bindings reproducible while keeping them under workflow ownership.
 
+From `v1.63` the canonicalizer also receives the finding IDs a collaborator dismissed through the
+review invocation budget (see [Dismissing a finding](#dismissing-a-finding)). A dismissed ID
+leaves the authenticated active set before binding: a `Still open`, `Resolved`, or `Retracted`
+block naming it is normalized with `dismissed_prior_id`, and a new finding whose derived ID is
+dismissed — the model repeating the same claim verbatim — is normalized the same way instead of
+re-entering the document. The finding therefore disappears from the canonical Markdown, from
+`accepted-count`, and from the remaining finding IDs for as long as the dismissal stands. The
+audit trail is the budget ledger, not the review document. OpenCode derives no `RVW-` IDs — its
+canonicalizer binds carryover by exact heading text — so a dismissal cannot name an OpenCode
+finding until that reviewer assigns IDs.
+
 ### Hard checkpoints and soft finding filters
 
 The canonicalizer fails the whole document for exactly these hard reasons: `candidate_missing`,
@@ -549,7 +560,8 @@ Once the document boundary and trusted scope are valid, a bad individual block d
 valid siblings. It is filtered or normalized with exactly one of `invalid_anchor`,
 `invalid_trigger_evidence`, `invalid_severity`, `invalid_impact_class`,
 `missing_material_impact`, `unsupported_performance_basis`, `non_actionable_category`,
-`unknown_prior_id`, `duplicate_prior_binding`, or `missing_fix_anchor`. Rejected prose is absent
+`unknown_prior_id`, `duplicate_prior_binding`, `missing_fix_anchor`, or (from `v1.63`)
+`dismissed_prior_id`. Rejected prose is absent
 from canonical Markdown, result JSON, workflow state, and the PR comment; only bounded counts,
 claimed maximum severity, and fixed reason codes are observable. From `v1.62` the Claude and
 Gemini workflows write those reason codes to the run summary whenever `filtered-count` is not zero,
@@ -988,6 +1000,57 @@ handoff and validates them before model execution and canonical finalization.
 Budget exhaustion is not approval: the ledger cannot publish findings, report CLEAN,
 or authorize merge. `/jhw:ship` polls existing review comments and CI signals
 deterministically and does not parse this budget ledger as review evidence.
+
+### Dismissing a finding
+
+From `v1.63` a collaborator can retire a false-positive finding without spending a round and
+without a model retraction. The trust path is the one the override label already uses: the
+budget action reads the PR timeline, uses the fixed grammar below only to decide whose
+repository permission to fetch through the collaborators API, and lets a comment count only
+after that permission has been verified. At most sixteen distinct label or comment actors are
+looked up per timeline; more fails closed with `permission_actors_exceeded`, because anyone who
+can comment can add an actor.
+
+A dismissal is one issue comment on the pull request whose whole body is exactly
+
+```text
+dismiss RVW-<12 lowercase hex> <reason>
+```
+
+— the word `dismiss`, one space, the finding ID as printed in the review comment, one space, and
+a non-empty single-line reason. Trailing whitespace is ignored; any other leading text, casing,
+spacing, or a second line makes the comment inert. The reason is for human readers and is never
+copied into the ledger or the bot comment: the ledger records only the finding ID and the comment
+ID, and the summary links to the comment, so the audit trail lives in the collaborator's own
+words on the pull request.
+
+Only comments whose author holds `write`, `maintain`, or `admin` permission count. Each `claim`
+and `finalize` replaces the ledger's dismissal snapshot with the current timeline, binding every
+dismissed ID to its earliest authorizing comment, sorted by ID and bounded at sixteen entries.
+More than sixteen distinct dismissed IDs fails the whole round closed with
+`dismissed_findings_invalid` and records no snapshot at all, so every dismissal on that pull
+request stops applying until enough comments are deleted; the bound is twice the eight-ID
+remaining-finding cap and is not expected to be reached in normal use. Deleting a comment
+revokes its dismissal on the next run; editing it re-targets it. A refused claim — including
+`round_budget_exhausted` after every round is spent — still records the snapshot and rewrites the
+ledger comment, so a dismissal takes effect without a new model round. The OpenCode ledger
+ignores dismissal comments entirely and keeps the pre-`v1.63` summary text, because that
+reviewer assigns no `RVW-` IDs for a dismissal to name.
+
+The ledger key `dismissed_findings` is written only when at least one dismissal exists; a ledger
+without one keeps its exact pre-`v1.63` bytes, so every open pull request stays valid across the
+upgrade. A dismissed ID is never listed in the handoff's `remaining_finding_ids`, and a round
+finalized after the dismissal records its remaining IDs without it; a ledger whose handoff
+violates this fails closed with `handoff_mismatch`. Rounds finalized before the dismissal keep
+their historical lists. The action exposes the snapshot as the comma-separated `dismissed-finding-ids` output, which the
+Claude and Gemini workflows hand to the shared canonicalizer so the next round cannot carry the
+finding over or re-emit it (see [Candidate and carryover grammar](#candidate-and-carryover-grammar)).
+The bot comment lists each dismissal as `- Dismissed findings:` with a link to the comment and
+documents the grammar in its closing guidance.
+
+A dismissal is not approval either: it removes one finding from the active set and nothing else.
+The known limit is that finding IDs derive from the anchor line and title, so a reworded or
+re-anchored repeat of the same claim receives a new ID and must be dismissed again.
 
 ## Adoption and recovery
 

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -49,6 +49,7 @@ from scripts.workflow_release_inventory import (
     release_supports_review_optin,
     release_supports_review_rounds_variable,
     release_supports_filter_reason_surface,
+    release_supports_finding_dismissal,
     release_supports_same_head_cancel_guard,
     release_supports_review_policy,
     validate_release_listing,
@@ -488,6 +489,27 @@ def _canonicalize_action_with_filter_reasons(action: dict) -> dict:
 EXPECTED_CANONICALIZE_REVIEW_ACTION_V162 = _canonicalize_action_with_filter_reasons(
     EXPECTED_CANONICALIZE_REVIEW_ACTION
 )
+
+
+def _canonicalize_action_with_dismissals(action: dict) -> dict:
+    """Derive the v1.63 canonicalizer action: one optional input bridged to one flag."""
+
+    updated = deepcopy(action)
+    updated["inputs"]["dismissed-finding-ids"] = {"required": "false", "default": ""}
+    step = updated["runs"]["steps"][0]
+    step["env"]["DISMISSED_FINDING_IDS"] = "${{ inputs.dismissed-finding-ids }}"
+    anchor = '--repository-root "$GITHUB_WORKSPACE" '
+    if step["run"].count(anchor) != 1:
+        raise ValueError("canonicalize action run block differs")
+    step["run"] = step["run"].replace(
+        anchor, '--dismissed-finding-ids "$DISMISSED_FINDING_IDS" ' + anchor
+    )
+    return updated
+
+
+EXPECTED_CANONICALIZE_REVIEW_ACTION_V163 = _canonicalize_action_with_dismissals(
+    EXPECTED_CANONICALIZE_REVIEW_ACTION_V162
+)
 EXPECTED_CANONICALIZER_HARD_REASONS = frozenset(
     {
         "candidate_missing",
@@ -512,11 +534,18 @@ EXPECTED_CANONICALIZER_SOFT_REASONS = frozenset(
         "missing_fix_anchor",
     }
 )
+# v1.63 normalizes a carryover or re-emission of a finding a collaborator dismissed.
+EXPECTED_CANONICALIZER_SOFT_REASONS_V163 = EXPECTED_CANONICALIZER_SOFT_REASONS | {
+    "dismissed_prior_id",
+}
 EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256 = (
     "eb4ba827d3b03e3c9169cd95e9194d49b2b8b9b6956e7317b5c9cc9b7bb04fc5"
 )
 EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256_V162 = (
     "d814b42568e38a2f46f1772d00a5a713a467bba067d8865cf4f7657a38ac0739"
+)
+EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256_V163 = (
+    "36a2a9301e60f806c4ee32441a0bb98fccad091d96dfb63b6ca25773d3a28b3e"
 )
 EXPECTED_REVIEW_SCOPE_HELPER_SHA256 = (
     "68779c9038c31aa09a846b643bc0178b147798527e1a34ee5821ab539f10b19a"
@@ -576,6 +605,13 @@ EXPECTED_CANONICALIZER_RECORDS = {
         ("failure_reason", "str"),
         ("candidate_reasons", "tuple[CandidateReason, ...]"),
         ("candidate_validations", "tuple[CandidateValidation, ...]"),
+    ),
+}
+# v1.63 hands the canonicalizer the finding IDs a collaborator dismissed.
+EXPECTED_CANONICALIZER_RECORDS_V163 = {
+    **EXPECTED_CANONICALIZER_RECORDS,
+    "CanonicalizationRequest": EXPECTED_CANONICALIZER_RECORDS["CanonicalizationRequest"] + (
+        ("dismissed_finding_ids", "frozenset[str]"),
     ),
 }
 EXPECTED_SCOPE_RECORDS = {
@@ -686,6 +722,9 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256 = (
 EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256_V160 = (
     "d9cb26a5c340abd20707483f05f4e071b436dac17a900f670aacbd05140b981e"
 )
+EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256_V163 = (
+    "b9ebc50e0959d9a2db82b1b11715be81309581ac45bb29b6dab02dccacedb91c"
+)
 EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256 = (
     "43f15d59df0f529e2fa4f06488e49dc5ff78280762ee8d7248dbecb45cbb609d"
 )
@@ -694,6 +733,9 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V160 = (
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V162 = (
     "deda9f65bbe853860fa06599ce303b15cd63b15b5dad645896c8c76aae7e9b03"
+)
+EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V163 = (
+    "2123326a018589644cd9f5e1e49bdb33eaca8096272bd8396583da2f0f9518b7"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
     "claude": "d4db53b86603a3a113999409e2e4e35c397adf276981e7f68c0ea57a6198faa2",
@@ -724,6 +766,13 @@ EXPECTED_FILTER_REASON_WORKFLOW_SHA256 = {
 EXPECTED_SAME_HEAD_CANCEL_WORKFLOW_SHA256 = {
     "claude": "b3b7d95cb8e87164470759f4c918f8c317e37a10d2c214ec915ac4a51963f04e",
     "gemini": "3271f4f7dd4d13711b91d65ac191451703ead424fcb67299ff504b8a26b32e0f",
+    "opencode": "4a173036252929de6320da7e04436d67b9a4759ed4b9f60b6bdf2b3a3ecc1d5a",
+}
+# v1.63 hands the budget action's dismissed finding IDs to the shared canonicalizer in
+# the Claude and Gemini workflows; OpenCode derives no finding IDs and is unchanged.
+EXPECTED_FINDING_DISMISSAL_WORKFLOW_SHA256 = {
+    "claude": "b32973a2434b7f3314c26d764f91715fc5f0770b5c26be6c2327212457f54ae2",
+    "gemini": "3ea5ef5d0c3f05beadb4fbf6dcf605840286b603123a5dac918cec3bd92414fe",
     "opencode": "4a173036252929de6320da7e04436d67b9a4759ed4b9f60b6bdf2b3a3ecc1d5a",
 }
 EXPECTED_REVIEW_POLICY_HELPER_SHA256 = (
@@ -1200,6 +1249,39 @@ def _budget_action_with_round_variable(action: dict) -> dict:
 
 EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_V160 = _budget_action_with_round_variable(
     EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION
+)
+
+
+def _budget_action_with_dismissals(action: dict) -> dict:
+    """Derive the v1.63 budget action: one output naming the dismissed finding IDs.
+
+    The publisher inside the run block gains the matching value and its closed pattern;
+    every other byte of the action is the v1.60 document.
+    """
+
+    updated = deepcopy(action)
+    updated["outputs"]["dismissed-finding-ids"] = {
+        "value": "${{ steps.budget.outputs.dismissed-finding-ids }}"
+    }
+    step = updated["runs"]["steps"][0]
+    for anchor, addition in (
+        (
+            '    "comment-id": comment_id,\n}\n',
+            '    "dismissed-finding-ids": output["dismissed-finding-ids"],\n',
+        ),
+        (
+            '    "comment-id": r"[0-9]*",\n}\n',
+            '    "dismissed-finding-ids": r"(?:RVW-[0-9a-f]{12}(?:,RVW-[0-9a-f]{12})*)?",\n',
+        ),
+    ):
+        if step["run"].count(anchor) != 1:
+            raise ValueError("budget action run block differs")
+        step["run"] = step["run"].replace(anchor, anchor[: -len("}\n")] + addition + "}\n")
+    return updated
+
+
+EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_V163 = _budget_action_with_dismissals(
+    EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_V160
 )
 REVIEW_DIFF_DEPENDENCY_WORKFLOWS = (
     "claude-code-review.yml",
@@ -3060,7 +3142,9 @@ def _verify_canonicalize_review_helpers(tree: VerifiedCommitTree, ref: str) -> N
         if (
             hashlib.sha256(canonical_source).hexdigest()
             != (
-                EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256_V162
+                EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256_V163
+                if release_supports_finding_dismissal(ref)
+                else EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256_V162
                 if release_supports_filter_reason_surface(ref)
                 else EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256
             )
@@ -3076,9 +3160,14 @@ def _verify_canonicalize_review_helpers(tree: VerifiedCommitTree, ref: str) -> N
         canonical_module = ast.parse(canonical_text, filename=canonical_path)
         scope_module = ast.parse(scope_text, filename=scope_path)
 
+        dismissals = release_supports_finding_dismissal(ref)
         canonical_literals = {
             "HARD_REASONS": EXPECTED_CANONICALIZER_HARD_REASONS,
-            "SOFT_REASONS": EXPECTED_CANONICALIZER_SOFT_REASONS,
+            "SOFT_REASONS": (
+                EXPECTED_CANONICALIZER_SOFT_REASONS_V163
+                if dismissals
+                else EXPECTED_CANONICALIZER_SOFT_REASONS
+            ),
             "SEVERITIES": ("CRITICAL", "HIGH", "MEDIUM"),
             "IMPACT_CLASSES": frozenset(
                 {
@@ -3131,7 +3220,10 @@ def _verify_canonicalize_review_helpers(tree: VerifiedCommitTree, ref: str) -> N
         if _static_literal(scope_module, "GIT_ENV") != EXPECTED_SCOPE_GIT_ENV:
             raise ValueError("scope Git environment differs")
 
-        for name, expected in EXPECTED_CANONICALIZER_RECORDS.items():
+        expected_records = (
+            EXPECTED_CANONICALIZER_RECORDS_V163 if dismissals else EXPECTED_CANONICALIZER_RECORDS
+        )
+        for name, expected in expected_records.items():
             if _record_fields(_class_node(canonical_module, name)) != expected:
                 raise ValueError("canonical record differs")
         for name, expected in EXPECTED_SCOPE_RECORDS.items():
@@ -3200,7 +3292,9 @@ def _verify_canonicalize_review_action(
             "canonicalize-review action contract is invalid"
         ) from None
     expected_action = (
-        EXPECTED_CANONICALIZE_REVIEW_ACTION_V162
+        EXPECTED_CANONICALIZE_REVIEW_ACTION_V163
+        if release_supports_finding_dismissal(ref)
+        else EXPECTED_CANONICALIZE_REVIEW_ACTION_V162
         if release_supports_filter_reason_surface(ref)
         else EXPECTED_CANONICALIZE_REVIEW_ACTION
     )
@@ -4150,7 +4244,10 @@ def _local_literal(function: ast.FunctionDef, name: str) -> object:
 
 
 def require_budget_helper_contract(
-    source: str, rounds_variable: bool = False, filter_reasons: bool = False
+    source: str,
+    rounds_variable: bool = False,
+    filter_reasons: bool = False,
+    dismissals: bool = False,
 ) -> None:
     """Require the authenticated schema-1 helper and every fixed policy gate."""
 
@@ -4197,11 +4294,25 @@ def require_budget_helper_contract(
                 "opencode": "opencode run session",
             },
         }
+        dismissal_bindings: set[str] = set()
+        if dismissals:
+            # v1.63: who may dismiss, and how many dismissals and actor lookups a
+            # pull request may carry, are policy and stay structurally pinned.
+            expected_literals.update({
+                "_DISMISS_PERMISSIONS": frozenset({"admin", "maintain", "write"}),
+                "MAX_DISMISSED_FINDINGS": 16,
+                "MAX_PERMISSION_ACTORS": 16,
+            })
+            dismissal_bindings = {
+                "_DISMISS_COMMAND", "DismissEvent", "DismissedFinding",
+                "parse_dismiss_command", "choose_dismissals",
+            }
         _require_unique_module_bindings(
             module,
             frozenset(
                 {
                     *expected_literals,
+                    *dismissal_bindings,
                     "BudgetPolicy",
                     "LedgerState",
                     "ClaimRequest",
@@ -4371,6 +4482,33 @@ def require_budget_helper_contract(
                 ("handoff", "Handoff", "field(default_factory=Handoff)"),
             ),
         }
+        if dismissals:
+            # v1.63 carries the dismissal comments into the claim and the bounded
+            # snapshot into the ledger; a ledger without one keeps the v1.47 bytes.
+            expected_records["ClaimRequest"] += (
+                ("dismiss_events", "tuple[DismissEvent, ...]", "()"),
+            )
+            expected_records["LedgerState"] += (
+                ("dismissed_findings", "tuple[DismissedFinding, ...]", "()"),
+            )
+            expected_records["FinalizeRequest"] = (
+                ("repository", "str", None),
+                ("pr", "int", None),
+                ("reviewer", "Reviewer", None),
+                ("run_id", "int", None),
+                ("run_attempt", "int", None),
+                ("head_sha", "str", None),
+                ("full_diff_sha256", "str", None),
+                ("model_route", "tuple[str, ...]", None),
+                ("effort", "str", None),
+                ("call_count", "int", None),
+                ("elapsed_seconds", "int", None),
+                ("outcome", "Outcome", None),
+                ("stop_reason", "str", None),
+                ("authenticated_review", "AuthenticatedReview", None),
+                ("remaining_finding_ids", "tuple[str, ...]", None),
+                ("dismiss_events", "tuple[DismissEvent, ...]", "()"),
+            )
         if any(
             _record_shape(_class_node(module, name))
             != _expected_record_shape(fields)
@@ -4513,6 +4651,27 @@ def require_budget_helper_contract(
             )
         ):
             raise ValueError("finding identity differs")
+        if dismissals:
+            command_bindings = [
+                item.value
+                for item in module.body
+                if isinstance(item, ast.Assign)
+                and len(item.targets) == 1
+                and isinstance(item.targets[0], ast.Name)
+                and item.targets[0].id == "_DISMISS_COMMAND"
+            ]
+            if (
+                len(command_bindings) != 1
+                or ast.dump(command_bindings[0], include_attributes=False)
+                != ast.dump(
+                    ast.parse(
+                        're.compile(r"dismiss (RVW-[0-9a-f]{12}) (\\S[^\\r\\n]*)\\Z")',
+                        mode="eval",
+                    ).body,
+                    include_attributes=False,
+                )
+            ):
+                raise ValueError("dismiss grammar differs")
         functions = _module_function_headers(module)
         required_functions = {
             "serialize_ledger": "def serialize_ledger(state: LedgerState) -> str",
@@ -4542,16 +4701,32 @@ def require_budget_helper_contract(
                 "def load_checkpoint(payload: bytes) -> LedgerState"
             ),
         }
+        if dismissals:
+            required_functions.update({
+                "parse_dismiss_command": (
+                    "def parse_dismiss_command(body: object) -> str | None"
+                ),
+                "choose_dismissals": (
+                    "def choose_dismissals(state: LedgerState, "
+                    "events: Sequence[DismissEvent]) -> tuple[DismissedFinding, ...]"
+                ),
+            })
         if any(
             functions.get(name) != header
             for name, header in required_functions.items()
         ):
             raise ValueError("public helper function differs")
         claim_function = _function_node(module, "claim")
+        dismissal_snapshot = (
+            "        validated = _apply_dismissals(validated, request.dismiss_events)\n"
+            if dismissals
+            else ""
+        )
         expected_claim = ast.parse(
             "def expected(state, request, provenances):\n"
             "    try:\n"
             "        validated = validate_or_initialize(state, request, provenances)\n"
+            f"{dismissal_snapshot}"
             "    except BudgetStateError as exc:\n"
             "        return _invalid_transition(state, request, str(exc))\n"
             "    same_run = [item for item in validated.invocations "
@@ -5647,7 +5822,9 @@ def _verify_review_invocation_budget(
             reject_duplicate_keys=release_supports_review_policy(ref),
         )
         expected_action = (
-            EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_V160
+            EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_V163
+            if release_supports_finding_dismissal(ref)
+            else EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_V160
             if release_supports_review_rounds_variable(ref)
             else EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION
         )
@@ -5668,6 +5845,7 @@ def _verify_review_invocation_budget(
         helper,
         release_supports_review_rounds_variable(ref),
         release_supports_filter_reason_surface(ref),
+        release_supports_finding_dismissal(ref),
     )
     for reviewer, workflow in REVIEWER_WORKFLOWS.items():
         require_budget_workflow_contract(
@@ -5677,16 +5855,21 @@ def _verify_review_invocation_budget(
             review_policy=release_supports_review_policy(ref),
         )
     rounds_variable = release_supports_review_rounds_variable(ref)
+    dismissals = release_supports_finding_dismissal(ref)
     authenticated_digests = {
         action_path: (
             action_payload,
-            EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256_V160
+            EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256_V163
+            if dismissals
+            else EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256_V160
             if rounds_variable
             else EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256,
         ),
         REVIEW_INVOCATION_BUDGET_HELPER_ROOT.path.as_posix(): (
             helper_payload,
-            EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V162
+            EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V163
+            if dismissals
+            else EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V162
             if release_supports_filter_reason_surface(ref)
             else EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V160
             if rounds_variable
@@ -5694,7 +5877,9 @@ def _verify_review_invocation_budget(
         ),
     }
     workflow_digests = (
-        EXPECTED_FILTER_REASON_WORKFLOW_SHA256
+        EXPECTED_FINDING_DISMISSAL_WORKFLOW_SHA256
+        if dismissals
+        else EXPECTED_FILTER_REASON_WORKFLOW_SHA256
         if release_supports_filter_reason_surface(ref)
         else EXPECTED_SAME_HEAD_CANCEL_WORKFLOW_SHA256
         if release_supports_same_head_cancel_guard(ref)
@@ -5998,7 +6183,7 @@ def _named_step(job: object, name: str) -> dict:
 
 
 def _expected_canonicalize_step(
-    contract: dict[str, str], *, budget: bool = False
+    contract: dict[str, str], *, budget: bool = False, dismissals: bool = False
 ) -> dict[str, object]:
     reviewer = contract["reviewer"]
     reset = contract["reset"]
@@ -6034,6 +6219,16 @@ def _expected_canonicalize_step(
             "diff-mode": "${{ steps.prepare-diff.outputs.diff-mode }}",
             "previous-sha": contract["previous_sha"],
             "previous-review-file": contract["previous_file"],
+            # v1.63 hands the budget claim's dismissed finding IDs to the canonicalizer.
+            **(
+                {
+                    "dismissed-finding-ids": (
+                        "${{ steps.review-budget-claim.outputs.dismissed-finding-ids }}"
+                    ),
+                }
+                if dismissals
+                else {}
+            ),
         },
     }
 
@@ -6185,7 +6380,9 @@ def _verify_review_publication_contracts(
             if job.get("permissions", {}).get("actions") != "read":
                 raise ValueError("review run provenance permission differs")
             canonical_step = _named_step(job, contract["canonical_step"])
-            if canonical_step != _expected_canonicalize_step(contract, budget=budget):
+            if canonical_step != _expected_canonicalize_step(
+                contract, budget=budget, dismissals=release_supports_finding_dismissal(ref)
+            ):
                 raise ValueError("canonicalizer call differs")
             rejected_diagnostic_upload = _named_step(
                 job,

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -151,6 +151,7 @@ REVIEW_OPTIN_RELEASE = (1, 59)
 REVIEW_ROUNDS_VARIABLE_RELEASE = (1, 60)
 SAME_HEAD_CANCEL_RELEASE = (1, 61)
 FILTER_REASON_SURFACE_RELEASE = (1, 62)
+FINDING_DISMISSAL_RELEASE = (1, 63)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -205,6 +206,12 @@ def release_supports_filter_reason_surface(ref: str) -> bool:
     """Return whether ``ref`` surfaces filtered-finding reasons and refuses OpenCode overrides."""
 
     return _release_version(ref) >= FILTER_REASON_SURFACE_RELEASE
+
+
+def release_supports_finding_dismissal(ref: str) -> bool:
+    """Return whether ``ref`` lets a write collaborator dismiss a finding by comment."""
+
+    return _release_version(ref) >= FINDING_DISMISSAL_RELEASE
 
 
 def release_roots_for(ref: str) -> tuple[ReleaseRoot, ...]:

--- a/tests/test_canonicalize_review.py
+++ b/tests/test_canonicalize_review.py
@@ -133,6 +133,7 @@ class ReviewCase:
             result_file=self.result, scope_manifest=manifest, selected_diff=selected_diff,
             repository_root=base, diff_mode="full", previous_sha="",
             previous_review_file=None, expected_repository="example/repo",
+            dismissed_finding_ids=frozenset(),
         )
 
     def run(self) -> tuple[object, str | None]:
@@ -217,6 +218,7 @@ class ReviewQualityRepo:
     def _request(
         self, text: str, *, reviewer: str, head: str, diff_mode: str = "full",
         previous_sha: str = "", previous_review: str | None = None,
+        dismissed_finding_ids: frozenset[str] = frozenset(),
     ) -> CanonicalizationRequest:
         _git(self.repository, "checkout", "--quiet", head)
         self.candidate.write_text(text, encoding="utf-8")
@@ -241,31 +243,41 @@ class ReviewQualityRepo:
             result_file=self.result, scope_manifest=manifest, selected_diff=selected_diff,
             repository_root=self.repository, diff_mode=diff_mode, previous_sha=previous_sha,
             previous_review_file=previous_file, expected_repository="example/repo",
+            dismissed_finding_ids=dismissed_finding_ids,
         )
 
     def _run(self, request: CanonicalizationRequest) -> tuple[object, str]:
         result = canonicalize(request)
         return result, self.canonical.read_text(encoding="utf-8") if self.canonical.exists() else ""
 
-    def run_fixture(self, name: str, reviewer: str = "claude") -> tuple[object, str]:
+    def run_fixture(
+        self, name: str, reviewer: str = "claude", dismissed_finding_ids: frozenset[str] = frozenset(),
+    ) -> tuple[object, str]:
         return self._run(self._request(
             (self.fixtures / name).read_text(encoding="utf-8"), reviewer=reviewer,
-            head=self.review_head,
+            head=self.review_head, dismissed_finding_ids=dismissed_finding_ids,
         ))
 
     def run_text(self, text: str, reviewer: str = "claude") -> tuple[object, str]:
         return self._run(self._request(text, reviewer=reviewer, head=self.review_head))
 
-    def run_delta(self, previous_review: str, candidate: str) -> tuple[object, str]:
+    def run_delta(
+        self, previous_review: str, candidate: str,
+        dismissed_finding_ids: frozenset[str] = frozenset(),
+    ) -> tuple[object, str]:
         return self._run(self._request(
             candidate, reviewer="gemini", head=self.fixed_head, diff_mode="delta",
             previous_sha=self.review_head, previous_review=previous_review,
+            dismissed_finding_ids=dismissed_finding_ids,
         ))
 
-    def run_carryover(self, previous_review: str, candidate: str) -> tuple[object, str]:
+    def run_carryover(
+        self, previous_review: str, candidate: str,
+        dismissed_finding_ids: frozenset[str] = frozenset(),
+    ) -> tuple[object, str]:
         return self._run(self._request(
             candidate, reviewer="gemini", head=self.review_head, previous_sha=self.review_head,
-            previous_review=previous_review,
+            previous_review=previous_review, dismissed_finding_ids=dismissed_finding_ids,
         ))
 
 
@@ -550,6 +562,7 @@ def test_clean_candidate_accepts_a_tree_equivalent_empty_full_scope(tmp_path: Pa
         previous_sha="",
         previous_review_file=None,
         expected_repository="example/repo",
+        dismissed_finding_ids=frozenset(),
     ))
 
     assert result == canonicalize_review.CanonicalizationResult(
@@ -737,7 +750,9 @@ def test_clean_canonical_output_round_trips_with_summary_prose(case_factory):
     assert round_trip == canonical
 
 
-def _cli_args(case: ReviewCase, github_output: Path | None = None) -> list[str]:
+def _cli_args(
+    case: ReviewCase, github_output: Path | None = None, dismissed: str | None = None,
+) -> list[str]:
     args = [
         sys.executable, str(MODULE_PATH), "--reviewer", "claude",
         "--candidate-file", str(case.candidate), "--canonical-file", str(case.canonical),
@@ -747,6 +762,8 @@ def _cli_args(case: ReviewCase, github_output: Path | None = None) -> list[str]:
     ]
     if github_output is not None:
         args.extend(("--github-output", str(github_output)))
+    if dismissed is not None:
+        args.extend(("--dismissed-finding-ids", dismissed))
     return args
 
 
@@ -1844,3 +1861,116 @@ def test_visible_text_canonicalization_is_idempotent(raw, expected):
     once = canonicalize_review._canonical_visible_text(raw)
     assert once == expected
     assert canonicalize_review._canonical_visible_text(once) == expected
+
+
+# --- A human dismissal removes a finding from carryover and from re-emission (issue #112) ---
+
+DISMISSED_PLAN_ID = "RVW-3253866a28c6"
+CLEAN_DOCUMENT = "### New findings\n\nNone\n\nNo validated blocking issues found.\n"
+
+
+def test_dismissed_prior_id_is_a_soft_normalization_reason():
+    assert "dismissed_prior_id" in canonicalize_review.SOFT_REASONS
+
+
+@pytest.mark.parametrize(
+    ("runner", "candidate", "section", "claimed"),
+    (
+        ("run_delta", valid_still_open_candidate(), "Still open", "MEDIUM"),
+        ("run_delta", resolved_rejected_plan_candidate(), "Resolved", "HIGH"),
+        ("run_carryover", retracted_rejected_plan_candidate(), "Retracted", "HIGH"),
+    ),
+)
+def test_dismissed_prior_finding_is_normalized_out_of_every_carryover_section(
+    review_quality_repo, runner, candidate, section, claimed,
+):
+    result, canonical = getattr(review_quality_repo, runner)(
+        accepted_rejected_plan_review(), candidate,
+        dismissed_finding_ids=frozenset({DISMISSED_PLAN_ID}),
+    )
+
+    assert result == canonicalize_review.CanonicalizationResult(
+        True, 0, 0, 1, "none", "",
+        (CandidateReason(0, section, "normalized", "dismissed_prior_id", claimed),), (),
+    )
+    assert canonical == CLEAN_DOCUMENT
+
+
+def test_dismissed_prior_finding_omitted_by_the_model_is_simply_gone(review_quality_repo):
+    result, canonical = review_quality_repo.run_delta(
+        accepted_rejected_plan_review(), "### New findings\nNone\n",
+        dismissed_finding_ids=frozenset({DISMISSED_PLAN_ID}),
+    )
+
+    assert result == canonicalize_review.CanonicalizationResult(True, 0, 0, 0, "none", "", (), ())
+    assert canonical == CLEAN_DOCUMENT
+
+
+def test_a_repeated_new_finding_whose_id_is_dismissed_is_normalized(review_quality_repo):
+    """The issue #112 shape: the model re-emits the dismissed finding verbatim."""
+
+    result, canonical = review_quality_repo.run_fixture(
+        "rejected-plan.md", reviewer="gemini", dismissed_finding_ids=frozenset({DISMISSED_PLAN_ID}),
+    )
+
+    assert (result.accepted_count, result.filtered_count, result.normalized_count) == (0, 0, 1)
+    assert result.candidate_reasons == (
+        CandidateReason(0, "New findings", "normalized", "dismissed_prior_id", "HIGH"),
+    )
+    assert DISMISSED_PLAN_ID not in canonical
+    assert canonical == CLEAN_DOCUMENT
+
+
+def test_an_unrelated_dismissal_leaves_the_finding_accepted(review_quality_repo):
+    result, canonical = review_quality_repo.run_fixture(
+        "rejected-plan.md", reviewer="gemini", dismissed_finding_ids=frozenset({"RVW-000000000000"}),
+    )
+
+    assert (result.accepted_count, result.normalized_count) == (1, 0)
+    assert DISMISSED_PLAN_ID in canonical
+
+
+def _dismissable_case(case_factory) -> ReviewCase:
+    return case_factory(b"""### New findings
+
+#### [MEDIUM] Broad ValueError catch hides invalid configuration
+- Changed anchor: {"path":"review_cases.py","line":26}
+- Trigger evidence: {"path":"review_cases.py","line":25,"quote":"        return int(value)"}
+- Impact class: runtime
+- Material impact: An invalid numeric configuration is converted into a normal result.
+""")
+
+
+def test_cli_dismissed_ids_are_a_comma_separated_list(case_factory):
+    case = _dismissable_case(case_factory)
+    github_output = case.root / "github-output.txt"
+
+    completed = subprocess.run(
+        _cli_args(case, github_output, dismissed="RVW-000000000000,RVW-61d4cd9ac260"),
+        cwd=ACTION_DIR, capture_output=True, text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "accepted_count=0\nfiltered_count=0\nnormalized_count=1\n" in github_output.read_text(encoding="utf-8")
+    assert "candidate[0]: section=New findings outcome=normalized reason=dismissed_prior_id claimed_severity=MEDIUM" in completed.stdout
+    assert case.canonical.read_text(encoding="utf-8") == CLEAN_DOCUMENT
+
+
+def test_cli_empty_dismissed_ids_change_nothing(case_factory):
+    case = _dismissable_case(case_factory)
+
+    completed = subprocess.run(_cli_args(case, dismissed=""), cwd=ACTION_DIR, capture_output=True, text=True)
+
+    assert completed.returncode == 0, completed.stderr
+    assert "RVW-61d4cd9ac260 [MEDIUM] Broad ValueError catch" in case.canonical.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("dismissed", ("RVW-61d4cd9ac26", "rvw-61d4cd9ac260", "RVW-61d4cd9ac260,", " RVW-61d4cd9ac260", "RVW-61d4cd9ac260 RVW-000000000000"))
+def test_cli_rejects_a_malformed_dismissal_list_before_reading_the_candidate(case_factory, dismissed):
+    case = _dismissable_case(case_factory)
+
+    completed = subprocess.run(_cli_args(case, dismissed=dismissed), cwd=ACTION_DIR, capture_output=True, text=True)
+
+    assert completed.returncode == 2
+    assert not case.canonical.exists()
+    assert not case.result.exists()

--- a/tests/test_review_invocation_budget.py
+++ b/tests/test_review_invocation_budget.py
@@ -645,8 +645,9 @@ def test_comment_summary_and_handoff_are_exact_and_workflow_owned():
         "- Automatic rounds: 1/2\n"
         "- Override rounds: 0/1\n"
         "- Current run: https://github.com/example/repo/actions/runs/700\n"
-        "- Stop reason: duplicate_head\n\n"
-        "Budget exhaustion is not review approval. Use the authenticated review checkpoint and remaining finding IDs before merge."
+        "- Stop reason: duplicate_head\n"
+        "- Dismissed findings: none\n\n"
+        f"{DISMISS_GUIDANCE}"
     )
     state_lines = (
         f"{budget.MARKERS['claude']}\n"
@@ -1164,3 +1165,301 @@ def test_override_is_refused_for_opencode():
     state = budget.LedgerState.initial(REPOSITORY, PR, "opencode")
 
     assert budget.choose_override(state, (override_event(),)) is None
+
+
+# --- A collaborator can dismiss a false-positive finding by comment (issue #112) ---
+
+
+FINDING_3 = "RVW-333333333333"
+DISMISS_GUIDANCE = (
+    "Budget exhaustion is not review approval. Use the authenticated review checkpoint and "
+    "remaining finding IDs before merge. A collaborator with write permission can dismiss a "
+    "false positive by commenting `dismiss RVW-<12 hex> <reason>` on this pull request; the "
+    "dismissal takes effect on the next review run and is revoked by deleting that comment."
+)
+
+
+def dismiss_event(event_id=200, finding_id=FINDING_1, permission="write"):
+    return budget.DismissEvent(event_id, finding_id, permission)
+
+
+def dismissed(finding_id=FINDING_1, comment_id=200):
+    return budget.DismissedFinding(finding_id, comment_id)
+
+
+def authenticated(remaining=(FINDING_1, FINDING_2), head=HEAD_A, full_hash=HASH_1):
+    return budget.AuthenticatedReview(True, head, full_hash, tuple(remaining))
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    (
+        ("dismiss RVW-111111111111 the cited constant table is wrong", FINDING_1),
+        ("dismiss RVW-111111111111 wrong\r\n", FINDING_1),
+        ("dismiss RVW-111111111111 사유는 어느 언어로 써도 된다", FINDING_1),
+        ("dismiss RVW-111111111111 punctuation: `code`, <tags>, -- fine", FINDING_1),
+        ("dismiss RVW-111111111111", None),
+        ("dismiss RVW-111111111111 ", None),
+        ("dismiss RVW-111111111111   ", None),
+        ("dismiss RVW-111111111111  double space", None),
+        ("Dismiss RVW-111111111111 reason", None),
+        ("dismiss rvw-111111111111 reason", None),
+        ("dismiss RVW-11111111111 reason", None),
+        ("dismiss RVW-1111111111111 reason", None),
+        ("dismiss RVW-11111111111g reason", None),
+        ("dismiss RVW-111111111111 reason\nsecond line", None),
+        ("dismiss RVW-111111111111 reason\r\nsecond line", None),
+        ("please dismiss RVW-111111111111 reason", None),
+        (" dismiss RVW-111111111111 reason", None),
+        ("dismiss  RVW-111111111111 reason", None),
+        ("dismiss\tRVW-111111111111 reason", None),
+        ("", None),
+        ("dismiss", None),
+    ),
+)
+def test_dismiss_command_grammar_is_fixed(body, expected):
+    assert budget.parse_dismiss_command(body) == expected
+
+
+def test_dismissals_require_write_permission_and_bind_the_earliest_comment():
+    events = (
+        dismiss_event(300, FINDING_1, "write"),
+        dismiss_event(200, FINDING_1, "admin"),
+        dismiss_event(400, FINDING_2, "read"),
+        dismiss_event(500, FINDING_2, "triage"),
+        dismiss_event(501, FINDING_2, None),
+        dismiss_event(600, FINDING_3, "maintain"),
+    )
+
+    state = budget.LedgerState.initial(REPOSITORY, PR, "claude")
+
+    assert budget.choose_dismissals(state, events) == (dismissed(FINDING_1, 200), dismissed(FINDING_3, 600))
+    assert budget.choose_dismissals(state, ()) == ()
+
+
+def test_dismissals_beyond_the_ledger_bound_fail_closed():
+    """The bound is a documented contract value, so the test names the literal."""
+
+    assert budget.MAX_DISMISSED_FINDINGS == 16
+    state = budget.LedgerState.initial(REPOSITORY, PR, "claude")
+    events = tuple(dismiss_event(1000 + index, f"RVW-{index:012x}", "write") for index in range(17))
+
+    with pytest.raises(budget.BudgetStateError, match="dismissed_findings_invalid"):
+        budget.choose_dismissals(state, events)
+    assert len(budget.choose_dismissals(state, events[1:])) == 16
+
+
+def test_dismissals_are_ignored_for_opencode():
+    """OpenCode derives no RVW- IDs, so a dismissal can never name one of its findings."""
+
+    state = budget.LedgerState.initial(REPOSITORY, PR, "opencode")
+
+    assert budget.choose_dismissals(state, (dismiss_event(),)) == ()
+    claim_request = request(reviewer="opencode", dismiss_events=(dismiss_event(),))
+    claimed = budget.claim(None, claim_request, claim_provenances(None, claim_request)).state
+    assert claimed.dismissed_findings == ()
+    assert budget.render_summary(claimed) == (
+        "## OpenCode review invocation budget\n"
+        "- Decision: claimed\n"
+        "- Automatic rounds: 1/2\n"
+        "- Override rounds: 0/1\n"
+        "- Current run: https://github.com/example/repo/actions/runs/700\n"
+        "- Stop reason: claimed\n\n"
+        "Budget exhaustion is not review approval. Use the authenticated review checkpoint and "
+        "remaining finding IDs before merge."
+    )
+
+
+def test_a_present_but_empty_dismissal_list_is_not_a_ledger_shape():
+    payload = budget.LedgerState.initial(REPOSITORY, PR, "claude").to_dict()
+    payload["dismissed_findings"] = []
+
+    with pytest.raises(budget.BudgetStateError, match="dismissed_findings_invalid"):
+        budget.LedgerState.from_dict(payload)
+
+
+def test_ledger_serializes_dismissals_only_when_present():
+    """A ledger without dismissals keeps the pre-v1.63 bytes, so open PRs stay valid."""
+
+    state = budget.LedgerState.initial(REPOSITORY, PR, "claude")
+    with_dismissal = replace(state, dismissed_findings=(dismissed(),))
+
+    assert "dismissed_findings" not in state.to_dict()
+    assert with_dismissal.to_dict()["dismissed_findings"] == [
+        {"comment_id": 200, "finding_id": FINDING_1},
+    ]
+    assert budget.LedgerState.from_dict(with_dismissal.to_dict()) == with_dismissal
+    for candidate in (state, with_dismissal):
+        assert budget.parse_ledger(
+            ledger_body(candidate), repository=REPOSITORY, pr=PR, reviewer="claude",
+        ) == candidate
+        assert budget.load_checkpoint(budget.render_checkpoint(candidate)) == candidate
+
+
+@pytest.mark.parametrize(
+    "entries",
+    (
+        (dismissed(FINDING_1, 200), dismissed(FINDING_1, 300)),
+        (dismissed(FINDING_2, 200), dismissed(FINDING_1, 300)),
+        (dismissed(FINDING_1, 200), dismissed(FINDING_2, 200)),
+        (dismissed("RVW-not-a-finding", 200),),
+        (dismissed(FINDING_1, 0),),
+        (dismissed(FINDING_1, True),),
+        tuple(
+            dismissed(f"RVW-{index:012x}", 1000 + index)
+            for index in range(budget.MAX_DISMISSED_FINDINGS + 1)
+        ),
+    ),
+)
+def test_stored_dismissals_are_validated(entries):
+    state = replace(budget.LedgerState.initial(REPOSITORY, PR, "claude"), dismissed_findings=entries)
+
+    assert_stored_state_rejected(state, "dismissed_findings_invalid")
+
+
+def test_the_dismissal_bound_is_pinned_to_the_documented_literal():
+    assert budget.MAX_DISMISSED_FINDINGS == 16
+    assert budget.MAX_PERMISSION_ACTORS == 16
+
+
+def test_a_dismissed_id_can_never_remain_in_the_handoff():
+    state = claimed_state()
+    finalized = budget.finalize(
+        state, finalize_request(remaining=(FINDING_1, FINDING_2)), current_provenances(state),
+    ).state
+    assert finalized.handoff.remaining_finding_ids == (FINDING_1, FINDING_2)
+
+    stale = replace(finalized, dismissed_findings=(dismissed(FINDING_1),))
+
+    assert_stored_state_rejected(stale, "handoff_mismatch")
+
+
+def test_claim_rejects_malformed_dismiss_events():
+    malformed = request(dismiss_events=(("not", "an", "event"),))
+
+    transition = budget.claim(None, malformed, claim_provenances(None, malformed))
+
+    assert (transition.decision, transition.stop_reason) == ("state_invalid", "dismiss_events_invalid")
+
+
+def test_claim_records_authorized_dismissals_and_drops_them_from_remaining_ids():
+    state = claimed_state()
+    first = budget.finalize(
+        state, finalize_request(remaining=(FINDING_1, FINDING_2)), current_provenances(state),
+    ).state
+    second = request(
+        head=HEAD_B, full_hash=HASH_2, run_id=701, authenticated_review=authenticated(),
+        dismiss_events=(dismiss_event(200, FINDING_1, "write"), dismiss_event(201, FINDING_2, "read")),
+    )
+
+    transition = budget.claim(first, second, claim_provenances(first, second))
+
+    assert transition.decision == "claimed"
+    assert transition.state.dismissed_findings == (dismissed(FINDING_1, 200),)
+    assert transition.state.handoff.remaining_finding_ids == (FINDING_2,)
+    budget.serialize_ledger(transition.state)
+
+
+def test_refused_claim_still_records_dismissals_and_updates_the_handoff():
+    """The issue #112 shape: both rounds are spent, then a human dismisses the false positive."""
+
+    state = claimed_state()
+    first = budget.finalize(
+        state, finalize_request(remaining=(FINDING_1, FINDING_2)), current_provenances(state),
+    ).state
+    second_request = request(head=HEAD_B, full_hash=HASH_2, run_id=701, authenticated_review=authenticated())
+    second = budget.claim(first, second_request, claim_provenances(first, second_request)).state
+    second = budget.finalize(
+        second,
+        finalize_request(
+            head=HEAD_B, full_hash=HASH_2, run_id=701, remaining=(FINDING_1, FINDING_2),
+            authenticated_review=authenticated(),
+        ),
+        current_provenances(second),
+    ).state
+    third_request = request(
+        head=HEAD_C, full_hash=HASH_3, run_id=702,
+        authenticated_review=authenticated(head=HEAD_B, full_hash=HASH_2),
+        dismiss_events=(dismiss_event(200, FINDING_1, "write"),),
+    )
+
+    refused = budget.claim(second, third_request, claim_provenances(second, third_request))
+
+    assert (refused.decision, refused.mutate_comment) == ("round_budget_exhausted", True)
+    assert refused.state.dismissed_findings == (dismissed(FINDING_1, 200),)
+    assert refused.state.handoff.remaining_finding_ids == (FINDING_2,)
+    budget.serialize_ledger(refused.state)
+
+
+def test_dismissal_is_revoked_when_the_comment_no_longer_exists():
+    state = claimed_state()
+    first = budget.finalize(
+        state, finalize_request(remaining=(FINDING_1, FINDING_2)), current_provenances(state),
+    ).state
+    dismissing = request(
+        head=HEAD_B, full_hash=HASH_2, run_id=701, authenticated_review=authenticated(),
+        dismiss_events=(dismiss_event(),),
+    )
+    with_dismissal = budget.claim(first, dismissing, claim_provenances(first, dismissing)).state
+    assert with_dismissal.handoff.remaining_finding_ids == (FINDING_2,)
+    revoking = request(head=HEAD_C, full_hash=HASH_3, run_id=702, authenticated_review=authenticated())
+
+    revoked = budget.claim(with_dismissal, revoking, claim_provenances(with_dismissal, revoking)).state
+
+    assert revoked.dismissed_findings == ()
+    assert revoked.handoff.remaining_finding_ids == (FINDING_1, FINDING_2)
+
+
+def test_finalize_refreshes_dismissals_and_never_records_a_dismissed_id_as_remaining():
+    claim_request = request(dismiss_events=(dismiss_event(200, FINDING_1),))
+    state = budget.claim(None, claim_request, claim_provenances(None, claim_request)).state
+    assert state.dismissed_findings == (dismissed(FINDING_1, 200),)
+
+    finalized = budget.finalize(
+        state,
+        finalize_request(
+            remaining=(FINDING_1, FINDING_2),
+            dismiss_events=(dismiss_event(200, FINDING_1), dismiss_event(300, FINDING_2)),
+        ),
+        current_provenances(state),
+    ).state
+
+    assert finalized.dismissed_findings == (dismissed(FINDING_1, 200), dismissed(FINDING_2, 300))
+    assert finalized.invocations[-1].remaining_finding_ids == ()
+    assert finalized.handoff.remaining_finding_ids == ()
+    budget.serialize_ledger(finalized)
+
+
+def test_comment_summary_lists_dismissals_and_documents_the_command():
+    claim_request = request(dismiss_events=(dismiss_event(200, FINDING_1), dismiss_event(300, FINDING_2)))
+    state = budget.claim(None, claim_request, claim_provenances(None, claim_request)).state
+
+    assert budget.render_summary(state) == (
+        "## Claude review invocation budget\n"
+        "- Decision: claimed\n"
+        "- Automatic rounds: 1/2\n"
+        "- Override rounds: 0/1\n"
+        "- Current run: https://github.com/example/repo/actions/runs/700\n"
+        "- Stop reason: claimed\n"
+        "- Dismissed findings: "
+        "[RVW-111111111111](https://github.com/example/repo/pull/52#issuecomment-200), "
+        "[RVW-222222222222](https://github.com/example/repo/pull/52#issuecomment-300)\n\n"
+        f"{DISMISS_GUIDANCE}"
+    )
+
+
+def test_invalid_claim_after_a_dismissal_still_renders_a_checkpoint():
+    """A refusal that keeps the validated state must not leave a handoff naming a dismissed ID."""
+
+    state = claimed_state()
+    finalized = budget.finalize(
+        state, finalize_request(remaining=(FINDING_1, FINDING_2)), current_provenances(state),
+    ).state
+    conflicting = request(head=HEAD_B, full_hash=HASH_2, dismiss_events=(dismiss_event(),))
+
+    transition = budget.claim(finalized, conflicting, valid_provenances(finalized))
+
+    assert (transition.decision, transition.stop_reason) == ("state_invalid", "duplicate_run_identity")
+    assert transition.state.dismissed_findings == (dismissed(),)
+    assert transition.state.handoff.remaining_finding_ids == (FINDING_2,)
+    budget.render_checkpoint(transition.state)

--- a/tests/test_review_invocation_budget_action.py
+++ b/tests/test_review_invocation_budget_action.py
@@ -133,7 +133,7 @@ elif "/issues/comments/" in endpoint:
         comment = {**comment, "body": comment["body"] + "\nchanged"}
     response = comment
 elif endpoint.endswith("/issues/52/timeline?per_page=100"):
-    response = []
+    response = config.get("timeline", [])
 elif "/actions/runs/501/attempts/1" in endpoint:
     response = {
         "id": 501,
@@ -187,7 +187,8 @@ elif "/actions/runs/700/attempts/1" in endpoint:
     elif config["scenario"] == "current-run-reference-wrong-sha":
         response["referenced_workflows"][0]["sha"] = "not-a-sha"
 elif "/collaborators/" in endpoint and endpoint.endswith("/permission"):
-    response = {"permission": "write", "user": {"login": "maintainer"}}
+    login = endpoint.split("/collaborators/", 1)[1].rsplit("/permission", 1)[0]
+    response = {"permission": config.get("permissions", {}).get(login, "write"), "user": {"login": login}}
 elif method in {"POST", "PATCH"}:
     input_path = Path(args[args.index("--input") + 1])
     response = {"id": 101 if method == "POST" else 80, "body": json.loads(input_path.read_text())["body"]}
@@ -220,6 +221,7 @@ class FakeGitHub:
     def run_action(
         self, *, mode: str, scenario: str, hostile: bool = False,
         diff_mode: str = "full", env_overrides: dict[str, str] | None = None,
+        timeline: list[dict] | None = None, permissions: dict[str, str] | None = None,
     ) -> ActionResult:
         document = yaml.load(ACTION.read_text(), Loader=yaml.BaseLoader)
         run = document["runs"]["steps"][0]["run"]
@@ -266,7 +268,10 @@ class FakeGitHub:
             comments = [_bot_comment(prior, login="octocat")]
 
         config = self.tmp_path / "config.json"
-        config.write_text(json.dumps({"scenario": scenario, "head": head, "comments": comments}))
+        config.write_text(json.dumps({
+            "scenario": scenario, "head": head, "comments": comments,
+            "timeline": timeline or [], "permissions": permissions or {},
+        }))
         output = self.tmp_path / "github-output"
         summary = self.tmp_path / "summary"
         checkpoint = workspace / "checkpoint.json"
@@ -360,7 +365,7 @@ def test_action_metadata_has_one_inert_environment_bridge():
     }
     assert set(document["outputs"]) == {
         "allow-invocation", "decision", "round", "invocation-key", "checkpoint-sha256",
-        "comment-id",
+        "comment-id", "dismissed-finding-ids",
     }
     assert document["runs"]["using"] == "composite"
     assert len(document["runs"]["steps"]) == 1
@@ -714,3 +719,144 @@ def test_input_paths_are_bounded_by_the_runner_workspace_environment(tmp_path, m
     }
     with pytest.raises(budget.TransportError, match="workspace_identity_mismatch"):
         budget._validated_input_paths(request)
+
+
+# --- Dismissal comments travel through the same timeline and permission transport (issue #112) ---
+
+
+def _timeline_comment(comment_id: int, login: str, body: str) -> dict:
+    return {
+        "id": comment_id, "event": "commented", "actor": {"login": login},
+        "user": {"login": login}, "author_association": "NONE", "body": body,
+    }
+
+
+def test_timeline_permission_actors_include_dismiss_comment_authors(tmp_path):
+    (tmp_path / "timeline.json").write_text(json.dumps([
+        {
+            "id": 9001,
+            "event": "labeled",
+            "label": {"name": "review-budget-override"},
+            "actor": {"login": "maintainer"},
+        },
+        _timeline_comment(5001, "reviewer", "dismiss RVW-111111111111 the cited constant is wrong"),
+        _timeline_comment(5002, "maintainer", "dismiss RVW-222222222222 stale"),
+        _timeline_comment(5003, "stranger", "looks good to me"),
+        _timeline_comment(5004, "stranger", "please dismiss RVW-333333333333 for me"),
+        _timeline_comment(5005, "reviewer", "dismiss RVW-444444444444 second comment, same author"),
+    ]))
+
+    assert budget._timeline_permission_actors(tmp_path) == [
+        {"index": 0, "login": "maintainer", "encoded_login": "maintainer"},
+        {"index": 1, "login": "reviewer", "encoded_login": "reviewer"},
+    ]
+
+
+def _write_permission_fixture(tmp_path, timeline, permissions):
+    (tmp_path / "timeline.json").write_text(json.dumps(timeline))
+    actors = [
+        {"index": index, "login": login, "encoded_login": login}
+        for index, login in enumerate(permissions)
+    ]
+    (tmp_path / "run-identities.json").write_text(json.dumps({
+        "error": None, "permission_actors": actors, "runs": [],
+    }))
+    for actor in actors:
+        (tmp_path / f"permission-{actor['index']}.json").write_text(json.dumps({
+            "permission": permissions[actor["login"]], "user": {"login": actor["login"]},
+        }))
+
+
+def test_dismiss_events_bind_timeline_comments_to_fetched_permissions(tmp_path):
+    _write_permission_fixture(tmp_path, [
+        _timeline_comment(5001, "reviewer", "dismiss RVW-111111111111 the cited constant is wrong"),
+        _timeline_comment(5002, "maintainer", "dismiss RVW-222222222222 stale\r\n"),
+        _timeline_comment(5003, "maintainer", "not a command"),
+        {"id": 9001, "event": "labeled", "label": {"name": "review-budget-override"},
+         "actor": {"login": "maintainer"}},
+    ], {"reviewer": "read", "maintainer": "write"})
+
+    assert budget._dismiss_events(tmp_path) == (
+        budget.DismissEvent(5001, "RVW-111111111111", "read"),
+        budget.DismissEvent(5002, "RVW-222222222222", "write"),
+    )
+
+
+def test_dismiss_events_fail_closed_on_an_unverified_author(tmp_path):
+    _write_permission_fixture(tmp_path, [
+        _timeline_comment(5001, "ghost", "dismiss RVW-111111111111 unverified"),
+    ], {"maintainer": "write"})
+
+    with pytest.raises(budget.TransportError, match="dismiss_actor_invalid"):
+        budget._dismiss_events(tmp_path)
+
+
+def test_claim_records_a_dismissal_from_a_write_collaborator_comment(fake_github):
+    result = fake_github.run_action(
+        mode="claim", scenario="dismiss-comment",
+        timeline=[
+            _timeline_comment(5001, "maintainer", "dismiss RVW-111111111111 the cited constant is wrong"),
+            _timeline_comment(5002, "visitor", "dismiss RVW-222222222222 drive-by"),
+        ],
+        permissions={"visitor": "read"},
+    )
+
+    assert result.outputs["decision"] == "claimed"
+    assert result.outputs["dismissed-finding-ids"] == "RVW-111111111111"
+    assert result.checkpoint["ledger"]["dismissed_findings"] == [
+        {"comment_id": 5001, "finding_id": "RVW-111111111111"},
+    ]
+    looked_up = sorted(
+        part.split("/collaborators/", 1)[1].split("/", 1)[0]
+        for call in result.calls for part in call if "/collaborators/" in part
+    )
+    assert looked_up == ["maintainer", "visitor"]
+
+
+def test_claim_without_dismissals_publishes_an_empty_list(fake_github):
+    result = fake_github.run_action(mode="claim", scenario="first-comment-create")
+
+    assert result.outputs["dismissed-finding-ids"] == ""
+    assert "dismissed_findings" not in result.checkpoint["ledger"]
+
+
+def test_finalize_refreshes_the_dismissal_snapshot_from_the_timeline(fake_github):
+    result = fake_github.run_action(
+        mode="finalize", scenario="finalize-trusted-comment",
+        timeline=[_timeline_comment(5001, "maintainer", "dismiss RVW-111111111111 wrong constant")],
+    )
+
+    assert result.outputs["decision"] == "finalized"
+    assert result.outputs["dismissed-finding-ids"] == "RVW-111111111111"
+    assert result.checkpoint["ledger"]["dismissed_findings"] == [
+        {"comment_id": 5001, "finding_id": "RVW-111111111111"},
+    ]
+    assert result.checkpoint["handoff"]["remaining_finding_ids"] == []
+
+
+def test_permission_lookups_are_bounded_per_timeline(tmp_path):
+    """Any commenter can add a lookup, so the actor list fails closed past the bound."""
+
+    assert budget.MAX_PERMISSION_ACTORS == 16
+    comments = [
+        _timeline_comment(5000 + index, f"user{index}", "dismiss RVW-111111111111 same finding")
+        for index in range(17)
+    ]
+    (tmp_path / "timeline.json").write_text(json.dumps(comments))
+
+    with pytest.raises(budget.TransportError, match="permission_actors_exceeded"):
+        budget._timeline_permission_actors(tmp_path)
+    (tmp_path / "timeline.json").write_text(json.dumps(comments[1:]))
+    assert len(budget._timeline_permission_actors(tmp_path)) == 16
+
+
+def test_dismiss_events_surface_the_recorded_manifest_error(tmp_path):
+    (tmp_path / "timeline.json").write_text(json.dumps([
+        _timeline_comment(5001, "maintainer", "dismiss RVW-111111111111 wrong constant"),
+    ]))
+    (tmp_path / "run-identities.json").write_text(json.dumps({
+        "error": "permission_actors_exceeded", "permission_actors": [], "runs": [],
+    }))
+
+    with pytest.raises(budget.TransportError, match="permission_actors_exceeded"):
+        budget._dismiss_events(tmp_path)

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -2538,6 +2538,7 @@ def test_claude_uses_one_shared_canonicalizer_and_upsert_reads_only_canonical_fi
             "${{ steps.prepare-review-input.outputs.previous_sha != '' "
             "&& format('{0}/claude-previous-review.md', runner.temp) || '' }}"
         ),
+        "dismissed-finding-ids": "${{ steps.review-budget-claim.outputs.dismissed-finding-ids }}",
     }
     assert action["if"] == (
         "${{ always() && steps.reset-claude-artifacts.outcome == 'success' "
@@ -2585,6 +2586,7 @@ def test_gemini_uses_the_same_canonicalizer_contract_as_claude():
             "${{ steps.pr-details.outputs.previous_sha != '' "
             "&& format('{0}/gemini-previous-review.md', runner.temp) || '' }}"
         ),
+        "dismissed-finding-ids": "${{ steps.review-budget-claim.outputs.dismissed-finding-ids }}",
     }
     assert action["if"] == (
         "${{ always() && steps.reset-gemini-artifacts.outcome == 'success' "

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -103,6 +103,7 @@ V1462_WORKFLOW_FIXTURE_COMMIT = "d42c28ddd827554e6e46a2ab49dfe34c838c0425"
 V158_REVIEW_POLICY_HELPER_COMMIT = "1b98172325533ef6ad37f3d2cfc3870073fac26d"
 V159_ROUND_BUDGET_COMMIT = "96d66e1d17952f01b19bb957057830a2b2a6318b"
 V161_FILTER_SURFACE_COMMIT = "08f96e3244bfe8bdd569fb926b26d3086bab125d"
+V162_FINDING_DISMISSAL_COMMIT = "1cbb6df4590fb6be8a5012de31d98dc1f1cd3fa8"
 V1462_WORKFLOW_FIXTURE_SHA256 = {
     "claude-code-review.yml": (
         "008bbdcdeacdaf7796c1e3b59d22194d3f1ce380735d36dada5efab8ff52d112"
@@ -232,6 +233,7 @@ def current_release_repo(tmp_path: Path) -> tuple[Path, str]:
             shutil.copytree(source, target)
         else:
             shutil.copy2(source, target)
+    restore_pre_v163_finding_dismissal(repo)
     restore_pre_v151_review_policy(repo)
     restore_pre_v160_round_budget(repo)
     restore_pre_v162_filter_surface(repo)
@@ -267,6 +269,7 @@ def v1462_release_repo(tmp_path: Path) -> tuple[Path, str]:
             shutil.copytree(source, target)
         else:
             shutil.copy2(source, target)
+    restore_pre_v163_finding_dismissal(repo)
     restore_v1462_workflow_fixtures(repo)
     restore_pre_v162_filter_surface(repo)
     git(repo, "init", "-q")
@@ -319,6 +322,51 @@ def restore_pre_v159_review_policy_helper(repo: Path) -> None:
         == release_verifier.EXPECTED_REVIEW_POLICY_HELPER_SHA256
     )
     (repo / relative).write_bytes(payload)
+
+
+def restore_pre_v163_finding_dismissal(repo: Path, *, budget: bool = False) -> None:
+    """Restore the authenticated pre-v1.63 canonicalizer, budget action, and workflows.
+
+    v1.63 adds the dismissed-finding input to the shared canonicalizer and a matching
+    budget-action output. The workflow edit removes the wiring line as text so it
+    composes with the other historical restores, and it runs first (newest release
+    first) so no later whole-file restore is undone. ``budget`` re-restores both
+    invocation-budget files for the prepares that copy the current ones back in.
+    """
+
+    tree = release_verifier.VerifiedCommitTree.open(ROOT, V162_FINDING_DISMISSAL_COMMIT)
+    (repo / ".github/actions/canonicalize-review/action.yml").write_bytes(
+        tree.read_file(".github/actions/canonicalize-review/action.yml")
+    )
+    helper = tree.read_file(".github/actions/canonicalize-review/canonicalize_review.py")
+    assert (
+        hashlib.sha256(helper).hexdigest()
+        == release_verifier.EXPECTED_CANONICALIZE_REVIEW_HELPER_SHA256_V162
+    )
+    (repo / ".github/actions/canonicalize-review/canonicalize_review.py").write_bytes(helper)
+    if budget:
+        for relative, expected in (
+            (
+                ".github/actions/review-invocation-budget/action.yml",
+                release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_SHA256_V160,
+            ),
+            (
+                ".github/actions/review-invocation-budget/review_invocation_budget.py",
+                release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V162,
+            ),
+        ):
+            payload = tree.read_file(relative)
+            assert hashlib.sha256(payload).hexdigest() == expected
+            (repo / relative).write_bytes(payload)
+    wiring = (
+        "          dismissed-finding-ids: "
+        "${{ steps.review-budget-claim.outputs.dismissed-finding-ids }}\n"
+    )
+    for reviewer in ("claude", "gemini"):
+        path = repo / ".github/workflows" / release_verifier.REVIEWER_WORKFLOWS[reviewer]
+        text = path.read_text(encoding="utf-8")
+        assert text.count(wiring) == 1
+        path.write_text(text.replace(wiring, ""), encoding="utf-8")
 
 
 def restore_pre_v162_filter_surface(repo: Path, *, budget: bool = False) -> None:
@@ -465,6 +513,7 @@ def copy_review_policy_release_files(repo: Path) -> None:
 
 def prepare_v151(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v163_finding_dismissal(repo)
     restore_pre_v162_filter_surface(repo)
     restore_pre_v161_cancel_guard(repo)
     restore_pre_v159_review_policy_helper(repo)
@@ -474,6 +523,7 @@ def prepare_v151(repo: Path) -> str:
 
 def prepare_v159(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v163_finding_dismissal(repo)
     restore_pre_v162_filter_surface(repo)
     restore_pre_v161_cancel_guard(repo)
     restore_pre_v160_round_budget(repo)
@@ -488,6 +538,7 @@ def prepare_v160(repo: Path) -> str:
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v163_finding_dismissal(repo, budget=True)
     restore_pre_v162_filter_surface(repo, budget=True)
     restore_pre_v161_cancel_guard(repo)
     assert_pre_v161_workflow_bytes(repo)
@@ -1918,7 +1969,49 @@ def prepare_v162(repo: Path) -> str:
         ".github/actions/canonicalize-review/canonicalize_review.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v163_finding_dismissal(repo, budget=True)
     return commit(repo, "v1.62 candidate")
+
+
+def prepare_v163(repo: Path) -> str:
+    copy_review_policy_release_files(repo)
+    for relative in (
+        ".github/actions/review-invocation-budget/action.yml",
+        ".github/actions/review-invocation-budget/review_invocation_budget.py",
+        ".github/actions/canonicalize-review/action.yml",
+        ".github/actions/canonicalize-review/canonicalize_review.py",
+    ):
+        shutil.copy2(ROOT / relative, repo / relative)
+    return commit(repo, "v1.63 candidate")
+
+
+def test_v163_accepts_current_finding_dismissal_release_contract(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v163(repo)
+
+    assert release_verifier.verify_commit_content(repo, "v1.63", candidate) == candidate
+
+
+def test_v163_finding_dismissal_is_rejected_on_the_v162_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v163(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.62", candidate)
+
+
+def test_pre_v163_finding_dismissal_is_rejected_on_the_v163_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v162(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.63", candidate)
 
 
 def test_v162_accepts_current_filter_surface_release_contract(
@@ -1957,6 +2050,7 @@ def prepare_v161(repo: Path) -> str:
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v163_finding_dismissal(repo, budget=True)
     restore_pre_v162_filter_surface(repo, budget=True)
     return commit(repo, "v1.61 candidate")
 

--- a/tests/test_workflow_release_bundle.py
+++ b/tests/test_workflow_release_bundle.py
@@ -77,6 +77,7 @@ def test_canonicalize_review_composite_action_has_exact_safe_shell_contract() ->
             "diff-mode": {"required": "true"},
             "previous-sha": {"required": "false", "default": ""},
             "previous-review-file": {"required": "false", "default": ""},
+            "dismissed-finding-ids": {"required": "false", "default": ""},
         },
         "outputs": {
             "document-valid": {"value": "${{ steps.canonicalize.outputs.document_valid }}"},
@@ -107,6 +108,7 @@ def test_canonicalize_review_composite_action_has_exact_safe_shell_contract() ->
                         "DIFF_MODE": "${{ inputs.diff-mode }}",
                         "PREVIOUS_SHA": "${{ inputs.previous-sha }}",
                         "PREVIOUS_REVIEW_FILE": "${{ inputs.previous-review-file }}",
+                        "DISMISSED_FINDING_IDS": "${{ inputs.dismissed-finding-ids }}",
                     },
                     "run": (
                         'python3 "$GITHUB_ACTION_PATH/canonicalize_review.py" '
@@ -119,6 +121,7 @@ def test_canonicalize_review_composite_action_has_exact_safe_shell_contract() ->
                         '--diff-mode "$DIFF_MODE" '
                         '--previous-sha "$PREVIOUS_SHA" '
                         '--previous-review-file "$PREVIOUS_REVIEW_FILE" '
+                        '--dismissed-finding-ids "$DISMISSED_FINDING_IDS" '
                         '--repository-root "$GITHUB_WORKSPACE" '
                         '--expected-repository "$GITHUB_REPOSITORY" '
                         '--github-output "$GITHUB_OUTPUT"'
@@ -158,6 +161,7 @@ def test_canonicalize_review_action_run_passes_quoted_environment_values_to_help
         "SCOPE_MANIFEST": hostile + " manifest",
         "SELECTED_DIFF": hostile + " diff",
         "PREVIOUS_REVIEW_FILE": hostile + " previous",
+        "DISMISSED_FINDING_IDS": hostile + " dismissed",
     }
     environment = {
         **os.environ,
@@ -191,6 +195,7 @@ def test_canonicalize_review_action_run_passes_quoted_environment_values_to_help
         "--diff-mode", "full",
         "--previous-sha", "-- sha ; λ value",
         "--previous-review-file", values["PREVIOUS_REVIEW_FILE"],
+        "--dismissed-finding-ids", values["DISMISSED_FINDING_IDS"],
         "--repository-root", str(workspace),
         "--expected-repository", "owner/repository ; λ",
         "--github-output", str(github_output),
@@ -426,9 +431,9 @@ def test_review_invocation_budget_action_has_exact_safe_contract() -> None:
     document = yaml.load(payload, Loader=yaml.BaseLoader)
 
     assert hashlib.sha256(payload).hexdigest() == (
-        "d9cb26a5c340abd20707483f05f4e071b436dac17a900f670aacbd05140b981e"
+        "b9ebc50e0959d9a2db82b1b11715be81309581ac45bb29b6dab02dccacedb91c"
     )
-    assert document == release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_V160
+    assert document == release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_V163
 
 
 def git(repo: Path, *args: str) -> str:


### PR DESCRIPTION
## Summary

Implements the finding-dismissal path scoped in #112 (2026-09-04 design comment): a collaborator with `write`/`maintain`/`admin` permission posts one PR comment whose whole body is exactly

```text
dismiss RVW-<12 lowercase hex> <reason>
```

and the finding stops being carried over or re-emitted until the comment is deleted.

- **Budget helper/action** — dismissal comments travel through the trust path the override label already uses (timeline → collaborators API permission → fixed grammar). The ledger records a bounded snapshot (`dismissed_findings`: finding ID + comment ID, earliest authorizing comment, ≤ 16), replaces it on every claim/finalize (deleting the comment revokes), and never lists a dismissed ID in `remaining_finding_ids`. A refused claim after all rounds are spent still records it, so no new model round is needed. The key is written only when non-empty, so every pre-v1.63 ledger keeps its exact bytes. New output `dismissed-finding-ids`; the summary links each dismissal to its comment and documents the grammar. Permission lookups are bounded at 16 distinct actors (`permission_actors_exceeded`).
- **Shared canonicalizer** — `--dismissed-finding-ids`; a carryover naming a dismissed ID or a new finding whose derived ID is dismissed (the model repeating itself verbatim) is normalized with `dismissed_prior_id` and leaves the document, `accepted-count`, and the remaining IDs.
- **Workflows** — Claude and Gemini pass the budget claim's output to the canonicalizer (one line each). OpenCode bytes are unchanged.
- **Verifier** — v1.63 gate `release_supports_finding_dismissal`; both action documents derived from the v1.62 ones by stating the delta; grammar, permitted roles, both bounds, new public functions and the `FinalizeRequest` record are structurally pinned; `restore_pre_v163_finding_dismissal` runs first (newest release first) in every fixture.
- **Docs** — `contracts.md` "Dismissing a finding".

## ⚠️ Scope finding: OpenCode findings carry no `RVW-` IDs

The issue's design assumed every reviewer derives `RVW-` IDs (citing `canonicalize_review.py:216-220`). That is true only for the shared Claude/Gemini canonicalizer. OpenCode's inline canonicalizer binds carryover by exact heading text and never derives an ID — the OpenCode sticky on wlan-package#282 (the incident behind #112) reads `#### [MEDIUM] BSS mask bits …` with no ID, and OpenCode's `remaining_finding_ids` is always `[]`. Consequently:

- the dismiss path covers Claude and Gemini fully;
- the OpenCode ledger **ignores** dismissal comments and keeps the pre-v1.63 summary text, rather than advertising a path nothing consumes;
- the issue's own motivating case is **not** fixed by this PR. Giving OpenCode findings IDs is the "finding ID 재설계" the issue explicitly left out of scope — I recommend a follow-up issue for it, and I have not closed #112 (`Refs #112`).

## Verification

- v1.63 accepted; v1.63 bytes rejected on the v1.62 line; v1.62 wiring rejected on the v1.63 line; v1.51/v1.59/v1.60/v1.61/v1.62 still pass.
- Full suite on the frozen tree: see the commit message for counts. The only failures are the 2 pre-existing local `umask 0002` mode assertions (`test_v145_review_fixtures_match_the_immutable_release_blobs`), which also fail on unmodified `main` and pass in CI.
- `actionlint 1.7.12 -shellcheck= -pyflakes=` (CI invocation) is clean.
- Independent review pass (code-reviewer, Opus): 2 HIGH + 5 MEDIUM + 6 LOW addressed or explicitly declined in the diff; the "404 permission lookup" open question was checked against the live API (bot → `none`, ghost → `read`; only a nonexistent login 404s, which a timeline actor cannot be).
- Timeline `commented` payload shape (`actor`/`user`/`body`/`id`/`author_association`) confirmed on automation#123.

## Release note

Workflow bytes changed (Claude/Gemini), so this needs **v1.63 + a 17-target rollout** after merge. Not started — the tag is create-only and the OpenCode scope finding above may change what you want in this release line.

Refs #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnEJTjxEwdMh5sPkeVZYzy
