### PR TITLE
chore(workflows): default rollout to v1.64

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.63",
+  "automation_ref": "v1.64",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.63"
+    assert config.automation_ref == "v1.64"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
Move the default rollout ref from `v1.63` to `v1.64` now that every fleet target is on the new release.

## Evidence

- Tag `v1.64` → commit `311278d`, annotated tag object `9e02281291abe4ca4245cd29c236435d97470d9f`. `verify_release` passes against `origin`; the pre-tag check passes for `v1.64` and **fails** for `v1.63` (`review-policy caller contract is invalid`), so the gate reads the new caller bytes rather than passing everything.
- Rollout: 17 planned, 17 published, 17 merged, 0 blocked.
- Audit: `ref=v1.64 commit=311278d total=17 current=17 drift=0 blocked=0`.
- Review labels: `ensure_review_labels.py` reports `repos=16 missing=0 drift=0` across the fleet, satisfying the new precondition.

## What v1.64 ships

- **#111** — the six review callers subscribe to `labeled` and guard on `github.event.label.name == 'review:request'`, so adding the label to an already-open pull request starts a review instead of silently doing nothing. Confirmed live on #130: the label landed at 07:44:04Z and three review runs started at 07:44:08Z.
- **#115** — the rollout tooling refuses to plan, publish, or audit a repository missing `review:request`, `review:skip`, or `review-budget-override`, the manifest records `required_labels`, and `scripts/ensure_review_labels.py` reports, creates, and normalizes them.

Refs #111, #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnEJTjxEwdMh5sPkeVZYzy
