### PR TITLE
chore(workflows): default rollout to v1.65

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.64",
+  "automation_ref": "v1.65",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.64"
+    assert config.automation_ref == "v1.65"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
Move the default rollout ref from `v1.64` to `v1.65` now that every fleet target is on the new release.

## Evidence

- Tag `v1.65` → commit `3bd4909`, annotated tag object `35379e7535904bdfc7ea550ee6dc5e4a2fb3eb19`. `verify_release` passes against `origin`; the pre-tag check passes for `v1.65` and **fails** for `v1.64` (`invocation-budget authenticated source digest differs`), so the gate reads the new workflow bytes.
- Rollout: 17 planned, 17 published, 17 merged, 0 blocked.
- Audit: `ref=v1.65 commit=3bd4909 total=17 current=17 drift=0 blocked=0`.

## What v1.65 ships

- **#132** — the `skipped` job of `claude-code-review.yml` and `gemini-auto-review.yml` names the reason a review declined instead of always citing `workflow-config.yml`, and the three reasons that mean automatic review is off tell the reader to add the `review:request` label. Confirmed live: an unlabeled push printed `did not run because automatic review is off for this repository; add the review:request label to run one`, where the old text claimed the workflow was disabled in a file that says `enabled: true`.
- **#131** — the manual `@claude` path can be told to show its output, gated on the debug variables this repository already uses, so a failure there is diagnosable without turning full output on for everyone.

`opencode-auto-review.yml` is unchanged; its wording already names the cross-repository case.

Also documents when `review:request` is safe to add, after an in-flight `opened` run failed closed with `review_mode_label_mismatch` on this release's own pull request. Whether that guard should decline more gracefully is tracked in #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnEJTjxEwdMh5sPkeVZYzy
