### PR TITLE
chore(workflows): default rollout to v1.67

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.66",
+  "automation_ref": "v1.67",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.66"
+    assert config.automation_ref == "v1.67"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
Move the default rollout ref from `v1.66` to `v1.67` now that every fleet target is on the new release.

## Evidence

- Tag `v1.67` → commit `fbcbb30`, annotated tag object `88a2a11543bc047c6c1bb668e8ba325790d1ce6a`. `verify_release` passes against `origin`.
- Rollout: 17 planned, 17 published, 17 merged, 0 blocked.
- Audit: `ref=v1.67 commit=fbcbb30 total=17 current=17 drift=0 blocked=0`.

The gate is two-sided in the direction that matters for a structural contract:

| Tree | Line | Result |
| --- | --- | --- |
| v1.67 | v1.67 | PASS |
| v1.66 | v1.67 | FAIL, `review job does not prepare a diff for the manual review` |
| v1.66 | v1.66 | PASS |

## What v1.67 ships

**#133** — the `review` job of `gemini-dispatch.yml` builds the diff it is reviewing. It previously checked out the reviewed commit and asked the model to look beyond the change while giving it no diff, no `git`, and no MCP server, so general architecture advice was the only answer available. The base comes from the pull request the dispatch job already fetches, because the `issue_comment` event carrying `/review` has no `pull_request` object. The range honours `commit=` and an incremental base when asked.

A diff that cannot be produced stops the round with a named reason that reaches the sticky comment, rather than leaving the model to trip over a missing file and answer in generalities, which is the failure being removed.

The release now refuses a tree whose review job does not prepare that diff, whose prompts do not read it, or whose primary model does not wait for it. Without that, the fix could have been deleted later with every release check still green, which is how the gap survived in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnEJTjxEwdMh5sPkeVZYzy
