### PR TITLE
chore(workflows): default rollout to v1.63

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.62",
+  "automation_ref": "v1.63",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.62"
+    assert config.automation_ref == "v1.63"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
Records v1.63 (tag object 52810787 → commit d115dc66) as the default `automation_ref` after the 17-target fleet rollout (PR #126, refs #112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnEJTjxEwdMh5sPkeVZYzy