### PR TITLE
feat(review): start a review from the request label and require the review labels (#111, #115)

### DIFF
--- a/.github/workflows/_self-claude-review.yml
+++ b/.github/workflows/_self-claude-review.yml
@@ -7,7 +7,7 @@ name: Self Claude Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -15,7 +15,7 @@ on:
         type: number
         required: true
       force_review:
-        description: Perform one authorized same-HEAD review
+        description: Perform one authorized same-HEAD override round; requires the review-budget-override label
         type: boolean
         required: false
         default: false
@@ -26,7 +26,8 @@ jobs:
       (github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false) ||
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'review:request')) ||
       (github.event_name == 'workflow_dispatch' && inputs.force_review)
     permissions:
       actions: read

--- a/.github/workflows/_self-gemini-auto-review.yml
+++ b/.github/workflows/_self-gemini-auto-review.yml
@@ -9,7 +9,7 @@ name: Self Gemini Auto Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -17,7 +17,7 @@ on:
         type: number
         required: true
       force_review:
-        description: Perform one authorized same-HEAD review
+        description: Perform one authorized same-HEAD override round; requires the review-budget-override label
         type: boolean
         required: false
         default: false
@@ -49,7 +49,8 @@ jobs:
       ((github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false) ||
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'review:request')) ||
       (github.event_name == 'workflow_dispatch' && inputs.force_review))
     permissions:
       actions: read

--- a/.github/workflows/_self-opencode-auto-review.yml
+++ b/.github/workflows/_self-opencode-auto-review.yml
@@ -8,7 +8,7 @@ name: Self OpenCode Auto Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -16,7 +16,7 @@ on:
         type: number
         required: true
       force_review:
-        description: Perform one authorized same-HEAD review
+        description: Perform one authorized same-HEAD override round; requires the review-budget-override label
         type: boolean
         required: false
         default: false
@@ -50,7 +50,8 @@ jobs:
       ((github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false) ||
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'review:request')) ||
       (github.event_name == 'workflow_dispatch' && inputs.force_review))
     permissions:
       actions: read

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -422,8 +422,8 @@ as an implicit bootstrap opportunity. Audit reports `current`, `drift`, or `bloc
 each configured target.
 
 The manifest and operator output identify the default target and include
-the observed base SHA, release commit, required secret and variable **names**, and managed
-diff paths. The manifest is a convenience report, not an approval token; publish always
+the observed base SHA, release commit, required secret, variable, and (from `v1.64`) review-label
+**names**, and managed diff paths. The manifest is a convenience report, not an approval token; publish always
 refetches and recomputes.
 
 ### 2. Publish independent PRs
@@ -591,13 +591,35 @@ After merge, use a **GitHub-native revert** PR (or a normal reviewed PR containi
 `git revert`). Never move an immutable automation tag. Repair a bad central release with a
 new immutable release and new consumer PRs.
 
+## Review labels
+
+From `v1.64` the plan, publish, and audit tools also read each repository's label names and
+block a repository that lacks `review:request`, `review:skip`, or `review-budget-override`
+(`missing labels: ...`), because the shipped review policy is opt-in through those labels. The
+tools never create labels. Create or repair them with the explicit operator step, which is
+read-only without `--confirm`:
+
+```bash
+python3 "$AUTOMATION_RELEASE_ROOT/scripts/ensure_review_labels.py" \
+  --automation "$AUTOMATION_RELEASE_ROOT"                        # report per repository
+python3 "$AUTOMATION_RELEASE_ROOT/scripts/ensure_review_labels.py" \
+  --automation "$AUTOMATION_RELEASE_ROOT" --confirm              # create the missing labels
+python3 "$AUTOMATION_RELEASE_ROOT/scripts/ensure_review_labels.py" \
+  --automation "$AUTOMATION_RELEASE_ROOT" --confirm --normalize  # also repair color/description
+```
+
+Use repeated `--repo NAME` arguments to narrow it. Labels are per repository, so the operator
+step checks a multi-branch repository such as `wlan-driver-v2` once, while plan and audit read
+the names once per branch target. Color or description drift is reported but never blocks a
+rollout; only a missing name does.
+
 ## Token synchronization
 
 Workflow PR rollout and credential lifecycle are separate operations. The workflow tools
-may inspect required secret and variable **names** as preconditions, but they never read a
-provider value, consume a local provider file, or call a secret/variable mutation API.
-Missing names block the affected repository until an independently reviewed credential
-process resolves them.
+may inspect required secret, variable, and review-label **names** as preconditions, but they
+never read a provider value, consume a local provider file, or call a secret/variable/label
+mutation API. Missing names block the affected repository until an independently reviewed
+credential process (or the label step above) resolves them.
 
 Claude token rotation remains owned by `personal-ops/claude-token-sync`, including its
 inventory, locking, health checks, and deployment lifecycle. Other provider-key changes

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -215,17 +215,42 @@ Every review channel is off by default and requires an explicit opt-in:
 `/jhw:pr --review` applies the label and posts both mentions, so opting one pull request into all
 three channels is a single command.
 
-Managed-reviewer opt-in must be in place before the run starts. The callers subscribe to `opened`,
-`synchronize`, and `ready_for_review`, never `labeled`, so adding `review:request` to an
-already-open pull request starts no run by itself; and adding it while a run is already resolving
-fails that run closed with `review_mode_label_mismatch`, because the caller's `review_mode` input
-was read from an event payload that predates the label. Apply the label before the final ready
-head — `/jhw:pr --review` labels the draft and then marks it ready — or, on a pull request that is
-already open, start one authorized same-head review through a `workflow_dispatch` carrying
-`force_review: true`.
+The labels themselves are a fleet precondition. Every configured repository must define
+`review:request` (`0E8A16`, "Explicitly request AI review"), `review:skip` (`BFDADC`,
+"Explicitly skip AI review"), and `review-budget-override` (`D93F0B`, "Authorize one bounded
+reviewer override round"). From `v1.64` the rollout plan, publish, and audit tools read the
+repository's label names next to its secret and variable names and report a repository whose
+names are missing as `blocked` with `missing labels: ...`; the tools never create labels. The
+explicit, idempotent operator step is `scripts/ensure_review_labels.py`, which reports missing
+labels and color/description drift, creates the missing ones with `--confirm`, and repairs drift
+with `--confirm --normalize`.
+
+From `v1.64` the managed callers also subscribe to `labeled`, guarded so that only the
+`review:request` label starts a run: `github.event.action != 'labeled' ||
+github.event.label.name == 'review:request'`. Adding `review:request` to an already-open,
+non-draft pull request therefore starts one review of its current head without a new commit,
+a ready transition, or a dispatch, provided that workflow is enabled in
+`.github/workflow-config.yml`; the `labeled` payload carries the updated label list, so the
+caller's `review_mode` resolves to `request`. Unrelated labels start nothing, and the event is
+never a cancellation trigger. Three consequences follow from contracts that did not change:
+adding the label while another run is still resolving fails that run closed with
+`review_mode_label_mismatch` — so labeling a non-draft pull request right after opening it
+leaves one red `opened` run beside the `labeled` run that reviews, which is the expected
+steady state of that sequence; adding it to a pull request that already carries `review:skip`
+starts a run that fails closed with `review_label_conflict` before any model is invoked, so
+remove `review:skip` first and re-add `review:request`; and a head that a reviewer already
+reviewed is refused with `duplicate_head` — the label reviews each head once, and a same-head
+re-review still needs the override round below. On draft pull requests the label starts nothing
+until the pull request is marked ready. Before `v1.64` the callers subscribed to `opened`,
+`synchronize`, and `ready_for_review` only, so the label had to be applied before the final
+ready head — `/jhw:pr --review` labels the draft and then marks it ready — or an already-open
+pull request needed a `workflow_dispatch` carrying `force_review: true`.
 
 A bounded override round (`review-budget-override` plus a `workflow_dispatch` carrying
-`force_review: true`) is available for Claude and Gemini only. From `v1.62` the budget refuses it
+`force_review: true`) is available for Claude and Gemini only; from `v1.64` the callers'
+`force_review` input says so ("Perform one authorized same-HEAD override round; requires the
+review-budget-override label"), because a dispatch without the label is refused as
+`round_budget_exhausted` even on a first review. From `v1.62` the budget refuses it
 for OpenCode, because that canonicalizer authenticates `pull_request` provenance throughout and a
 dispatch round can never publish: spending the override there consumed it and lost the verdict.
 

--- a/examples/baseline-workflows/.github/workflows/claude-code-review.yml
+++ b/examples/baseline-workflows/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -10,7 +10,7 @@ on:
         type: number
         required: true
       force_review:
-        description: Perform one authorized same-HEAD review
+        description: Perform one authorized same-HEAD override round; requires the review-budget-override label
         type: boolean
         required: false
         default: false
@@ -21,7 +21,8 @@ jobs:
       (github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false) ||
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'review:request')) ||
       (github.event_name == 'workflow_dispatch' && inputs.force_review)
     permissions:
       actions: read

--- a/examples/baseline-workflows/.github/workflows/gemini-auto-review.yml
+++ b/examples/baseline-workflows/.github/workflows/gemini-auto-review.yml
@@ -2,7 +2,7 @@ name: Gemini Auto PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -10,7 +10,7 @@ on:
         type: number
         required: true
       force_review:
-        description: Perform one authorized same-HEAD review
+        description: Perform one authorized same-HEAD override round; requires the review-budget-override label
         type: boolean
         required: false
         default: false
@@ -21,7 +21,8 @@ jobs:
       (github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false) ||
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'review:request')) ||
       (github.event_name == 'workflow_dispatch' && inputs.force_review)
     permissions:
       actions: read

--- a/examples/baseline-workflows/.github/workflows/opencode-auto-review.yml
+++ b/examples/baseline-workflows/.github/workflows/opencode-auto-review.yml
@@ -2,7 +2,7 @@ name: OpenCode Auto PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -10,7 +10,7 @@ on:
         type: number
         required: true
       force_review:
-        description: Perform one authorized same-HEAD review
+        description: Perform one authorized same-HEAD override round; requires the review-budget-override label
         type: boolean
         required: false
         default: false
@@ -21,7 +21,8 @@ jobs:
       (github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false) ||
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'review:request')) ||
       (github.event_name == 'workflow_dispatch' && inputs.force_review)
     permissions:
       actions: read

--- a/scripts/audit_workflow_fleet.py
+++ b/scripts/audit_workflow_fleet.py
@@ -64,6 +64,7 @@ def audit_repository(
     secret_names: set[str],
     variable_names: set[str],
     *,
+    label_names: set[str],
     observed_revision: str | None = None,
     base_branch: str = "",
 ) -> AuditResult:
@@ -79,6 +80,7 @@ def audit_repository(
             bundle.commit,
             secret_names,
             variable_names,
+            label_names=label_names,
             bootstrap=False,
             observed_revision=observed_revision,
         )
@@ -225,6 +227,7 @@ def main(argv: list[str] | None = None) -> int:
                                 profile,
                                 set(snapshot.secret_names),
                                 set(snapshot.variable_names),
+                                label_names=set(snapshot.label_names),
                                 observed_revision=base_sha,
                                 base_branch=selected_base,
                                 ),

--- a/scripts/ensure_review_labels.py
+++ b/scripts/ensure_review_labels.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Create or normalize the fleet's review labels in configured repositories (issue #115).
+
+The rollout and audit tools only inspect label names and block a repository whose
+opt-in labels are missing; they never create anything but Git objects. This script is
+the explicit, idempotent operator step that creates the missing labels and, with
+``--normalize``, also repairs color/description drift. Without ``--confirm`` it only
+reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import workflow_fleet_git as fleet_git  # noqa: E402
+from scripts.prepare_workflow_rollout import REQUIRED_REVIEW_LABELS  # noqa: E402
+from scripts.workflow_catalog import CatalogError, load_catalog, load_fleet_config  # noqa: E402
+
+LIST_LIMIT = "300"
+_ALLOWED_GH = (["gh", "label", "list"], ["gh", "label", "create"], ["gh", "label", "edit"])
+
+
+def _gh_label(args: list[str]) -> str:
+    """Run one label command; nothing but list/create/edit can leave this script."""
+    if args[:3] not in _ALLOWED_GH:
+        raise ValueError("label operation is not permitted")
+    return fleet_git.run(args)
+
+
+class LabelInventoryError(ValueError):
+    """GitHub returned a label inventory that cannot be trusted."""
+
+
+@dataclass(frozen=True)
+class LabelOutcome:
+    repo: str
+    missing: tuple[str, ...]
+    drift: tuple[str, ...]
+    created: tuple[str, ...]
+    normalized: tuple[str, ...]
+    error: str | None = None
+
+
+def configured_repositories(root: Path) -> tuple[str, ...]:
+    config = load_fleet_config(root, load_catalog(root))
+    return tuple(sorted(config.profiles))
+
+
+def fleet_owner(root: Path) -> str:
+    return load_fleet_config(root, load_catalog(root)).owner
+
+
+def label_inventory(owner: str, repo: str) -> dict[str, tuple[str, str]]:
+    raw = _gh_label([
+        "gh", "label", "list", "-R", f"{owner}/{repo}",
+        "--json", "name,color,description", "--limit", LIST_LIMIT,
+    ])
+    try:
+        data = json.loads(raw)
+    except ValueError as exc:
+        raise LabelInventoryError("GitHub returned malformed label inventory") from exc
+    if not isinstance(data, list):
+        raise LabelInventoryError("GitHub returned malformed label inventory")
+    inventory: dict[str, tuple[str, str]] = {}
+    for item in data:
+        if (
+            not isinstance(item, dict)
+            or not isinstance(item.get("name"), str)
+            or not item["name"]
+        ):
+            raise LabelInventoryError("GitHub returned malformed label inventory")
+        color = item.get("color")
+        description = item.get("description")
+        inventory[item["name"]] = (
+            color.upper() if isinstance(color, str) else "",
+            description if isinstance(description, str) else "",
+        )
+    return inventory
+
+
+def ensure_repository(
+    owner: str, repo: str, *, confirm: bool, normalize: bool
+) -> LabelOutcome:
+    try:
+        inventory = label_inventory(owner, repo)
+    except (fleet_git.FleetGitError, LabelInventoryError) as exc:
+        return LabelOutcome(repo, (), (), (), (), str(exc))
+    missing: list[str] = []
+    drift: list[str] = []
+    drifted = []
+    for label in REQUIRED_REVIEW_LABELS:
+        if label.name not in inventory:
+            missing.append(label.name)
+            continue
+        color, description = inventory[label.name]
+        fields = []
+        if color != label.color:
+            fields.append(f"color={color} expected={label.color}")
+        if description != label.description:
+            fields.append(f"description={description!r} expected={label.description!r}")
+        if fields:
+            drift.append(f"{label.name} " + " ".join(fields))
+            drifted.append(label)
+    created: list[str] = []
+    normalized: list[str] = []
+    try:
+        if confirm:
+            for label in sorted(
+                (item for item in REQUIRED_REVIEW_LABELS if item.name in missing),
+                key=lambda item: item.name,
+            ):
+                _gh_label([
+                    "gh", "label", "create", label.name, "-R", f"{owner}/{repo}",
+                    "--color", label.color, "--description", label.description,
+                ])
+                created.append(label.name)
+            if normalize:
+                for label in drifted:
+                    _gh_label([
+                        "gh", "label", "edit", label.name, "-R", f"{owner}/{repo}",
+                        "--color", label.color, "--description", label.description,
+                    ])
+                    normalized.append(label.name)
+    except fleet_git.FleetGitError as exc:
+        return LabelOutcome(
+            repo, tuple(sorted(missing)), tuple(drift), tuple(created), tuple(normalized),
+            str(exc),
+        )
+    return LabelOutcome(
+        repo, tuple(sorted(missing)), tuple(drift), tuple(created), tuple(normalized)
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--automation", type=Path, default=ROOT)
+    parser.add_argument("--repo", action="append", default=[])
+    parser.add_argument("--confirm", action="store_true", help="create missing labels")
+    parser.add_argument(
+        "--normalize",
+        action="store_true",
+        help="with --confirm, also repair color/description drift",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    try:
+        fleet = configured_repositories(args.automation)
+        owner = fleet_owner(args.automation)
+    except (CatalogError, OSError, ValueError) as exc:
+        parser.error(f"fleet configuration is invalid: {exc}")
+    selected = tuple(args.repo) if args.repo else fleet
+    unknown = sorted(set(selected) - set(fleet))
+    if unknown:
+        parser.error(f"repository is not configured: {', '.join(unknown)}")
+    totals = {"missing": 0, "drift": 0, "created": 0, "normalized": 0}
+    failed = False
+    for repo in selected:
+        outcome = ensure_repository(
+            owner, repo, confirm=args.confirm, normalize=args.normalize
+        )
+        if outcome.error is not None:
+            failed = True
+            print(f"ERROR {repo}: {outcome.error}")
+        remaining = tuple(name for name in outcome.missing if name not in outcome.created)
+        unresolved = tuple(
+            line for line in outcome.drift
+            if line.split(" ", 1)[0] not in outcome.normalized
+        )
+        if outcome.created:
+            print(f"CREATED {repo}: {', '.join(outcome.created)}")
+        if outcome.normalized:
+            print(f"NORMALIZED {repo}: {', '.join(outcome.normalized)}")
+        if remaining:
+            failed = True
+            print(f"MISSING {repo}: {', '.join(remaining)}")
+        for line in unresolved:
+            print(f"DRIFT {repo}: {line}")
+        quiet = not (remaining or unresolved or outcome.created or outcome.normalized)
+        if outcome.error is None and quiet:
+            print(f"CURRENT {repo}: {len(REQUIRED_REVIEW_LABELS)} review labels current")
+        totals["missing"] += len(remaining)
+        totals["drift"] += len(unresolved)
+        totals["created"] += len(outcome.created)
+        totals["normalized"] += len(outcome.normalized)
+    print(
+        f"SUMMARY repos={len(selected)} missing={totals['missing']} "
+        f"drift={totals['drift']} created={totals['created']} "
+        f"normalized={totals['normalized']}"
+    )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ensure_review_labels.py
+++ b/scripts/ensure_review_labels.py
@@ -69,6 +69,10 @@ def label_inventory(owner: str, repo: str) -> dict[str, tuple[str, str]]:
         raise LabelInventoryError("GitHub returned malformed label inventory") from exc
     if not isinstance(data, list):
         raise LabelInventoryError("GitHub returned malformed label inventory")
+    if len(data) >= int(LIST_LIMIT):
+        # A full page truncates newest-first and could hide exactly the review labels;
+        # creating "missing" ones on that evidence would be wrong, so refuse instead.
+        raise LabelInventoryError("GitHub label inventory exceeds the page limit")
     inventory: dict[str, tuple[str, str]] = {}
     for item in data:
         if (

--- a/scripts/prepare_workflow_rollout.py
+++ b/scripts/prepare_workflow_rollout.py
@@ -93,6 +93,29 @@ class GitTreeEntry:
 
 
 @dataclass(frozen=True)
+class ReviewLabel:
+    name: str
+    color: str
+    description: str
+
+
+# Issue #115: v1.59 made `review:request` the per-pull-request opt-in and the override
+# round needs `review-budget-override`, so a repository without these labels cannot use
+# the shipped review policy. They are inspected as names, like secret and variable
+# names; `scripts/ensure_review_labels.py` is the explicit operator step that creates them.
+REQUIRED_REVIEW_LABELS: tuple[ReviewLabel, ...] = (
+    ReviewLabel("review:request", "0E8A16", "Explicitly request AI review"),
+    ReviewLabel("review:skip", "BFDADC", "Explicitly skip AI review"),
+    ReviewLabel(
+        "review-budget-override", "D93F0B", "Authorize one bounded reviewer override round"
+    ),
+)
+REQUIRED_REVIEW_LABEL_NAMES: frozenset[str] = frozenset(
+    label.name for label in REQUIRED_REVIEW_LABELS
+)
+
+
+@dataclass(frozen=True)
 class RenderPlan:
     status: Literal["current", "drift", "bootstrap_required", "blocked"]
     reason: str
@@ -101,6 +124,7 @@ class RenderPlan:
     required_variables: frozenset[str]
     managed_results: tuple[ManagedResult, ...] = ()
     observed_revision: str | None = None
+    required_labels: frozenset[str] = REQUIRED_REVIEW_LABEL_NAMES
 
     def after(self, path: str) -> bytes | None:
         requested = PurePosixPath(path)
@@ -607,14 +631,19 @@ def _prerequisite_reason(
     required_variables: frozenset[str],
     secret_names: set[str],
     variable_names: set[str],
+    required_labels: frozenset[str],
+    label_names: set[str],
 ) -> str:
     parts: list[str] = []
     missing_secrets = sorted(required_secrets - secret_names)
     missing_variables = sorted(required_variables - variable_names)
+    missing_labels = sorted(required_labels - label_names)
     if missing_secrets:
         parts.append(f"missing secrets: {', '.join(missing_secrets)}")
     if missing_variables:
         parts.append(f"missing variables: {', '.join(missing_variables)}")
+    if missing_labels:
+        parts.append(f"missing labels: {', '.join(missing_labels)}")
     return "; ".join(parts)
 
 
@@ -628,6 +657,7 @@ def render_repository(
     secret_names: set[str],
     variable_names: set[str],
     *,
+    label_names: set[str],
     bootstrap: bool = False,
     observed_revision: str | None = None,
 ) -> RenderPlan:
@@ -720,6 +750,8 @@ def render_repository(
             required_variables,
             secret_names,
             variable_names,
+            REQUIRED_REVIEW_LABEL_NAMES,
+            label_names,
         )
         if missing:
             return block(missing)
@@ -812,6 +844,8 @@ def render_repository(
             required_variables,
             secret_names,
             variable_names,
+            REQUIRED_REVIEW_LABEL_NAMES,
+            label_names,
         )
         reason = "disabled bootstrap required"
         if prerequisites:

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -560,6 +560,7 @@ def validate_managed_result(
                 profile,
                 set(plan.required_secrets),
                 set(plan.required_variables),
+                label_names=set(plan.required_labels),
             )
             if result.status != "current":
                 raise CommandError(f"catalog audit failed: {result.detail}")
@@ -1081,6 +1082,7 @@ def _render(
         bundle.commit,
         set(snapshot.secret_names),
         set(snapshot.variable_names),
+        label_names=set(snapshot.label_names),
         bootstrap=bootstrap,
         observed_revision=snapshot.base_sha,
     )
@@ -1515,6 +1517,7 @@ def _plan_record(prepared: PreparedRepo, commit: str) -> dict[str, object]:
             "reason": prepared.outcome.detail,
             "required_secrets": sorted(plan.required_secrets) if plan else [],
             "required_variables": sorted(plan.required_variables) if plan else [],
+            "required_labels": sorted(plan.required_labels) if plan else [],
             "managed_diff_paths": list(_changed_paths(plan)) if plan else [],
         }
     )

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -50,6 +50,7 @@ from scripts.workflow_release_inventory import (
     release_supports_review_rounds_variable,
     release_supports_filter_reason_surface,
     release_supports_finding_dismissal,
+    release_supports_label_review_trigger,
     release_supports_same_head_cancel_guard,
     release_supports_review_policy,
     validate_release_listing,
@@ -6048,10 +6049,18 @@ def _verify_review_policy_workflows(documents: dict[str, dict]) -> None:
         ) from None
 
 
-def _verify_review_policy_callers(tree: VerifiedCommitTree) -> None:
+def _verify_review_policy_callers(tree: VerifiedCommitTree, ref: str) -> None:
+    # v1.64 subscribes the callers to `labeled`, guards that event on the
+    # `review:request` label so unrelated labels start no run, and describes
+    # `force_review` as the override round that needs `review-budget-override`.
+    label_trigger = release_supports_label_review_trigger(ref)
     trigger = {
         "pull_request": {
-            "types": ["opened", "synchronize", "ready_for_review"]
+            "types": (
+                ["opened", "synchronize", "ready_for_review", "labeled"]
+                if label_trigger
+                else ["opened", "synchronize", "ready_for_review"]
+            )
         },
         "workflow_dispatch": {
             "inputs": {
@@ -6061,7 +6070,12 @@ def _verify_review_policy_callers(tree: VerifiedCommitTree) -> None:
                     "required": "true",
                 },
                 "force_review": {
-                    "description": "Perform one authorized same-HEAD review",
+                    "description": (
+                        "Perform one authorized same-HEAD override round; "
+                        "requires the review-budget-override label"
+                        if label_trigger
+                        else "Perform one authorized same-HEAD review"
+                    ),
                     "type": "boolean",
                     "required": "false",
                     "default": "false",
@@ -6073,8 +6087,14 @@ def _verify_review_policy_callers(tree: VerifiedCommitTree) -> None:
         "(github.event_name == 'pull_request' && "
         "github.event.pull_request.head.repo.fork == false && "
         "github.event.pull_request.head.repo.full_name == github.repository && "
-        "github.event.pull_request.draft == false) || "
-        "(github.event_name == 'workflow_dispatch' && inputs.force_review)"
+        + (
+            "github.event.pull_request.draft == false && "
+            "(github.event.action != 'labeled' || "
+            "github.event.label.name == 'review:request')) || "
+            if label_trigger
+            else "github.event.pull_request.draft == false) || "
+        )
+        + "(github.event_name == 'workflow_dispatch' && inputs.force_review)"
     )
     review_mode = (
         "${{\n"
@@ -6958,7 +6978,7 @@ def _verify_commit_content(
         _verify_canonicalize_review_action(tree, ref)
     if release_supports_review_policy(ref):
         _verify_review_policy_action(tree, ref)
-        _verify_review_policy_callers(tree)
+        _verify_review_policy_callers(tree, ref)
     _verify_approved_v140_policy(tree, ref)
     _verify_manual_gemini_output_contract(tree, ref)
     catalog = _verify_tag_catalog(tree, ref)

--- a/scripts/workflow-catalog.json
+++ b/scripts/workflow-catalog.json
@@ -53,7 +53,8 @@
           "types": [
             "opened",
             "synchronize",
-            "ready_for_review"
+            "ready_for_review",
+            "labeled"
           ]
         },
         "workflow_dispatch": {
@@ -64,7 +65,7 @@
               "required": "true"
             },
             "force_review": {
-              "description": "Perform one authorized same-HEAD review",
+              "description": "Perform one authorized same-HEAD override round; requires the review-budget-override label",
               "type": "boolean",
               "required": "false",
               "default": "false"
@@ -104,7 +105,8 @@
           "types": [
             "opened",
             "synchronize",
-            "ready_for_review"
+            "ready_for_review",
+            "labeled"
           ]
         },
         "workflow_dispatch": {
@@ -115,7 +117,7 @@
               "required": "true"
             },
             "force_review": {
-              "description": "Perform one authorized same-HEAD review",
+              "description": "Perform one authorized same-HEAD override round; requires the review-budget-override label",
               "type": "boolean",
               "required": "false",
               "default": "false"
@@ -612,7 +614,8 @@
           "types": [
             "opened",
             "synchronize",
-            "ready_for_review"
+            "ready_for_review",
+            "labeled"
           ]
         },
         "workflow_dispatch": {
@@ -623,7 +626,7 @@
               "required": "true"
             },
             "force_review": {
-              "description": "Perform one authorized same-HEAD review",
+              "description": "Perform one authorized same-HEAD override round; requires the review-budget-override label",
               "type": "boolean",
               "required": "false",
               "default": "false"

--- a/scripts/workflow_fleet_git.py
+++ b/scripts/workflow_fleet_git.py
@@ -62,6 +62,7 @@ class RepositorySnapshot:
     secret_names: frozenset[str]
     variable_names: frozenset[str]
     base_branch: str | None = None
+    label_names: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -362,10 +363,20 @@ def _snapshot_base_branch(snapshot: RepositorySnapshot) -> str:
     return branch
 
 
+LABEL_PAGE_LIMIT = 300
+
+
 def _inventory(owner: str, repo: str, kind: str) -> frozenset[str]:
-    data = _json(["gh", kind, "list", "-R", f"{owner}/{repo}", "--json", "name"])
+    args = ["gh", kind, "list", "-R", f"{owner}/{repo}", "--json", "name"]
+    if kind == "label":
+        # `gh label list` pages at 30 by default and truncates newest-first, so a full
+        # page could hide exactly the review labels; refuse to trust one.
+        args += ["--limit", str(LABEL_PAGE_LIMIT)]
+    data = _json(args)
     if not isinstance(data, list):
         raise FleetGitError("GitHub returned malformed prerequisite inventory")
+    if kind == "label" and len(data) >= LABEL_PAGE_LIMIT:
+        raise FleetGitError("GitHub label inventory exceeds the page limit")
     names: set[str] = set()
     for item in data:
         if not isinstance(item, dict):
@@ -442,6 +453,7 @@ def clone_branch(
     base_sha = _validate_object_id(_git(["rev-parse", "HEAD"], cwd=target))
     secret_names = _inventory(owner, repo, "secret")
     variable_names = _inventory(owner, repo, "variable")
+    label_names = _inventory(owner, repo, "label")
     return RepositorySnapshot(
         path=target,
         default_branch=default_branch,
@@ -449,6 +461,7 @@ def clone_branch(
         secret_names=secret_names,
         variable_names=variable_names,
         base_branch=base_branch,
+        label_names=label_names,
     )
 
 

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -152,6 +152,7 @@ REVIEW_ROUNDS_VARIABLE_RELEASE = (1, 60)
 SAME_HEAD_CANCEL_RELEASE = (1, 61)
 FILTER_REASON_SURFACE_RELEASE = (1, 62)
 FINDING_DISMISSAL_RELEASE = (1, 63)
+LABEL_REVIEW_TRIGGER_RELEASE = (1, 64)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -212,6 +213,12 @@ def release_supports_finding_dismissal(ref: str) -> bool:
     """Return whether ``ref`` lets a write collaborator dismiss a finding by comment."""
 
     return _release_version(ref) >= FINDING_DISMISSAL_RELEASE
+
+
+def release_supports_label_review_trigger(ref: str) -> bool:
+    """Return whether ``ref``'s managed callers start a review when `review:request` is added."""
+
+    return _release_version(ref) >= LABEL_REVIEW_TRIGGER_RELEASE
 
 
 def release_roots_for(ref: str) -> tuple[ReleaseRoot, ...]:

--- a/tests/release_fixture_helpers.py
+++ b/tests/release_fixture_helpers.py
@@ -34,9 +34,70 @@ V145_PREPARE_DIFF_FIXTURE = (
 )
 
 
+LABELED_TRIGGER_TYPES = "    types: [opened, synchronize, ready_for_review, labeled]\n"
+PRE_V164_TRIGGER_TYPES = "    types: [opened, synchronize, ready_for_review]\n"
+LABELED_GUARD_LINES = (
+    "      github.event.pull_request.draft == false &&\n"
+    "      (github.event.action != 'labeled' || github.event.label.name == 'review:request')) ||\n"
+)
+PRE_V164_GUARD_LINES = "      github.event.pull_request.draft == false) ||\n"
+OVERRIDE_DESCRIPTION = (
+    "        description: Perform one authorized same-HEAD override round; "
+    "requires the review-budget-override label\n"
+)
+PRE_V164_DESCRIPTION = "        description: Perform one authorized same-HEAD review\n"
+CATALOG_LABELED_TYPES = '            "synchronize",\n            "ready_for_review",\n            "labeled"\n'
+CATALOG_PRE_V164_TYPES = '            "synchronize",\n            "ready_for_review"\n'
+CATALOG_OVERRIDE_DESCRIPTION = (
+    '"description": "Perform one authorized same-HEAD override round; '
+    'requires the review-budget-override label"'
+)
+CATALOG_PRE_V164_DESCRIPTION = '"description": "Perform one authorized same-HEAD review"'
+
+
+def restore_pre_v164_label_trigger(repo: Path) -> None:
+    """Restore the pre-v1.64 review callers and catalog triggers by text.
+
+    v1.64 subscribes the three managed review callers to `labeled`, guards that
+    event on `review:request`, and describes `force_review` as the override round;
+    the catalog `trigger` blocks change with them. This runs first (newest release
+    first) so the older restores still find the text they assert on.
+    """
+
+    # Idempotent: a fixture that already restored (or never had) the v1.64 text is
+    # left alone, so this can also run first inside the older restore chains.
+    for workflow in ("claude-code-review.yml", "gemini-auto-review.yml", "opencode-auto-review.yml"):
+        path = repo / "examples/baseline-workflows/.github/workflows" / workflow
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for current, historical in (
+            (LABELED_TRIGGER_TYPES, PRE_V164_TRIGGER_TYPES),
+            (LABELED_GUARD_LINES, PRE_V164_GUARD_LINES),
+            (OVERRIDE_DESCRIPTION, PRE_V164_DESCRIPTION),
+        ):
+            # 0 is legitimate: trees older than v1.51 carry neither form and are
+            # restored further by the callers below.
+            assert text.count(current) <= 1, (workflow, current)
+            text = text.replace(current, historical)
+        path.write_text(text, encoding="utf-8")
+    catalog = repo / "scripts/workflow-catalog.json"
+    if catalog.exists():
+        text = catalog.read_text(encoding="utf-8")
+        for current, historical in (
+            (CATALOG_LABELED_TYPES, CATALOG_PRE_V164_TYPES),
+            (CATALOG_OVERRIDE_DESCRIPTION, CATALOG_PRE_V164_DESCRIPTION),
+        ):
+            assert text.count(current) in (0, 3), current
+            text = text.replace(current, historical)
+        catalog.write_text(text, encoding="utf-8")
+
+
+
 def restore_pre_v151_review_policy_callers(repo: Path) -> None:
     """Remove only the v1.51 caller policy surface from historical fixtures."""
 
+    restore_pre_v164_label_trigger(repo)
     baseline_root = repo / "examples/baseline-workflows/.github/workflows"
     review_mode = (
         "      review_mode: >-\n"

--- a/tests/test_audit_workflow_fleet.py
+++ b/tests/test_audit_workflow_fleet.py
@@ -27,6 +27,7 @@ ALL_SECRETS = {
     "APP_PRIVATE_KEY",
 }
 ALL_VARIABLES = {"APP_ID"}
+ALL_LABELS = {"review:request", "review:skip", "review-budget-override"}
 COMMIT = "1" * 40
 BASE = "2" * 40
 
@@ -79,6 +80,7 @@ def apply_bundle(repo: Path, bundle: ReleaseBundle, profile) -> None:
         ALL_SECRETS,
         ALL_VARIABLES,
         bootstrap=False,
+        label_names=ALL_LABELS,
     )
     assert plan.status == "drift"
     apply_render_plan(repo, plan)
@@ -88,7 +90,8 @@ def test_audit_classifies_content_not_history(
     repo: Path, bundle: ReleaseBundle, profile
 ) -> None:
     result = audit_repository(
-        repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main"
+        repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main",
+        label_names=ALL_LABELS,
     )
     assert result.status == "drift"
     assert result.repo == "gstApp"
@@ -98,7 +101,8 @@ def test_audit_classifies_content_not_history(
     apply_bundle(repo, bundle, profile)
     assert (
         audit_repository(
-            repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main"
+            repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main",
+            label_names=ALL_LABELS,
         ).status
         == "current"
     )
@@ -107,7 +111,8 @@ def test_audit_classifies_content_not_history(
     )
     assert (
         audit_repository(
-            repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main"
+            repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main",
+            label_names=ALL_LABELS,
         ).status
         == "current"
     )
@@ -120,7 +125,8 @@ def test_audit_reports_managed_byte_mismatch_as_drift(
     managed = repo / ".github/workflows/claude.yml"
     managed.write_bytes(managed.read_bytes() + b"# drift\n")
     result = audit_repository(
-        repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main"
+        repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main",
+        label_names=ALL_LABELS,
     )
     assert result.status == "drift"
     assert ".github/workflows/claude.yml" in result.changed_paths
@@ -133,7 +139,8 @@ def test_audit_reports_unknown_or_malformed_content_as_blocked(
         "jobs:\n  call:\n    uses: jhw7500/automation/.github/workflows/claude.yml@v1.40\n"
     )
     result = audit_repository(
-        repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main"
+        repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main",
+        label_names=ALL_LABELS,
     )
     assert result == AuditResult(
         "gstApp",
@@ -148,7 +155,8 @@ def test_audit_reports_unknown_or_malformed_content_as_blocked(
         "automation_ref:\n  nested: value\n"
     )
     result = audit_repository(
-        repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main"
+        repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, base_branch="main",
+        label_names=ALL_LABELS,
     )
     assert result.status == "blocked"
     assert "automation_ref must be a scalar" in result.detail
@@ -157,7 +165,7 @@ def test_audit_reports_unknown_or_malformed_content_as_blocked(
 def test_audit_reports_missing_prerequisite_names_as_blocked(
     repo: Path, bundle: ReleaseBundle, profile
 ) -> None:
-    result = audit_repository(repo, bundle, profile, set(), set(), base_branch="main")
+    result = audit_repository(repo, bundle, profile, set(), set(), base_branch="main", label_names=ALL_LABELS)
     assert result.status == "blocked"
     assert "missing secrets" in result.detail
     assert "missing variables" in result.detail
@@ -203,6 +211,7 @@ def test_fleet_cli_audits_all_profiles_with_refetch_and_no_remote_write(
             frozenset(ALL_SECRETS),
             frozenset(ALL_VARIABLES),
             branch or "main",
+            label_names=ALL_LABELS,
         )
 
     def refetch(snapshot: RepositorySnapshot) -> str:
@@ -277,7 +286,7 @@ def test_fleet_cli_selects_repositories_and_blocks_only_on_blocked(
         path = root / repo
         path.mkdir()
         (path / ".git").mkdir()
-        return RepositorySnapshot(path, "main", BASE, frozenset(), frozenset(), branch or "main")
+        return RepositorySnapshot(path, "main", BASE, frozenset(), frozenset(), branch or "main", label_names=ALL_LABELS)
 
     with (
         mock.patch.object(
@@ -325,7 +334,8 @@ def test_selected_repository_audits_main_and_ported_and_ported_drift_prevents_al
         path.mkdir()
         (path / ".git").mkdir()
         return RepositorySnapshot(
-            path, "main", BASE, frozenset(ALL_SECRETS), frozenset(ALL_VARIABLES), branch or "main"
+            path, "main", BASE, frozenset(ALL_SECRETS), frozenset(ALL_VARIABLES), branch or "main",
+            label_names=ALL_LABELS,
         )
 
     def classify(path, _bundle, _profile, _secrets, _variables, *, base_branch, **_kwargs):
@@ -369,7 +379,8 @@ def test_target_clone_failure_blocks_only_the_exact_target_and_stays_in_totals(
         path.mkdir()
         (path / ".git").mkdir()
         return RepositorySnapshot(
-            path, "main", BASE, frozenset(ALL_SECRETS), frozenset(ALL_VARIABLES), "main"
+            path, "main", BASE, frozenset(ALL_SECRETS), frozenset(ALL_VARIABLES), "main",
+            label_names=ALL_LABELS,
         )
 
     with (
@@ -423,7 +434,8 @@ def test_unresolved_implicit_default_has_a_label_distinct_from_a_valid_branch_na
         path.mkdir()
         (path / ".git").mkdir()
         return RepositorySnapshot(
-            path, "main", BASE, frozenset(ALL_SECRETS), frozenset(ALL_VARIABLES), branch
+            path, "main", BASE, frozenset(ALL_SECRETS), frozenset(ALL_VARIABLES), branch,
+            label_names=ALL_LABELS,
         )
 
     with (
@@ -471,7 +483,8 @@ def test_target_refetch_failure_blocks_only_ported_and_keeps_main_visible(
         path.mkdir()
         (path / ".git").mkdir()
         return RepositorySnapshot(
-            path, "main", BASE, frozenset(ALL_SECRETS), frozenset(ALL_VARIABLES), branch or "main"
+            path, "main", BASE, frozenset(ALL_SECRETS), frozenset(ALL_VARIABLES), branch or "main",
+            label_names=ALL_LABELS,
         )
 
     def refetch(snapshot: RepositorySnapshot) -> str:
@@ -539,6 +552,7 @@ def test_inconsistent_resolved_targets_are_blocked_without_hiding_target_rows(
             frozenset(ALL_SECRETS),
             frozenset(ALL_VARIABLES),
             default_branch if branch is None else branch,
+            label_names=ALL_LABELS,
         )
 
     with (
@@ -587,3 +601,13 @@ def test_audit_git_wrapper_rejects_every_mutation_before_child(
         with pytest.raises(audit.FleetGitError, match="not permitted"):
             audit.git(args)
         child.assert_not_called()
+
+
+def test_audit_reports_missing_label_names_as_blocked(
+    repo: Path, bundle: ReleaseBundle, profile
+) -> None:
+    result = audit_repository(
+        repo, bundle, profile, ALL_SECRETS, ALL_VARIABLES, label_names=set(), base_branch="main",
+    )
+    assert result.status == "blocked"
+    assert result.detail == "missing labels: review-budget-override, review:request, review:skip"

--- a/tests/test_canonical_workflow_tree.py
+++ b/tests/test_canonical_workflow_tree.py
@@ -86,7 +86,7 @@ EXPECTED_TRIGGERS: dict[str, object] = {
         "issues": {"types": ["opened", "assigned"]},
     },
     "claude-code-review.yml": {
-        "pull_request": {"types": ["opened", "synchronize", "ready_for_review"]},
+        "pull_request": {"types": ["opened", "synchronize", "ready_for_review", "labeled"]},
         "workflow_dispatch": {
             "inputs": {
                 "pr_number": {
@@ -95,7 +95,7 @@ EXPECTED_TRIGGERS: dict[str, object] = {
                     "required": "true",
                 },
                 "force_review": {
-                    "description": "Perform one authorized same-HEAD review",
+                    "description": "Perform one authorized same-HEAD override round; requires the review-budget-override label",
                     "type": "boolean",
                     "required": "false",
                     "default": "false",
@@ -104,7 +104,7 @@ EXPECTED_TRIGGERS: dict[str, object] = {
         },
     },
     "gemini-auto-review.yml": {
-        "pull_request": {"types": ["opened", "synchronize", "ready_for_review"]},
+        "pull_request": {"types": ["opened", "synchronize", "ready_for_review", "labeled"]},
         "workflow_dispatch": {
             "inputs": {
                 "pr_number": {
@@ -113,7 +113,7 @@ EXPECTED_TRIGGERS: dict[str, object] = {
                     "required": "true",
                 },
                 "force_review": {
-                    "description": "Perform one authorized same-HEAD review",
+                    "description": "Perform one authorized same-HEAD override round; requires the review-budget-override label",
                     "type": "boolean",
                     "required": "false",
                     "default": "false",
@@ -255,7 +255,7 @@ EXPECTED_TRIGGERS: dict[str, object] = {
         "pull_request_review_comment": {"types": ["created"]},
     },
     "opencode-auto-review.yml": {
-        "pull_request": {"types": ["opened", "synchronize", "ready_for_review"]},
+        "pull_request": {"types": ["opened", "synchronize", "ready_for_review", "labeled"]},
         "workflow_dispatch": {
             "inputs": {
                 "pr_number": {
@@ -264,7 +264,7 @@ EXPECTED_TRIGGERS: dict[str, object] = {
                     "required": "true",
                 },
                 "force_review": {
-                    "description": "Perform one authorized same-HEAD review",
+                    "description": "Perform one authorized same-HEAD override round; requires the review-budget-override label",
                     "type": "boolean",
                     "required": "false",
                     "default": "false",
@@ -500,8 +500,9 @@ def test_auto_review_callers_forward_the_resolved_review_mode() -> None:
         job = caller["jobs"][job_name]
 
         assert caller["on"]["pull_request"]["types"] == [
-            "opened", "synchronize", "ready_for_review",
+            "opened", "synchronize", "ready_for_review", "labeled",
         ]
+        assert "(github.event.action != 'labeled' || github.event.label.name == 'review:request')" in " ".join(job["if"].split())
         assert " ".join(job["with"]["review_mode"].split()) == REVIEW_MODE_EXPRESSION
         assert "github.event.pull_request.draft == false" in job["if"]
 
@@ -517,8 +518,9 @@ def test_self_auto_review_callers_forward_label_review_mode() -> None:
         job = caller["jobs"][job_name]
 
         assert caller["on"]["pull_request"]["types"] == [
-            "opened", "synchronize", "ready_for_review",
+            "opened", "synchronize", "ready_for_review", "labeled",
         ]
+        assert "(github.event.action != 'labeled' || github.event.label.name == 'review:request')" in " ".join(job["if"].split())
         assert " ".join(job["with"]["review_mode"].split()) == REVIEW_MODE_EXPRESSION
         assert "github.event.pull_request.draft == false" in job["if"]
 

--- a/tests/test_ensure_review_labels.py
+++ b/tests/test_ensure_review_labels.py
@@ -117,3 +117,18 @@ def test_unknown_repository_and_malformed_inventory_fail_closed(fake_github, mon
     monkeypatch.setattr(workflow_fleet_git.subprocess, "run", broken_run)
     assert ensure.main(["--automation", str(ROOT), "--repo", "gstApp"]) == 1
     assert "ERROR gstApp:" in capsys.readouterr().out
+
+
+def test_a_full_label_page_fails_closed_instead_of_reporting_missing(fake_github, capsys) -> None:
+    """`gh label list` truncates newest-first, so a full page could hide the review labels."""
+
+    fake_github["labels"]["jhw7500/gstApp"] = [
+        {"name": f"label-{index}", "color": "000000", "description": ""} for index in range(300)
+    ]
+
+    assert ensure.main(["--automation", str(ROOT), "--repo", "gstApp", "--confirm"]) == 1
+
+    out = capsys.readouterr().out
+    assert "ERROR gstApp: GitHub label inventory exceeds the page limit" in out
+    assert "MISSING" not in out
+    assert fake_github["mutations"] == []

--- a/tests/test_ensure_review_labels.py
+++ b/tests/test_ensure_review_labels.py
@@ -1,0 +1,119 @@
+"""The operator script that creates the fleet's review labels (issue #115)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import ensure_review_labels as ensure
+from scripts import workflow_fleet_git
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STANDARD = [
+    {"name": "review:request", "color": "0E8A16", "description": "Explicitly request AI review"},
+    {"name": "review:skip", "color": "BFDADC", "description": "Explicitly skip AI review"},
+    {"name": "review-budget-override", "color": "D93F0B",
+     "description": "Authorize one bounded reviewer override round"},
+]
+
+
+def completed(args: list[str], stdout: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+
+@pytest.fixture
+def fake_github(monkeypatch: pytest.MonkeyPatch):
+    """Serve `gh label list` per repository and record every mutation."""
+
+    state: dict[str, object] = {"labels": {}, "mutations": []}
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert args[:2] == ["gh", "label"], args
+        repo = args[args.index("-R") + 1]
+        if args[2] == "list":
+            assert args[3:] == ["-R", repo, "--json", "name,color,description", "--limit", "300"]
+            return completed(args, json.dumps(state["labels"].get(repo, [])))
+        state["mutations"].append(args)
+        return completed(args)
+
+    monkeypatch.setattr(workflow_fleet_git.subprocess, "run", fake_run)
+    return state
+
+
+def test_current_repository_needs_no_mutation(fake_github, capsys) -> None:
+    fake_github["labels"]["jhw7500/gstApp"] = list(STANDARD)
+
+    assert ensure.main(["--automation", str(ROOT), "--repo", "gstApp"]) == 0
+
+    assert fake_github["mutations"] == []
+    assert "CURRENT gstApp: 3 review labels current" in capsys.readouterr().out
+
+
+def test_missing_labels_are_reported_and_fail_without_confirmation(fake_github, capsys) -> None:
+    fake_github["labels"]["jhw7500/gstApp"] = [STANDARD[0]]
+
+    assert ensure.main(["--automation", str(ROOT), "--repo", "gstApp"]) == 1
+
+    out = capsys.readouterr().out
+    assert "MISSING gstApp: review-budget-override, review:skip" in out
+    assert "SUMMARY repos=1 missing=2 drift=0 created=0 normalized=0" in out
+    assert fake_github["mutations"] == []
+
+
+def test_confirmed_run_creates_only_the_missing_labels(fake_github, capsys) -> None:
+    fake_github["labels"]["jhw7500/gstApp"] = [STANDARD[0]]
+
+    assert ensure.main(["--automation", str(ROOT), "--repo", "gstApp", "--confirm"]) == 0
+
+    assert fake_github["mutations"] == [
+        ["gh", "label", "create", "review-budget-override", "-R", "jhw7500/gstApp",
+         "--color", "D93F0B", "--description", "Authorize one bounded reviewer override round"],
+        ["gh", "label", "create", "review:skip", "-R", "jhw7500/gstApp",
+         "--color", "BFDADC", "--description", "Explicitly skip AI review"],
+    ]
+    assert "CREATED gstApp: review-budget-override, review:skip" in capsys.readouterr().out
+
+
+def test_drift_is_reported_but_only_normalized_on_request(fake_github, capsys) -> None:
+    drifted = dict(STANDARD[1], color="B60205")
+    fake_github["labels"]["jhw7500/gstApp"] = [STANDARD[0], drifted, STANDARD[2]]
+
+    assert ensure.main(["--automation", str(ROOT), "--repo", "gstApp", "--confirm"]) == 0
+    assert fake_github["mutations"] == []
+    assert "DRIFT gstApp: review:skip color=B60205 expected=BFDADC" in capsys.readouterr().out
+
+    assert ensure.main(["--automation", str(ROOT), "--repo", "gstApp", "--confirm", "--normalize"]) == 0
+    assert fake_github["mutations"] == [
+        ["gh", "label", "edit", "review:skip", "-R", "jhw7500/gstApp",
+         "--color", "BFDADC", "--description", "Explicitly skip AI review"],
+    ]
+    assert "NORMALIZED gstApp: review:skip" in capsys.readouterr().out
+
+
+def test_every_configured_repository_is_checked_once_by_default(fake_github, capsys) -> None:
+    fleet = ensure.configured_repositories(ROOT)
+    for repo in fleet:
+        fake_github["labels"][f"jhw7500/{repo}"] = list(STANDARD)
+
+    assert ensure.main(["--automation", str(ROOT)]) == 0
+
+    out = capsys.readouterr().out
+    assert len(fleet) == 16
+    assert out.count("CURRENT ") == 16
+    assert "SUMMARY repos=16 missing=0 drift=0 created=0 normalized=0" in out
+
+
+def test_unknown_repository_and_malformed_inventory_fail_closed(fake_github, monkeypatch, capsys) -> None:
+    with pytest.raises(SystemExit):
+        ensure.main(["--automation", str(ROOT), "--repo", "not-in-fleet"])
+
+    def broken_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return completed(args, "not json")
+
+    monkeypatch.setattr(workflow_fleet_git.subprocess, "run", broken_run)
+    assert ensure.main(["--automation", str(ROOT), "--repo", "gstApp"]) == 1
+    assert "ERROR gstApp:" in capsys.readouterr().out

--- a/tests/test_prepare_workflow_rollout.py
+++ b/tests/test_prepare_workflow_rollout.py
@@ -36,6 +36,7 @@ ALL_SECRETS = {
     "APP_PRIVATE_KEY",
 }
 ALL_VARIABLES = {"APP_ID"}
+ALL_LABELS = {"review:request", "review:skip", "review-budget-override"}
 
 
 def make_existing_repo(
@@ -62,6 +63,7 @@ def render_fixture(root: Path, *, auth: str) -> RenderPlan:
         COMMIT,
         ALL_SECRETS,
         ALL_VARIABLES,
+        label_names=ALL_LABELS,
     )
 
 
@@ -76,6 +78,7 @@ def render_existing(root: Path, *, config: bytes) -> RenderPlan:
         COMMIT,
         ALL_SECRETS,
         ALL_VARIABLES,
+        label_names=ALL_LABELS,
     )
 
 
@@ -90,6 +93,7 @@ def render_profile(repo: Path, name: str, *, bootstrap: bool = False) -> RenderP
         ALL_SECRETS,
         ALL_VARIABLES,
         bootstrap=bootstrap,
+        label_names=ALL_LABELS,
     )
 
 
@@ -370,6 +374,7 @@ def test_canonical_root_symlink_blocks_rendering(tmp_path: Path) -> None:
         COMMIT,
         ALL_SECRETS,
         ALL_VARIABLES,
+        label_names=ALL_LABELS,
     )
 
     assert plan.status == "blocked"
@@ -397,6 +402,7 @@ def test_canonical_intermediate_directory_symlink_blocks_rendering(
         COMMIT,
         ALL_SECRETS,
         ALL_VARIABLES,
+        label_names=ALL_LABELS,
     )
 
     assert plan.status == "blocked"
@@ -450,6 +456,7 @@ def test_rendered_config_must_still_be_valid_yaml(tmp_path: Path) -> None:
         COMMIT,
         ALL_SECRETS,
         ALL_VARIABLES,
+        label_names=ALL_LABELS,
     )
     assert plan.status == "blocked"
     assert plan.changes == ()
@@ -492,6 +499,7 @@ def test_missing_prerequisite_names_block_normal_repositories(tmp_path: Path) ->
         COMMIT,
         {"CLAUDE_CODE_OAUTH_TOKEN"},
         set(),
+        label_names=ALL_LABELS,
     )
     assert plan.status == "blocked"
     assert plan.changes == ()
@@ -519,6 +527,7 @@ def test_allowed_disabled_bootstrap_renders_required_callers_and_config_only(
         set(),
         set(),
         bootstrap=True,
+        label_names=ALL_LABELS,
     )
     assert plan.status == "bootstrap_required"
     paths = {change.path for change in plan.changes}
@@ -598,6 +607,7 @@ def test_provider_secret_values_never_enter_plan_bytes_repr_or_errors(
         COMMIT,
         set(sentinels),
         ALL_VARIABLES,
+        label_names=ALL_LABELS,
     )
     exposed = repr(plan) + plan.reason
     exposed += "".join(
@@ -617,6 +627,7 @@ def test_provider_secret_values_never_enter_plan_bytes_repr_or_errors(
             "not-a-commit",
             set(sentinels),
             ALL_VARIABLES,
+            label_names=ALL_LABELS,
         )
     assert not any(value in str(error.value) for value in sentinels.values())
 
@@ -747,3 +758,55 @@ def test_file_change_and_render_plan_are_immutable() -> None:
     assert plan.after(".github/workflows/x.yml") == b"x\n"
     with pytest.raises(dataclasses.FrozenInstanceError):
         change.after = b"y\n"  # type: ignore[misc]
+
+
+# --- issue #115: the opt-in labels are a fleet precondition, like secret and variable names ---
+
+
+def test_required_review_labels_are_the_fixed_fleet_contract() -> None:
+    from scripts.prepare_workflow_rollout import REQUIRED_REVIEW_LABELS, REQUIRED_REVIEW_LABEL_NAMES
+
+    assert [(label.name, label.color, label.description) for label in REQUIRED_REVIEW_LABELS] == [
+        ("review:request", "0E8A16", "Explicitly request AI review"),
+        ("review:skip", "BFDADC", "Explicitly skip AI review"),
+        ("review-budget-override", "D93F0B", "Authorize one bounded reviewer override round"),
+    ]
+    assert REQUIRED_REVIEW_LABEL_NAMES == frozenset(ALL_LABELS)
+
+
+def test_missing_label_names_block_normal_repositories(tmp_path: Path) -> None:
+    repo = make_existing_repo(tmp_path / "repo")
+    plan = render_repository(
+        repo,
+        CANONICAL,
+        CATALOG,
+        PROFILES["wlan-package"],
+        "v1.40",
+        COMMIT,
+        ALL_SECRETS,
+        ALL_VARIABLES,
+        label_names={"review:request"},
+    )
+    assert plan.status == "blocked"
+    assert plan.changes == ()
+    assert plan.required_labels == frozenset(ALL_LABELS)
+    assert plan.reason == "missing labels: review-budget-override, review:skip"
+
+
+def test_missing_label_names_are_non_blocking_for_explicit_bootstrap(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / ".github/workflows").mkdir(parents=True)
+    plan = render_repository(
+        repo,
+        CANONICAL,
+        CATALOG,
+        PROFILES["wpa-supplicant"],
+        "v1.40",
+        COMMIT,
+        ALL_SECRETS,
+        ALL_VARIABLES,
+        label_names=set(),
+        bootstrap=True,
+    )
+    assert plan.status == "bootstrap_required"
+    assert "non-blocking prerequisites: missing labels: review-budget-override, review:request, review:skip" in plan.reason

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -17646,3 +17646,43 @@ def test_filtered_findings_reach_the_run_summary(workflow, job, name):
     assert '[[ "$FILTERED_REASONS" =~ ^[a-z_]+(,[a-z_]+)*$ ]]' in step["run"]
     assert '>> "$GITHUB_STEP_SUMMARY"' in step["run"]
     assert "filtered-count != '0'" in step["if"]
+
+
+# --- v1.64: the request label starts a review on an already-open pull request (issue #111) ---
+
+REVIEW_CALLERS = (
+    ("examples/baseline-workflows/.github/workflows/claude-code-review.yml", "claude-review"),
+    ("examples/baseline-workflows/.github/workflows/gemini-auto-review.yml", "gemini-review"),
+    ("examples/baseline-workflows/.github/workflows/opencode-auto-review.yml", "opencode-review"),
+    (".github/workflows/_self-claude-review.yml", "claude-review"),
+    (".github/workflows/_self-gemini-auto-review.yml", "gemini-review"),
+    (".github/workflows/_self-opencode-auto-review.yml", "opencode-review"),
+)
+LABELED_GUARD = "(github.event.action != 'labeled' || github.event.label.name == 'review:request')"
+FORCE_REVIEW_DESCRIPTION = (
+    "Perform one authorized same-HEAD override round; requires the review-budget-override label"
+)
+
+
+@pytest.mark.parametrize(("path", "job"), REVIEW_CALLERS)
+def test_review_callers_start_on_the_request_label_only(path, job):
+    """`labeled` must start a run for `review:request` alone, so unrelated labels add no runs."""
+
+    document = yaml.load((ROOT / path).read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+    assert document["on"]["pull_request"]["types"] == [
+        "opened", "synchronize", "ready_for_review", "labeled",
+    ]
+    condition = " ".join(document["jobs"][job]["if"].split())
+    assert LABELED_GUARD in condition
+    assert condition.index("github.event.pull_request.draft == false") < condition.index(LABELED_GUARD)
+    assert condition.index(LABELED_GUARD) < condition.index("github.event_name == 'workflow_dispatch'")
+
+
+@pytest.mark.parametrize(("path", "job"), REVIEW_CALLERS)
+def test_review_callers_describe_force_review_as_the_override_round(path, job):
+    document = yaml.load((ROOT / path).read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    inputs = document["on"]["workflow_dispatch"]["inputs"]
+
+    assert inputs["force_review"]["description"] == FORCE_REVIEW_DESCRIPTION
+    assert inputs["force_review"]["default"] == "false"

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -33,6 +33,7 @@ ALL_SECRETS = frozenset(
     {"CLAUDE_CODE_OAUTH_TOKEN", "GEMINI_API_KEY", "ZHIPU_API_KEY", "APP_PRIVATE_KEY"}
 )
 ALL_VARIABLES = frozenset({"APP_ID"})
+ALL_LABELS = frozenset({"review:request", "review:skip", "review-budget-override"})
 CATALOG = load_catalog(ROOT)
 
 
@@ -660,6 +661,7 @@ def test_plan_prevalidates_all_repositories_and_never_enters_publish(
     assert all(item["release_commit"] == COMMIT for item in report)
     assert report[0]["observed_base"] == BASE
     assert report[0]["required_secrets"] == ["CLAUDE_CODE_OAUTH_TOKEN"]
+    assert report[0]["required_labels"] == ["review-budget-override", "review:request", "review:skip"]
     assert report[0]["managed_diff_paths"] == [".github/workflows/claude.yml"]
 
 
@@ -1219,7 +1221,7 @@ def snapshot(tmp_path: Path) -> RepositorySnapshot:
     (repo / ".github/workflows").mkdir(parents=True)
     (repo / ".git").mkdir()
     (repo / ".github/workflows/a.yml").write_bytes(b"new\n")
-    return RepositorySnapshot(repo, "main", BASE, ALL_SECRETS, ALL_VARIABLES)
+    return RepositorySnapshot(repo, "main", BASE, ALL_SECRETS, ALL_VARIABLES, label_names=ALL_LABELS)
 
 
 def exact_pr(
@@ -1519,7 +1521,7 @@ def initialized_repository(tmp_path: Path) -> tuple[RepositorySnapshot, RenderPl
             for entry in CATALOG.entries
         ),
     )
-    return RepositorySnapshot(repo, "main", base, frozenset(), frozenset()), plan
+    return RepositorySnapshot(repo, "main", base, frozenset(), frozenset(), label_names=ALL_LABELS), plan
 
 
 def initialized_canonical_fleet_repository(
@@ -1541,6 +1543,7 @@ def initialized_canonical_fleet_repository(
         bundle.commit,
         set(ALL_SECRETS),
         set(ALL_VARIABLES),
+        label_names=ALL_LABELS,
     )
     assert initial.status == "drift"
     apply_render_plan(repo, initial)
@@ -1561,7 +1564,8 @@ def initialized_canonical_fleet_repository(
         stdout=subprocess.PIPE,
     ).stdout.strip()
     return RepositorySnapshot(
-        repo, "main", base, ALL_SECRETS, ALL_VARIABLES
+        repo, "main", base, ALL_SECRETS, ALL_VARIABLES,
+        label_names=ALL_LABELS,
     )
 
 
@@ -1673,7 +1677,8 @@ def test_real_rollout_repairs_content_and_separate_mode_drift_and_attests_all_ma
     )
     base = commit_managed_fixture(snap.path, "content and mode drift")
     snap = RepositorySnapshot(
-        snap.path, snap.default_branch, base, snap.secret_names, snap.variable_names
+        snap.path, snap.default_branch, base, snap.secret_names, snap.variable_names,
+        label_names=ALL_LABELS,
     )
     assert tree_entry(snap.path, base, mode_path)[:2] == ("100755", "blob")
 
@@ -1704,7 +1709,8 @@ def test_real_mode_only_drift_is_planned_audited_and_published_as_a_repair(
     )
     base = commit_managed_fixture(snap.path, "mode-only drift")
     snap = RepositorySnapshot(
-        snap.path, snap.default_branch, base, snap.secret_names, snap.variable_names
+        snap.path, snap.default_branch, base, snap.secret_names, snap.variable_names,
+        label_names=ALL_LABELS,
     )
 
     plan = rollout._render(snap, bundle, snap.path.name, bootstrap=False)
@@ -1715,6 +1721,7 @@ def test_real_mode_only_drift_is_planned_audited_and_published_as_a_repair(
         set(snap.secret_names),
         set(snap.variable_names),
         observed_revision=base,
+        label_names=ALL_LABELS,
     )
 
     assert plan.status == "drift"
@@ -1816,7 +1823,8 @@ def test_real_tracked_nonregular_managed_entry_blocks_before_checkout_bytes_are_
         )
         base = commit_managed_fixture(snap.path, f"{object_type} type drift")
     snap = RepositorySnapshot(
-        snap.path, snap.default_branch, base, snap.secret_names, snap.variable_names
+        snap.path, snap.default_branch, base, snap.secret_names, snap.variable_names,
+        label_names=ALL_LABELS,
     )
     assert tree_entry(snap.path, base, relative)[:2] == (mode, object_type)
     # Deliberately leave canonical regular bytes in the checkout: only the observed
@@ -1865,7 +1873,8 @@ def test_real_tracked_nonregular_managed_ancestor_blocks_before_checkout_scan(
         oid,
     )
     snap = RepositorySnapshot(
-        snap.path, snap.default_branch, base, snap.secret_names, snap.variable_names
+        snap.path, snap.default_branch, base, snap.secret_names, snap.variable_names,
+        label_names=ALL_LABELS,
     )
     assert tree_entry(snap.path, base, workflows)[:2] == (mode, object_type)
     assert (snap.path / ".github/workflows/claude.yml").is_file()
@@ -2318,6 +2327,7 @@ def test_managed_result_passes_yaml_catalog_diff_and_local_actionlint_gates(
         set(ALL_SECRETS),
         set(ALL_VARIABLES),
         bootstrap=False,
+        label_names=ALL_LABELS,
     )
     assert plan.status == "drift"
 
@@ -2744,3 +2754,17 @@ def test_git_wrapper_rejects_forbidden_commands_before_child(
         with pytest.raises(rollout.CommandError, match="not permitted"):
             rollout.git(args)
         child.assert_not_called()
+
+
+def test_render_blocks_when_a_required_label_is_missing(tmp_path: Path, bundle) -> None:
+    snap = initialized_canonical_fleet_repository(tmp_path, bundle)
+    snap = RepositorySnapshot(
+        snap.path, snap.default_branch, snap.base_sha, snap.secret_names, snap.variable_names,
+        base_branch=snap.base_branch, label_names=frozenset({"review:request", "review:skip"}),
+    )
+
+    plan = rollout._render(snap, bundle, snap.path.name, bootstrap=False)
+
+    assert plan.status == "blocked"
+    assert plan.changes == ()
+    assert plan.reason == "missing labels: review-budget-override"

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -28,6 +28,7 @@ from release_fixture_helpers import (
     restore_historical_review_workflows,
     restore_pre_force_review_callers,
     restore_pre_v151_review_policy,
+    restore_pre_v164_label_trigger,
     restore_v145_review_workflows,
 )
 
@@ -233,6 +234,7 @@ def current_release_repo(tmp_path: Path) -> tuple[Path, str]:
             shutil.copytree(source, target)
         else:
             shutil.copy2(source, target)
+    restore_pre_v164_label_trigger(repo)
     restore_pre_v163_finding_dismissal(repo)
     restore_pre_v151_review_policy(repo)
     restore_pre_v160_round_budget(repo)
@@ -269,6 +271,7 @@ def v1462_release_repo(tmp_path: Path) -> tuple[Path, str]:
             shutil.copytree(source, target)
         else:
             shutil.copy2(source, target)
+    restore_pre_v164_label_trigger(repo)
     restore_pre_v163_finding_dismissal(repo)
     restore_v1462_workflow_fixtures(repo)
     restore_pre_v162_filter_surface(repo)
@@ -513,6 +516,7 @@ def copy_review_policy_release_files(repo: Path) -> None:
 
 def prepare_v151(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v164_label_trigger(repo)
     restore_pre_v163_finding_dismissal(repo)
     restore_pre_v162_filter_surface(repo)
     restore_pre_v161_cancel_guard(repo)
@@ -523,6 +527,7 @@ def prepare_v151(repo: Path) -> str:
 
 def prepare_v159(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v164_label_trigger(repo)
     restore_pre_v163_finding_dismissal(repo)
     restore_pre_v162_filter_surface(repo)
     restore_pre_v161_cancel_guard(repo)
@@ -533,6 +538,7 @@ def prepare_v159(repo: Path) -> str:
 
 def prepare_v160(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v164_label_trigger(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
@@ -1962,6 +1968,7 @@ def test_v159_opt_in_helper_is_rejected_on_the_v151_release_line(
 
 def prepare_v162(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v164_label_trigger(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
@@ -1975,6 +1982,7 @@ def prepare_v162(repo: Path) -> str:
 
 def prepare_v163(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v164_label_trigger(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
@@ -1983,6 +1991,47 @@ def prepare_v163(repo: Path) -> str:
     ):
         shutil.copy2(ROOT / relative, repo / relative)
     return commit(repo, "v1.63 candidate")
+
+
+def prepare_v164(repo: Path) -> str:
+    copy_review_policy_release_files(repo)
+    for relative in (
+        ".github/actions/review-invocation-budget/action.yml",
+        ".github/actions/review-invocation-budget/review_invocation_budget.py",
+        ".github/actions/canonicalize-review/action.yml",
+        ".github/actions/canonicalize-review/canonicalize_review.py",
+    ):
+        shutil.copy2(ROOT / relative, repo / relative)
+    return commit(repo, "v1.64 candidate")
+
+
+def test_v164_accepts_current_label_trigger_release_contract(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v164(repo)
+
+    assert release_verifier.verify_commit_content(repo, "v1.64", candidate) == candidate
+
+
+def test_v164_label_trigger_is_rejected_on_the_v163_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v164(repo)
+
+    with pytest.raises(ReleaseVerificationError, match="review-policy caller"):
+        release_verifier.verify_commit_content(repo, "v1.63", candidate)
+
+
+def test_pre_v164_callers_are_rejected_on_the_v164_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v163(repo)
+
+    with pytest.raises(ReleaseVerificationError, match="review-policy caller"):
+        release_verifier.verify_commit_content(repo, "v1.64", candidate)
 
 
 def test_v163_accepts_current_finding_dismissal_release_contract(
@@ -2045,6 +2094,7 @@ def test_pre_v162_filter_surface_is_rejected_on_the_v162_release_line(
 
 def prepare_v161(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v164_label_trigger(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",
         ".github/actions/review-invocation-budget/review_invocation_budget.py",

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -80,7 +80,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     }
     for entry in callers.values():
         assert entry.trigger["pull_request"]["types"] == [
-            "opened", "synchronize", "ready_for_review",
+            "opened", "synchronize", "ready_for_review", "labeled",
         ]
         assert "review_mode" in entry.caller_jobs[0].with_keys
 

--- a/tests/test_workflow_fleet_git.py
+++ b/tests/test_workflow_fleet_git.py
@@ -336,6 +336,8 @@ def test_clone_reads_only_metadata_and_prerequisite_names(
             return completed(args, '[{"name":"CLAUDE_CODE_OAUTH_TOKEN"}]')
         if args[:3] == ["gh", "variable", "list"]:
             return completed(args, '[{"name":"APP_ID"}]')
+        if args[:3] == ["gh", "label", "list"]:
+            return completed(args, '[{"name":"review:request"}]')
         payload = git_payload(args)
         if payload[0] == "clone":
             Path(payload[-1]).mkdir()
@@ -361,6 +363,7 @@ def test_clone_reads_only_metadata_and_prerequisite_names(
         secret_names=frozenset({"CLAUDE_CODE_OAUTH_TOKEN"}),
         variable_names=frozenset({"APP_ID"}),
         base_branch="main",
+        label_names=frozenset({"review:request"}),
     )
     clone = next(
         git_payload(args) for args, _ in calls if args[0] == "git" and "clone" in args
@@ -402,6 +405,17 @@ def test_clone_reads_only_metadata_and_prerequisite_names(
             "--json",
             "name",
         ],
+        [
+            "gh",
+            "label",
+            "list",
+            "-R",
+            "jhw7500/wlan-package",
+            "--json",
+            "name",
+            "--limit",
+            "300",
+        ],
     ]
 
 
@@ -423,7 +437,7 @@ def test_clone_branch_retains_repository_default_and_selected_base(
                     }
                 ),
             )
-        if args[:3] in (["gh", "secret", "list"], ["gh", "variable", "list"]):
+        if args[:3] in (["gh", "secret", "list"], ["gh", "variable", "list"], ["gh", "label", "list"]):
             return completed(args, "[]")
         payload = git_payload(args)
         if payload[0] == "clone":
@@ -1549,3 +1563,85 @@ def test_adapter_exposes_no_merge_revert_or_prerequisite_write_api() -> None:
         "refetch_default",
         "remote_branch_sha",
     }
+
+
+def test_clone_reads_label_names_with_the_prerequisite_inventory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Labels are read like secret and variable names: names only, with a page limit."""
+
+    root = workspace(tmp_path)
+    label_calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "repo", "view"]:
+            return completed(args, json.dumps({
+                "defaultBranchRef": {"name": "main"},
+                "url": "https://github.com/jhw7500/wlan-package",
+            }))
+        if args[:3] == ["gh", "secret", "list"]:
+            return completed(args, '[{"name":"CLAUDE_CODE_OAUTH_TOKEN"}]')
+        if args[:3] == ["gh", "variable", "list"]:
+            return completed(args, '[{"name":"APP_ID"}]')
+        if args[:3] == ["gh", "label", "list"]:
+            label_calls.append(args)
+            return completed(args, '[{"name":"review:request"},{"name":"bug"}]')
+        payload = git_payload(args)
+        if payload[0] == "clone":
+            Path(payload[-1]).mkdir()
+            (Path(payload[-1]) / ".git").mkdir()
+            return completed(args)
+        if payload in [
+            ["remote", "get-url", "--all", "origin"],
+            ["remote", "get-url", "--push", "--all", "origin"],
+        ]:
+            return completed(args, "https://github.com/jhw7500/wlan-package.git\n")
+        if payload == ["rev-parse", "HEAD"]:
+            return completed(args, f"{SHA}\n")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(workflow_fleet_git.subprocess, "run", fake_run)
+
+    result = workflow_fleet_git.clone_default_branch("jhw7500", "wlan-package", root)
+
+    assert result.label_names == frozenset({"review:request", "bug"})
+    assert label_calls == [[
+        "gh", "label", "list", "-R", "jhw7500/wlan-package", "--json", "name", "--limit", "300",
+    ]]
+
+
+def test_clone_fails_closed_when_the_label_page_is_full(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`gh label list` truncates newest-first, so a full page could hide the review labels."""
+
+    root = workspace(tmp_path)
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "repo", "view"]:
+            return completed(args, json.dumps({
+                "defaultBranchRef": {"name": "main"},
+                "url": "https://github.com/jhw7500/wlan-package",
+            }))
+        if args[:3] in (["gh", "secret", "list"], ["gh", "variable", "list"]):
+            return completed(args, "[]")
+        if args[:3] == ["gh", "label", "list"]:
+            return completed(args, json.dumps([{"name": f"label-{index}"} for index in range(300)]))
+        payload = git_payload(args)
+        if payload[0] == "clone":
+            Path(payload[-1]).mkdir()
+            (Path(payload[-1]) / ".git").mkdir()
+            return completed(args)
+        if payload in [
+            ["remote", "get-url", "--all", "origin"],
+            ["remote", "get-url", "--push", "--all", "origin"],
+        ]:
+            return completed(args, "https://github.com/jhw7500/wlan-package.git\n")
+        if payload == ["rev-parse", "HEAD"]:
+            return completed(args, f"{SHA}\n")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(workflow_fleet_git.subprocess, "run", fake_run)
+
+    with pytest.raises(workflow_fleet_git.FleetGitError, match="label inventory exceeds the page limit"):
+        workflow_fleet_git.clone_default_branch("jhw7500", "wlan-package", root)


### PR DESCRIPTION
## Summary

v1.64 bundles #111 and #115, the two gaps left by the v1.59 opt-in switch.

- **#111 `labeled` trigger** — the six review callers (3 baseline consumer callers + 3 self callers) subscribe to `labeled`, guarded so only `review:request` starts a run (`github.event.action != 'labeled' || github.event.label.name == 'review:request'`). Adding the label to an already-open, non-draft PR now reviews its head without a new commit, ready transition, or dispatch. Reusable workflows, resolver and budget are unchanged. A disposable probe (PR #129, closed) confirmed the `labeled` payload carries the updated label list, so `review_mode` resolves to `request`.
  - Documented, not special-cased: `review:skip` + `review:request` → `review_label_conflict` (remove skip first); an already-reviewed head → `duplicate_head` (override round remains the same-head re-review); drafts start nothing until ready.
  - `force_review` description → "Perform one authorized same-HEAD override round; requires the review-budget-override label".
- **#115 label precondition** — `REQUIRED_REVIEW_LABELS` (3, fixed) next to the required secret/variable names; the fleet snapshot reads label names (`gh label list --limit 300`); plan/publish/audit block on `missing labels: …` (name only; drift never blocks; non-blocking for explicit bootstrap); manifest records `required_labels`. New `scripts/ensure_review_labels.py` reports, creates (`--confirm`) and normalizes (`--confirm --normalize`). Live run before this PR: **16/16 CURRENT**.
- **Verifier** — `release_supports_label_review_trigger` (v1.64); `_verify_review_policy_callers(tree, ref)` branches on it; `restore_pre_v164_label_trigger` (idempotent, newest-first) keeps v1.51–v1.63 verifying.
- **Docs** — `contracts.md` opt-in section, `workflow-fleet-rollout.md` "Review labels".

## Design review

Approach-level critic pass before implementation (see the design note in the session): the `labeled` mechanism was kept over the issue's simpler options because a `workflow_dispatch` path requires `force_review`, which the budget refuses without the override label even on a first review (`claim()`), and documentation alone left the draft round-trip in place. Required labels stay at three (issue author's explicit scope); drift is reported by the ensure script, not blocked.

## Verification

- Gating: v1.64 accepted; v1.64 callers rejected on the v1.63 line; v1.63 callers rejected on the v1.64 line; v1.51/v1.59/v1.60/v1.61/v1.62/v1.63 pass.
- Full suite on the frozen tree: see the commit message / PR checks; the only local failures are the 2 pre-existing `umask 0002` mode assertions.
- `actionlint 1.7.12 -shellcheck= -pyflakes=` (CI invocation) clean.
- Independent code-review pass (Opus) addressed before opening this PR.

## Release note

Caller bytes changed, so the 17-target rollout PRs carry a real diff this time (trigger types, guard, description). v1.64 tag + rollout + bump follow after merge.

Closes #111, closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnEJTjxEwdMh5sPkeVZYzy
