### PR TITLE
chore(workflows): default rollout to v1.66

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.65",
+  "automation_ref": "v1.66",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.65"
+    assert config.automation_ref == "v1.66"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
Move the default rollout ref from `v1.65` to `v1.66` now that every fleet target is on the new release.

## Evidence

- Tag `v1.66` → commit `14f97fb`, annotated tag object `bfdff11b3a022bf28156d0b0b7522e03013143d9`. `verify_release` passes against `origin`; the pre-tag check passes for `v1.66` and **fails** for `v1.65` (`review-policy helper contract is invalid`), so the gate reads the new resolver bytes.
- Rollout: 17 planned, 17 published, 17 merged, 0 blocked.
- Audit: `ref=v1.66 commit=14f97fb total=17 current=17 drift=0 blocked=0`.

## What v1.66 ships

**#136** — a `review:request` or `review:skip` label that moves after a run is triggered now declines that run instead of failing it. The run reviews nothing under either outcome, so failing only reported a broken reviewer for an ordinary opt-in race, and the run started by the label carries the verdict. A manual `workflow_dispatch` with `force_review` still fails, because it has no follow-up run and declining would drop an explicit request.

`opencode-auto-review` joined the reason-aware skip notice in the same change. Left on its fixed sentence it would have answered a declined label change with three causes that are all false. Confirmed live on this release's own pull request: it printed `did not run because automatic review is off for this repository; add the review:request label to run one`.

Its bytes also gate two runtime allowlists that are independent of the digest table. Both had stopped at the v1.62 entry and were passing only because the opencode bytes had not moved since; both now carry the new digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnEJTjxEwdMh5sPkeVZYzy
