### PR TITLE
fix(release): require the manual review path to carry its diff

### DIFF
--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -53,6 +53,7 @@ from scripts.workflow_release_inventory import (
     release_supports_label_review_trigger,
     release_supports_skip_reason_notice,
     release_supports_label_mismatch_decline,
+    release_supports_dispatch_review_diff,
     release_supports_same_head_cancel_guard,
     release_supports_review_policy,
     validate_release_listing,
@@ -6768,6 +6769,57 @@ def _verify_token_mapping(
     return sinks
 
 
+def _verify_dispatch_review_diff(tree: "VerifiedCommitTree", ref: str) -> None:
+    """Require the manual review path to build and read the diff it reviews.
+
+    Nothing described this path before v1.67, so the reviewer could be left with a
+    bare checkout and the whole suite would still pass. The release now refuses a
+    tree where the diff step is gone or the model no longer waits for it.
+    """
+
+    name = ".github/workflows/gemini-dispatch.yml"
+    document = yaml.load(tree.read_text(name), Loader=yaml.BaseLoader)
+    try:
+        steps = document["jobs"]["review"]["steps"]
+    except (KeyError, TypeError) as exc:
+        raise ReleaseVerificationError(f"{name} has no review job") from exc
+    by_name = {step.get("name"): step for step in steps if isinstance(step, dict)}
+    prepare = by_name.get("Prepare review diff")
+    if prepare is None or prepare.get("id") != "review_diff":
+        raise ReleaseVerificationError(
+            f"{name} review job does not prepare a diff for the manual review"
+        )
+    script = prepare.get("run", "")
+    for fragment in ("git diff", "diff_ready", "diff_reason", "MAX_DIFF_BYTES"):
+        if fragment not in script:
+            raise ReleaseVerificationError(
+                f"{name} review diff step is missing {fragment}"
+            )
+    model_steps = [
+        step
+        for step in steps
+        if isinstance(step, dict)
+        and str(step.get("uses", "")).startswith("google-github-actions/run-gemini-cli@")
+    ]
+    if len(model_steps) != 2:
+        raise ReleaseVerificationError(
+            f"{name} review job must invoke exactly two review models"
+        )
+    for step in model_steps:
+        prompt = (step.get("with") or {}).get("prompt", "")
+        if "steps.review_diff.outputs.diff_file" not in prompt:
+            raise ReleaseVerificationError(
+                f"{name} review prompt does not read the prepared diff"
+            )
+    primary = by_name.get("Run Gemini pull request review (primary)")
+    if primary is None or primary.get("if") != (
+        "steps.review_diff.outputs.diff_ready == 'true'"
+    ):
+        raise ReleaseVerificationError(
+            f"{name} review model does not wait for a ready diff"
+        )
+
+
 def _verify_gemini_workflow(name: str, document: dict, ref: str) -> None:
     try:
         call = document["on"]["workflow_call"]
@@ -7010,6 +7062,8 @@ def _verify_commit_content(
         _verify_review_policy_callers(tree, ref)
     _verify_approved_v140_policy(tree, ref)
     _verify_manual_gemini_output_contract(tree, ref)
+    if release_supports_dispatch_review_diff(ref):
+        _verify_dispatch_review_diff(tree, ref)
     catalog = _verify_tag_catalog(tree, ref)
     names = [entry.path.as_posix() for entry in tree.files(".github/workflows")]
     workflows = [name for name in names if name.endswith((".yml", ".yaml"))]

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -155,6 +155,7 @@ FINDING_DISMISSAL_RELEASE = (1, 63)
 LABEL_REVIEW_TRIGGER_RELEASE = (1, 64)
 SKIP_REASON_NOTICE_RELEASE = (1, 65)
 LABEL_MISMATCH_DECLINE_RELEASE = (1, 66)
+DISPATCH_REVIEW_DIFF_RELEASE = (1, 67)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -233,6 +234,12 @@ def release_supports_label_mismatch_decline(ref: str) -> bool:
     """Return whether ``ref`` declines, rather than fails, an event-triggered label change."""
 
     return _release_version(ref) >= LABEL_MISMATCH_DECLINE_RELEASE
+
+
+def release_supports_dispatch_review_diff(ref: str) -> bool:
+    """Return whether ``ref``'s manual `/review` reviews a diff instead of the bare checkout."""
+
+    return _release_version(ref) >= DISPATCH_REVIEW_DIFF_RELEASE
 
 
 def release_roots_for(ref: str) -> tuple[ReleaseRoot, ...]:

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -2049,6 +2049,69 @@ def prepare_v166(repo: Path) -> str:
     return commit(repo, "v1.66 candidate")
 
 
+def prepare_v167(repo: Path) -> str:
+    copy_review_policy_release_files(repo)
+    for relative in (
+        ".github/actions/review-invocation-budget/action.yml",
+        ".github/actions/review-invocation-budget/review_invocation_budget.py",
+        ".github/actions/canonicalize-review/action.yml",
+        ".github/actions/canonicalize-review/canonicalize_review.py",
+        ".github/actions/resolve-review-policy/resolve_review_policy.py",
+        ".github/workflows/gemini-dispatch.yml",
+    ):
+        shutil.copy2(ROOT / relative, repo / relative)
+    return commit(repo, "v1.67 candidate")
+
+
+def test_v167_accepts_current_dispatch_review_diff_contract(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v167(repo)
+
+    assert release_verifier.verify_commit_content(repo, "v1.67", candidate) == candidate
+
+
+def test_v167_rejects_a_dispatch_review_that_prepares_no_diff(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    """Deleting the diff step must fail the release, not pass quietly.
+
+    Nothing described this path before, so the reviewer could be handed a bare
+    checkout while every existing contract stayed green.
+    """
+
+    repo, _ = current_release_repo
+    candidate = prepare_v167(repo)
+    workflow = repo / ".github/workflows/gemini-dispatch.yml"
+    text = workflow.read_text(encoding="utf-8")
+    start = text.index("      - name: Prepare review diff\n")
+    end = text.index("      - name: Run Gemini pull request review (primary)\n")
+    workflow.write_text(text[:start] + text[end:], encoding="utf-8")
+    candidate = commit(repo, "v1.67 without the diff step")
+
+    with pytest.raises(ReleaseVerificationError, match="does not prepare a diff"):
+        release_verifier.verify_commit_content(repo, "v1.67", candidate)
+
+
+def test_v167_rejects_a_review_model_that_ignores_the_prepared_diff(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    prepare_v167(repo)
+    workflow = repo / ".github/workflows/gemini-dispatch.yml"
+    workflow.write_text(
+        workflow.read_text(encoding="utf-8").replace(
+            "${{ steps.review_diff.outputs.diff_file }}", "review.diff", 1
+        ),
+        encoding="utf-8",
+    )
+    candidate = commit(repo, "v1.67 with an unwired prompt")
+
+    with pytest.raises(ReleaseVerificationError, match="does not read the prepared diff"):
+        release_verifier.verify_commit_content(repo, "v1.67", candidate)
+
+
 def test_v166_accepts_current_label_mismatch_release_contract(
     current_release_repo: tuple[Path, str],
 ) -> None:


### PR DESCRIPTION
Follow-up to #140, before v1.67 is tagged.

## The gap

#140 touches only `gemini-dispatch.yml`. That file carries no byte digest and no version-gated contract, so the release verifier could not distinguish the new tree from the old one:

```
v1.67 on the new tree: PASS
v1.66 on the new tree: PASS      ← the gate did not read the change
```

Every other release this month had a negative control proving the gate reads the new bytes. This one did not, which means a later change could delete the diff step and the release checks would stay green.

That is the same shape as the defect #140 fixes. Nothing described the manual review path, so a passing suite was evidence of irrelevance rather than of correctness.

## The contract

From `v1.67` the release refuses a `gemini-dispatch.yml` whose review job:

- has no `Prepare review diff` step, or one that no longer runs `git diff` or reports `diff_ready`
- has prompts that do not read the prepared diff
- has a primary model that does not wait for `diff_ready == 'true'`

Measured in all three directions:

| Tree | Line | Result |
| --- | --- | --- |
| with the diff step | v1.67 | PASS |
| without it (the v1.66 bump commit) | v1.67 | FAIL, `review job does not prepare a diff for the manual review` |
| without it | v1.66 | PASS |

Three tests cover this: the current tree is accepted, a tree with the step deleted is rejected, and a tree whose prompt no longer names the diff file is rejected.

Full suite: 3074 passed, 0 failed.

Refs #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnEJTjxEwdMh5sPkeVZYzy
