### PR TITLE
probe: does an injection payload in the diff silence OpenCode

### DIFF
--- a/tests/test_probe_injection_payload.py
+++ b/tests/test_probe_injection_payload.py
@@ -1,0 +1,22 @@
+"""Probe: does a diff carrying an injection payload silence the OpenCode reviewer?
+
+Temporary. Deleted once the question is answered.
+"""
+
+import subprocess
+
+
+def test_probe_payload_is_never_executed(tmp_path):
+    payload = "$(touch must-not-exist) `touch also-not` ${GITHUB_TOKEN}"
+    target = tmp_path / "notes.md"
+    result = subprocess.run(
+        ["bash", "-c", 'printf "%s\\n" "$PAYLOAD" > "$TARGET"'],
+        env={"PAYLOAD": payload, "TARGET": str(target), "PATH": "/usr/bin:/bin"},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / "must-not-exist").exists()
+    assert not (tmp_path / "also-not").exists()
+    assert payload in target.read_text(encoding="utf-8")


### PR DESCRIPTION
Temporary probe for #145. A ~25 line diff whose only unusual content is a command-substitution payload and a `${GITHUB_TOKEN}` literal, the content PR #144 carries. If OpenCode goes silent here, content is implicated; if it reviews, size or something else is. Closed once answered.