### PR TITLE
fix(review): make a declined review say why, and let the manual Claude path be diagnosed

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1184,7 +1184,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notice
+        # 이 잡은 두 가지 이유로 돌 수 있으므로 하나로 단정하지 않는다. enabled 는
+        # workflow-config.yml 이 끈 경우이고, policy_reason 은 리졸버가 내는 고정
+        # 어휘라 비신뢰 텍스트가 아니다. 정규식이 어휘 밖 값을 막고, 매핑에 없는
+        # 값은 사유를 그대로 보여 준다.
+        env:
+          WORKFLOW_ENABLED: ${{ needs.check-enabled.outputs.enabled }}
+          POLICY_REASON: ${{ needs.check-enabled.outputs.policy_reason }}
         run: |
-          echo "::notice::Claude Code Review workflow is disabled in .github/workflow-config.yml"
-          echo "## Workflow Skipped" >> $GITHUB_STEP_SUMMARY
-          echo "Claude Code Review is disabled in workflow-config.yml" >> $GITHUB_STEP_SUMMARY
+          set -euo pipefail
+          [[ "$POLICY_REASON" =~ ^[a-z_]*$ ]]
+          if [[ "$WORKFLOW_ENABLED" != "true" ]]; then
+            detail="claude-code-review is disabled in .github/workflow-config.yml"
+          else
+            case "$POLICY_REASON" in
+              default_auto_false|workflow_auto_false|review_auto_false)
+                detail="automatic review is off for this repository; add the review:request label to run one" ;;
+              skip) detail="the review:skip label is present" ;;
+              draft) detail="the pull request is a draft" ;;
+              closed) detail="the pull request is not open" ;;
+              unsafe_pr) detail="the pull request head is not in this repository" ;;
+              workflow_disabled) detail="claude-code-review is disabled in .github/workflow-config.yml" ;;
+              "") detail="the review policy produced no reason; see the Check if enabled job" ;;
+              *) detail="the review policy declined with reason $POLICY_REASON" ;;
+            esac
+          fi
+          echo "::notice::Claude Code Review did not run because $detail"
+          {
+            printf '## Workflow Skipped\n'
+            printf 'Claude Code Review did not run because %s.\n' "$detail"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,6 +69,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Off by default. This path takes the trigger comment as its prompt and
+          # pins no allowed-tools list, so full output is opt-in per repository:
+          # set the CLAUDE_DEBUG (or ACTIONS_STEP_DEBUG) variable to reproduce a
+          # failure. Without it a failed run reports only its duration.
+          show_full_output: ${{ vars.CLAUDE_DEBUG == 'true' || vars.ACTIONS_STEP_DEBUG == 'true' }}
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read

--- a/.github/workflows/gemini-auto-review.yml
+++ b/.github/workflows/gemini-auto-review.yml
@@ -2005,7 +2005,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notice
+        # 이 잡은 두 가지 이유로 돌 수 있으므로 하나로 단정하지 않는다. enabled 는
+        # workflow-config.yml 이 끈 경우이고, policy_reason 은 리졸버가 내는 고정
+        # 어휘라 비신뢰 텍스트가 아니다. 정규식이 어휘 밖 값을 막고, 매핑에 없는
+        # 값은 사유를 그대로 보여 준다.
+        env:
+          WORKFLOW_ENABLED: ${{ needs.check-enabled.outputs.enabled }}
+          POLICY_REASON: ${{ needs.check-enabled.outputs.policy_reason }}
         run: |
-          echo "::notice::Gemini Auto PR Review workflow is disabled in .github/workflow-config.yml"
-          echo "## Workflow Skipped" >> $GITHUB_STEP_SUMMARY
-          echo "Gemini Auto PR Review is disabled in workflow-config.yml" >> $GITHUB_STEP_SUMMARY
+          set -euo pipefail
+          [[ "$POLICY_REASON" =~ ^[a-z_]*$ ]]
+          if [[ "$WORKFLOW_ENABLED" != "true" ]]; then
+            detail="gemini-auto-review is disabled in .github/workflow-config.yml"
+          else
+            case "$POLICY_REASON" in
+              default_auto_false|workflow_auto_false|review_auto_false)
+                detail="automatic review is off for this repository; add the review:request label to run one" ;;
+              skip) detail="the review:skip label is present" ;;
+              draft) detail="the pull request is a draft" ;;
+              closed) detail="the pull request is not open" ;;
+              unsafe_pr) detail="the pull request head is not in this repository" ;;
+              workflow_disabled) detail="gemini-auto-review is disabled in .github/workflow-config.yml" ;;
+              "") detail="the review policy produced no reason; see the Check if enabled job" ;;
+              *) detail="the review policy declined with reason $POLICY_REASON" ;;
+            esac
+          fi
+          echo "::notice::Gemini Auto PR Review did not run because $detail"
+          {
+            printf '## Workflow Skipped\n'
+            printf 'Gemini Auto PR Review did not run because %s.\n' "$detail"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -261,6 +261,34 @@ settings; a custom cloud environment is not required, because the default `unive
 review. An unregistered repository either answers a mention with "create an environment for this
 repo" or stays silent, and no review appears.
 
+### Why a managed reviewer did not run
+
+From `v1.65` the `skipped` job of `claude-code-review.yml` and `gemini-auto-review.yml` names the
+reason instead of always citing `workflow-config.yml`. It reads the `enabled` and `policy_reason`
+outputs of `check-enabled` through the environment, rejects anything outside the resolver's fixed
+`^[a-z_]*$` vocabulary, and reports:
+
+| Condition | Reported as |
+| --- | --- |
+| `enabled` is not `true` | disabled in `.github/workflow-config.yml` |
+| `default_auto_false`, `workflow_auto_false`, `review_auto_false` | automatic review is off; add the `review:request` label |
+| `skip` | the `review:skip` label is present |
+| `draft` | the pull request is a draft |
+| `closed` | the pull request is not open |
+| `unsafe_pr` | the head is not in this repository |
+| empty | no reason was produced; read the `Check if enabled` job |
+| anything else | the reason verbatim |
+
+Since reviews became opt-in a decline is the ordinary path, so the notice is the first place a
+person looks. Before `v1.65` every one of these said the workflow was disabled in
+`workflow-config.yml`, which sent them to a file whose contents were already correct.
+
+`opencode-auto-review.yml` keeps its own wording and is not part of this contract.
+
+The `skipped` job's `if:` condition is unchanged: it still covers both causes, and the release
+verifier requires it to keep testing `policy_run != 'true'`.
+
+
 ## Deterministic automated-review input
 
 Claude, Gemini, and OpenCode call the same composite action:

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -261,6 +261,22 @@ settings; a custom cloud environment is not required, because the default `unive
 review. An unregistered repository either answers a mention with "create an environment for this
 repo" or stays silent, and no review appears.
 
+### When to add the label
+
+`review:request` may be added to an already-open pull request from `v1.64`, but not while the
+`opened` runs are still resolving. Those runs were triggered without the label, so `REVIEW_MODE`
+is `auto` for them; if the resolver reads the pull request after the label lands, trigger-time and
+read-time disagree and the `v1.51` guard fails the `Check if enabled` job closed with
+`review_mode_label_mismatch`. Every reviewer triggered by the same event fails together, and a
+re-run reproduces it because the replayed payload still carries the original mode.
+
+Label after the `opened` runs reach a conclusion, or open the pull request as a draft, label it,
+and then mark it ready. The `labeled` run itself is unaffected: it is triggered with the label
+present, so trigger-time and read-time agree.
+
+A run that failed this way reviewed nothing. The verdict for that head comes from the `labeled`
+run, not from the failed one.
+
 ### Why a managed reviewer did not run
 
 From `v1.65` the `skipped` job of `claude-code-review.yml` and `gemini-auto-review.yml` names the

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -51,6 +51,7 @@ from scripts.workflow_release_inventory import (
     release_supports_filter_reason_surface,
     release_supports_finding_dismissal,
     release_supports_label_review_trigger,
+    release_supports_skip_reason_notice,
     release_supports_same_head_cancel_guard,
     release_supports_review_policy,
     validate_release_listing,
@@ -774,6 +775,11 @@ EXPECTED_SAME_HEAD_CANCEL_WORKFLOW_SHA256 = {
 EXPECTED_FINDING_DISMISSAL_WORKFLOW_SHA256 = {
     "claude": "b32973a2434b7f3314c26d764f91715fc5f0770b5c26be6c2327212457f54ae2",
     "gemini": "3ea5ef5d0c3f05beadb4fbf6dcf605840286b603123a5dac918cec3bd92414fe",
+    "opencode": "4a173036252929de6320da7e04436d67b9a4759ed4b9f60b6bdf2b3a3ecc1d5a",
+}
+EXPECTED_SKIP_REASON_WORKFLOW_SHA256 = {
+    "claude": "4fe4bf0be84f3b155ec948d6628bf557babb6fff6bdc05ce2344d72c208a4a53",
+    "gemini": "c05f48186aefe8058fd26c4084f51202cc52649a3c97f853b85bae34335e1882",
     "opencode": "4a173036252929de6320da7e04436d67b9a4759ed4b9f60b6bdf2b3a3ecc1d5a",
 }
 EXPECTED_REVIEW_POLICY_HELPER_SHA256 = (
@@ -5878,7 +5884,9 @@ def _verify_review_invocation_budget(
         ),
     }
     workflow_digests = (
-        EXPECTED_FINDING_DISMISSAL_WORKFLOW_SHA256
+        EXPECTED_SKIP_REASON_WORKFLOW_SHA256
+        if release_supports_skip_reason_notice(ref)
+        else EXPECTED_FINDING_DISMISSAL_WORKFLOW_SHA256
         if dismissals
         else EXPECTED_FILTER_REASON_WORKFLOW_SHA256
         if release_supports_filter_reason_surface(ref)

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -153,6 +153,7 @@ SAME_HEAD_CANCEL_RELEASE = (1, 61)
 FILTER_REASON_SURFACE_RELEASE = (1, 62)
 FINDING_DISMISSAL_RELEASE = (1, 63)
 LABEL_REVIEW_TRIGGER_RELEASE = (1, 64)
+SKIP_REASON_NOTICE_RELEASE = (1, 65)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -219,6 +220,12 @@ def release_supports_label_review_trigger(ref: str) -> bool:
     """Return whether ``ref``'s managed callers start a review when `review:request` is added."""
 
     return _release_version(ref) >= LABEL_REVIEW_TRIGGER_RELEASE
+
+
+def release_supports_skip_reason_notice(ref: str) -> bool:
+    """Return whether ``ref``'s skipped notices name the reason the review declined."""
+
+    return _release_version(ref) >= SKIP_REASON_NOTICE_RELEASE
 
 
 def release_roots_for(ref: str) -> tuple[ReleaseRoot, ...]:

--- a/tests/release_fixture_helpers.py
+++ b/tests/release_fixture_helpers.py
@@ -97,6 +97,7 @@ def restore_pre_v164_label_trigger(repo: Path) -> None:
 def restore_pre_v151_review_policy_callers(repo: Path) -> None:
     """Remove only the v1.51 caller policy surface from historical fixtures."""
 
+    restore_pre_v165_skip_reason_notice(repo)
     restore_pre_v164_label_trigger(repo)
     baseline_root = repo / "examples/baseline-workflows/.github/workflows"
     review_mode = (
@@ -629,3 +630,34 @@ def restore_v145_review_workflows(repo: Path) -> None:
     prepare = repo / ".github/actions/prepare-review-diff/action.yml"
     prepare.parent.mkdir(parents=True, exist_ok=True)
     prepare.write_bytes(V145_PREPARE_DIFF_FIXTURE.read_bytes())
+
+
+PRE_V165_SKIPPED_JOBS = {
+    'claude-code-review.yml': (
+        '  skipped:\n    name: Workflow Skipped\n    needs: check-enabled\n    if: needs.check-enabled.outputs.enabled != \'true\' || needs.check-enabled.outputs.policy_run != \'true\'\n    runs-on: ubuntu-latest\n    steps:\n      - name: Notice\n        # 이 잡은 두 가지 이유로 돌 수 있으므로 하나로 단정하지 않는다. enabled 는\n        # workflow-config.yml 이 끈 경우이고, policy_reason 은 리졸버가 내는 고정\n        # 어휘라 비신뢰 텍스트가 아니다. 정규식이 어휘 밖 값을 막고, 매핑에 없는\n        # 값은 사유를 그대로 보여 준다.\n        env:\n          WORKFLOW_ENABLED: ${{ needs.check-enabled.outputs.enabled }}\n          POLICY_REASON: ${{ needs.check-enabled.outputs.policy_reason }}\n        run: |\n          set -euo pipefail\n          [[ "$POLICY_REASON" =~ ^[a-z_]*$ ]]\n          if [[ "$WORKFLOW_ENABLED" != "true" ]]; then\n            detail="claude-code-review is disabled in .github/workflow-config.yml"\n          else\n            case "$POLICY_REASON" in\n              default_auto_false|workflow_auto_false|review_auto_false)\n                detail="automatic review is off for this repository; add the review:request label to run one" ;;\n              skip) detail="the review:skip label is present" ;;\n              draft) detail="the pull request is a draft" ;;\n              closed) detail="the pull request is not open" ;;\n              unsafe_pr) detail="the pull request head is not in this repository" ;;\n              workflow_disabled) detail="claude-code-review is disabled in .github/workflow-config.yml" ;;\n              "") detail="the review policy produced no reason; see the Check if enabled job" ;;\n              *) detail="the review policy declined with reason $POLICY_REASON" ;;\n            esac\n          fi\n          echo "::notice::Claude Code Review did not run because $detail"\n          {\n            printf \'## Workflow Skipped\\n\'\n            printf \'Claude Code Review did not run because %s.\\n\' "$detail"\n          } >> "$GITHUB_STEP_SUMMARY"\n',
+        '  skipped:\n    name: Workflow Skipped\n    needs: check-enabled\n    if: needs.check-enabled.outputs.enabled != \'true\' || needs.check-enabled.outputs.policy_run != \'true\'\n    runs-on: ubuntu-latest\n    steps:\n      - name: Notice\n        run: |\n          echo "::notice::Claude Code Review workflow is disabled in .github/workflow-config.yml"\n          echo "## Workflow Skipped" >> $GITHUB_STEP_SUMMARY\n          echo "Claude Code Review is disabled in workflow-config.yml" >> $GITHUB_STEP_SUMMARY\n',
+    ),
+    'gemini-auto-review.yml': (
+        '  skipped:\n    permissions: {}\n    name: Workflow Skipped\n    needs: check-enabled\n    if: needs.check-enabled.outputs.enabled != \'true\' || needs.check-enabled.outputs.policy_run != \'true\'\n    runs-on: ubuntu-latest\n    steps:\n      - name: Notice\n        # 이 잡은 두 가지 이유로 돌 수 있으므로 하나로 단정하지 않는다. enabled 는\n        # workflow-config.yml 이 끈 경우이고, policy_reason 은 리졸버가 내는 고정\n        # 어휘라 비신뢰 텍스트가 아니다. 정규식이 어휘 밖 값을 막고, 매핑에 없는\n        # 값은 사유를 그대로 보여 준다.\n        env:\n          WORKFLOW_ENABLED: ${{ needs.check-enabled.outputs.enabled }}\n          POLICY_REASON: ${{ needs.check-enabled.outputs.policy_reason }}\n        run: |\n          set -euo pipefail\n          [[ "$POLICY_REASON" =~ ^[a-z_]*$ ]]\n          if [[ "$WORKFLOW_ENABLED" != "true" ]]; then\n            detail="gemini-auto-review is disabled in .github/workflow-config.yml"\n          else\n            case "$POLICY_REASON" in\n              default_auto_false|workflow_auto_false|review_auto_false)\n                detail="automatic review is off for this repository; add the review:request label to run one" ;;\n              skip) detail="the review:skip label is present" ;;\n              draft) detail="the pull request is a draft" ;;\n              closed) detail="the pull request is not open" ;;\n              unsafe_pr) detail="the pull request head is not in this repository" ;;\n              workflow_disabled) detail="gemini-auto-review is disabled in .github/workflow-config.yml" ;;\n              "") detail="the review policy produced no reason; see the Check if enabled job" ;;\n              *) detail="the review policy declined with reason $POLICY_REASON" ;;\n            esac\n          fi\n          echo "::notice::Gemini Auto PR Review did not run because $detail"\n          {\n            printf \'## Workflow Skipped\\n\'\n            printf \'Gemini Auto PR Review did not run because %s.\\n\' "$detail"\n          } >> "$GITHUB_STEP_SUMMARY"\n',
+        '  skipped:\n    permissions: {}\n    name: Workflow Skipped\n    needs: check-enabled\n    if: needs.check-enabled.outputs.enabled != \'true\' || needs.check-enabled.outputs.policy_run != \'true\'\n    runs-on: ubuntu-latest\n    steps:\n      - name: Notice\n        run: |\n          echo "::notice::Gemini Auto PR Review workflow is disabled in .github/workflow-config.yml"\n          echo "## Workflow Skipped" >> $GITHUB_STEP_SUMMARY\n          echo "Gemini Auto PR Review is disabled in workflow-config.yml" >> $GITHUB_STEP_SUMMARY\n',
+    ),
+}
+
+
+def restore_pre_v165_skip_reason_notice(repo: Path) -> None:
+    """Restore the pre-v1.65 skipped notices in the two managed review workflows.
+
+    v1.65 makes the skipped job name the reason the review declined instead of
+    always blaming workflow-config.yml. This runs first (newest release first) so
+    the older restores still find the text they assert on.
+    """
+
+    # Idempotent: a tree that already restored (or never had) the v1.65 job is
+    # left alone, so this can also run first inside the older restore chains.
+    for workflow, (current, historical) in PRE_V165_SKIPPED_JOBS.items():
+        path = repo / ".github/workflows" / workflow
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        assert text.count(current) <= 1, workflow
+        path.write_text(text.replace(current, historical), encoding="utf-8")

--- a/tests/test_action_pins.py
+++ b/tests/test_action_pins.py
@@ -115,6 +115,34 @@ class ActionPinsTest(unittest.TestCase):
             references,
         )
 
+    def test_manual_claude_path_exposes_full_output_behind_a_repository_variable(
+        self,
+    ) -> None:
+        """The manual @claude path must be diagnosable without defaulting to on.
+
+        `claude.yml` receives the trigger comment as its prompt and pins no
+        allowed-tools list, so its output is not equivalent to the review path's.
+        Gate it on the repository debug variables this repository already uses,
+        so a failure can be reproduced on demand while staying off by default.
+        """
+
+        workflow = yaml.load(
+            (ROOT / ".github/workflows/claude.yml").read_text(encoding="utf-8"),
+            Loader=yaml.BaseLoader,
+        )
+        steps = [
+            step
+            for job in workflow["jobs"].values()
+            for step in job.get("steps", [])
+            if str(step.get("uses", "")).startswith("anthropics/claude-code-action@")
+        ]
+        self.assertEqual(1, len(steps))
+        self.assertEqual(
+            "${{ vars.CLAUDE_DEBUG == 'true' "
+            "|| vars.ACTIONS_STEP_DEBUG == 'true' }}",
+            steps[0].get("with", {}).get("show_full_output"),
+        )
+
     def test_opencode_workflows_pin_cli_archive_and_cache_action(self) -> None:
         for filename, job_name, run_name in (
             ("opencode.yml", "opencode", "Run opencode"),

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -17686,3 +17686,111 @@ def test_review_callers_describe_force_review_as_the_override_round(path, job):
 
     assert inputs["force_review"]["description"] == FORCE_REVIEW_DESCRIPTION
     assert inputs["force_review"]["default"] == "false"
+
+
+# ---------------------------------------------------------------------------
+# skipped job: the notice must name the reason the reviewer did not run (#132)
+# ---------------------------------------------------------------------------
+
+SKIPPED_NOTICE_WORKFLOWS = (
+    ("claude-code-review.yml", "Claude Code Review", "claude-code-review"),
+    ("gemini-auto-review.yml", "Gemini Auto PR Review", "gemini-auto-review"),
+)
+
+
+def _run_skipped_notice(workflow_name, tmp_path, *, enabled, reason):
+    step = _step(_load(workflow_name), "skipped", "Notice")
+    summary = tmp_path / "step-summary"
+    summary.write_text("", encoding="utf-8")
+    result = subprocess.run(
+        ["bash", "-c", step["run"]],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "WORKFLOW_ENABLED": enabled,
+            "POLICY_REASON": reason,
+            "GITHUB_STEP_SUMMARY": str(summary),
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout + summary.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(("workflow_name", "label", "config_key"), SKIPPED_NOTICE_WORKFLOWS)
+def test_skipped_notice_blames_the_config_only_when_the_config_disabled_it(
+    workflow_name, label, config_key, tmp_path
+):
+    """A policy decline must not be reported as a workflow-config.yml setting.
+
+    The notice is the first place a person looks when a reviewer does not run,
+    and since reviews became opt-in a decline is the ordinary path. Pointing at
+    workflow-config.yml for a decline sends them to a file whose contents are
+    already correct.
+    """
+
+    disabled = _run_skipped_notice(
+        workflow_name, tmp_path, enabled="false", reason="workflow_disabled"
+    )
+    assert "workflow-config.yml" in disabled
+    assert config_key in disabled
+
+    declined = _run_skipped_notice(
+        workflow_name, tmp_path, enabled="true", reason="default_auto_false"
+    )
+    assert "workflow-config.yml" not in declined
+    assert "review:request" in declined
+    assert label in declined
+
+
+@pytest.mark.parametrize(("workflow_name", "label", "config_key"), SKIPPED_NOTICE_WORKFLOWS)
+def test_skipped_notice_distinguishes_every_declining_policy_reason(
+    workflow_name, label, config_key, tmp_path
+):
+    expected = {
+        "workflow_auto_false": "review:request",
+        "review_auto_false": "review:request",
+        "skip": "review:skip",
+        "draft": "draft",
+        "closed": "not open",
+        "unsafe_pr": "not in this repository",
+    }
+    for reason, fragment in expected.items():
+        rendered = _run_skipped_notice(
+            workflow_name, tmp_path, enabled="true", reason=reason
+        )
+        assert fragment in rendered, (reason, rendered)
+        assert "workflow-config.yml" not in rendered, reason
+
+    unknown = _run_skipped_notice(workflow_name, tmp_path, enabled="true", reason="")
+    assert "Check if enabled" in unknown
+
+
+@pytest.mark.parametrize(("workflow_name", "label", "config_key"), SKIPPED_NOTICE_WORKFLOWS)
+def test_skipped_notice_takes_the_reason_through_env_and_rejects_stray_text(
+    workflow_name, label, config_key, tmp_path
+):
+    step = _step(_load(workflow_name), "skipped", "Notice")
+    assert step["env"] == {
+        "WORKFLOW_ENABLED": "${{ needs.check-enabled.outputs.enabled }}",
+        "POLICY_REASON": "${{ needs.check-enabled.outputs.policy_reason }}",
+    }
+    assert "${{" not in step["run"]
+
+    result = subprocess.run(
+        ["bash", "-c", step["run"]],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "WORKFLOW_ENABLED": "true",
+            "POLICY_REASON": 'x"; touch must-not-exist; #',
+            "GITHUB_STEP_SUMMARY": str(tmp_path / "summary"),
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert not (tmp_path / "must-not-exist").exists()

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -29,6 +29,7 @@ from release_fixture_helpers import (
     restore_pre_force_review_callers,
     restore_pre_v151_review_policy,
     restore_pre_v164_label_trigger,
+    restore_pre_v165_skip_reason_notice,
     restore_v145_review_workflows,
 )
 
@@ -234,6 +235,7 @@ def current_release_repo(tmp_path: Path) -> tuple[Path, str]:
             shutil.copytree(source, target)
         else:
             shutil.copy2(source, target)
+    restore_pre_v165_skip_reason_notice(repo)
     restore_pre_v164_label_trigger(repo)
     restore_pre_v163_finding_dismissal(repo)
     restore_pre_v151_review_policy(repo)
@@ -271,6 +273,7 @@ def v1462_release_repo(tmp_path: Path) -> tuple[Path, str]:
             shutil.copytree(source, target)
         else:
             shutil.copy2(source, target)
+    restore_pre_v165_skip_reason_notice(repo)
     restore_pre_v164_label_trigger(repo)
     restore_pre_v163_finding_dismissal(repo)
     restore_v1462_workflow_fixtures(repo)
@@ -516,6 +519,7 @@ def copy_review_policy_release_files(repo: Path) -> None:
 
 def prepare_v151(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v165_skip_reason_notice(repo)
     restore_pre_v164_label_trigger(repo)
     restore_pre_v163_finding_dismissal(repo)
     restore_pre_v162_filter_surface(repo)
@@ -527,6 +531,7 @@ def prepare_v151(repo: Path) -> str:
 
 def prepare_v159(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v165_skip_reason_notice(repo)
     restore_pre_v164_label_trigger(repo)
     restore_pre_v163_finding_dismissal(repo)
     restore_pre_v162_filter_surface(repo)
@@ -538,6 +543,7 @@ def prepare_v159(repo: Path) -> str:
 
 def prepare_v160(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v165_skip_reason_notice(repo)
     restore_pre_v164_label_trigger(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",
@@ -1968,6 +1974,7 @@ def test_v159_opt_in_helper_is_rejected_on_the_v151_release_line(
 
 def prepare_v162(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v165_skip_reason_notice(repo)
     restore_pre_v164_label_trigger(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",
@@ -1982,6 +1989,7 @@ def prepare_v162(repo: Path) -> str:
 
 def prepare_v163(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v165_skip_reason_notice(repo)
     restore_pre_v164_label_trigger(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",
@@ -1995,6 +2003,7 @@ def prepare_v163(repo: Path) -> str:
 
 def prepare_v164(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v165_skip_reason_notice(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
@@ -2003,6 +2012,47 @@ def prepare_v164(repo: Path) -> str:
     ):
         shutil.copy2(ROOT / relative, repo / relative)
     return commit(repo, "v1.64 candidate")
+
+
+def prepare_v165(repo: Path) -> str:
+    copy_review_policy_release_files(repo)
+    for relative in (
+        ".github/actions/review-invocation-budget/action.yml",
+        ".github/actions/review-invocation-budget/review_invocation_budget.py",
+        ".github/actions/canonicalize-review/action.yml",
+        ".github/actions/canonicalize-review/canonicalize_review.py",
+    ):
+        shutil.copy2(ROOT / relative, repo / relative)
+    return commit(repo, "v1.65 candidate")
+
+
+def test_v165_accepts_current_skip_reason_release_contract(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v165(repo)
+
+    assert release_verifier.verify_commit_content(repo, "v1.65", candidate) == candidate
+
+
+def test_v165_skip_reason_notice_is_rejected_on_the_v164_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v165(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.64", candidate)
+
+
+def test_pre_v165_notices_are_rejected_on_the_v165_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v164(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.65", candidate)
 
 
 def test_v164_accepts_current_label_trigger_release_contract(
@@ -2094,6 +2144,7 @@ def test_pre_v162_filter_surface_is_rejected_on_the_v162_release_line(
 
 def prepare_v161(repo: Path) -> str:
     copy_review_policy_release_files(repo)
+    restore_pre_v165_skip_reason_notice(repo)
     restore_pre_v164_label_trigger(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",


### PR DESCRIPTION
v1.65 closes two diagnostic gaps that the opt-in review switch in v1.59 turned from rare into ordinary. Both came out of one incident on a consumer repository where three managed reviewers skipped, the manual reviewers were called instead, and none of the three channels could say what had happened.

## #131 — the manual `@claude` path could not be diagnosed

A manual `@claude` request failed after 1.8 seconds and no channel carried the error body: the step log hides output by design, no artifact was uploaded, and the pull-request comment said only that Claude had encountered an error. The review path has passed `show_full_output` since it was added; the manual path never did, and did not expose it as an input either, so a consumer had no way to turn it on.

It is now gated on the debug variables this repository already uses in thirteen other places:

```yaml
show_full_output: ${{ vars.CLAUDE_DEBUG == 'true' || vars.ACTIONS_STEP_DEBUG == 'true' }}
```

Not unconditionally on, because the two paths are not equivalent. `claude.yml` takes the trigger comment as its prompt and pins no allowed-tools list, while `claude-code-review.yml` supplies its own prompt and scopes writes to a single file. Opt-in per repository keeps the default unchanged and still lets a failure be reproduced on demand. The canonical caller forwards no inputs, so consumer bytes are unaffected.

## #132 — the skip notice named the wrong cause

The `skipped` job fires for two reasons and reported one. A policy decline was announced as `disabled in .github/workflow-config.yml`, sending the reader to a file that was already correct. The reason was computed and published as a `check-enabled` output that nothing consumed.

The notice now reads `enabled` and `policy_reason` through the environment, rejects anything outside the resolver's `^[a-z_]*$` vocabulary, and distinguishes each case. The three reasons that mean automatic review is off say to add the `review:request` label, so the notice carries its own recovery.

`opencode-auto-review.yml` is deliberately untouched. Its wording already names the cross-repository case, which the shared vocabulary would lose, and its bytes gate two runtime allowlists that are independent of the digest table.

## #133 is not in this release

Its stated target file did not run in the incident, and its stated cause is not the cause. Evidence is recorded on the issue: the run's `path` is `gemini-dispatch.yml`, and that workflow contains no `git diff` and grants the review job no `git` or MCP access, so the model had no channel through which to see the change. Removing the prohibition alone would license unfounded change-specific findings. It needs redesign first.

## Verification

| Check | Result |
| --- | --- |
| Full suite | 3050 passed, 0 failed |
| actionlint, CI flags (`-shellcheck= -pyflakes=`) | 0 findings, exit 0 |
| `skipped` notice behaviour | 6 new tests execute the real `run:` script per reason |
| v1.65 release gate | accepts the v1.65 tree, rejects it on the v1.64 line, rejects the v1.64 tree on the v1.65 line |

The notice tests run the workflow's own shell with each reason and assert the rendered text, including that an out-of-vocabulary reason makes the step fail rather than interpolate. No test pinned this wording before, so the behaviour was unprotected.

Closes #131, closes #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnEJTjxEwdMh5sPkeVZYzy
