### PR TITLE
fix(rollout): plan a retired caller's removal instead of refusing the repository

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,48 +1,40 @@
 # Handoff — automation
 
-_2026-09-05 · claude-code · main = d2832c5 (v1.67) · 작업 브랜치 `fix/133-request-notes` (v1.68, 전체 스위트 실행 중)_
+_2026-09-05 · claude-code · main = 867e88e · **태그 v1.68 발행됨, 롤아웃 보류** · 브랜치 `fix/143-rollout-retired-caller` (v1.69 후보, 스위트 실행 중)_
 
-## 체크포인트 — v1.68 두 갈래 구현 완료, 스위트 확인 중
-- **완료·검증됨 (A: 요청자 질문 전달, 커밋 `36c64ef`)**: 전체 스위트 **3083 통과** ·
-  되돌리면 7건 빨개짐 · actionlint 0건. `additional_context` 를 diff 와 같이 **파일로** 넘기고
-  프롬프트는 파일명만 가리킨다(UNTRUSTED 헤더 + BEGIN/END + 4000B 상한 + 잘림 표시).
-  **답글일 때 부모 코멘트 본문이 실리는데 그 작성자는 OWNER/MEMBER/COLLABORATOR 검사를 안 거친다** —
-  비신뢰 취급의 실제 근거.
-- **완료 (B: #143 폐기, 미커밋)**: 사용자 승인. 카탈로그 2항목 `retired`(롤아웃이 소비자 파일을 삭제),
-  정본 파일 2개·설정 키 2개 삭제, `_verify_manual_gemini_output_contract` 를 v1.68 게이트,
-  `restore_retired_manual_pr_review`(파일+카탈로그+설정 키 복원) + **전 체인 배선**
-  (`prepare_v151~v167`, `restore_historical_v140_manual_outputs`, 번들 픽스처).
-  릴리스 계약 테스트 2건(양방향). **검증기 601 통과 · actionlint 0건.**
-- **정본 트리는 카탈로그와 정확히 일치해야 한다**(`test_canonical_tree_is_exactly_catalogued`) —
-  파일을 남기고 `retired` 만 표시하는 방식은 불가함을 실측으로 확인했다.
-- **중앙 `.github/workflows/gemini-review.yml` 은 남겼다** — 소비자에 배포되지 않고, 지우면 과거 태그
-  픽스처까지 건드려 범위가 커진다. 후속 정리 대상.
-- **다음 액션 1개**: PR #144 라운드 → 머지 →
-  태그 v1.68 → 롤아웃(**이번 롤아웃은 소비자에서 파일 2개를 삭제한다**) → audit → 범프 PR.
-- **제약**: `gh`·`git push` 모두 `env -u GITHUB_TOKEN`. 롤아웃은 `--actionlint /tmp/actionlint-v1.7.12/actionlint`.
-  라벨은 `opened` 실행 종료 후. 호스트 메모리 빠듯 — BG 작업이 2회 강제종료된 적 있다.
-- **열린 이슈**: #143(이 릴리스로 해소) · #133(잔여 1건 — `gemini-review.yml:378` 금지 문장, 중앙 파일과 함께 정리) ·
-  #128 · #125 · #106 · #93 · #83.
+## 체크포인트 — v1.68 태그까지 완료, 롤아웃은 v1.69 수정이 선행돼야 함
+- **v1.68 머지·태그 완료**: PR #144 머지(`867e88e`), 태그 `v1.68`(tag object `f864e0b7…`),
+  `verify_release` PASS, 선검증 v1.67 음성 대조 FAIL. 리뷰어 3종 CLEAN, CI success, 전체 스위트 3084 통과.
+- **롤아웃은 하지 않았다** — plan 이 **17/17 BLOCKED** 였다:
+  `unknown central caller path: .github/workflows/gemini-pr-review.yml`.
+  `prepare_workflow_rollout.py:725` 가 소비자의 중앙 캘러를 `catalog.callers` 와 대조하는데
+  그 뷰는 `central_workflow is None` 인 항목을 **제외**한다 — 폐기 항목이 정확히 그것이다.
+  카탈로그가 관리하는 파일을 모르는 파일로 읽어, 그 파일을 지우려는 롤아웃 자체를 막았다.
+- **수정 완료(커밋 `045cc04`, 브랜치 푸시됨)**: 비교 대상을 `catalog.managed_paths` 로 바꿨다.
+  카탈로그가 선언한 적 없는 캘러를 잡는다는 원래 목적은 유지되고, 폐기 항목은 계획된 삭제로 넘어간다.
+  **되돌리면 실패하는 테스트 추가** — 소비자가 폐기 캘러를 갖고 있는 픽스처는 지금까지 없었다
+  (배포된 상태에서 무언가를 폐기한 적이 없어서). 수정 후 plan 재실행: **17/17 PLANNED, blocked=0**,
+  `changed_paths` 에 두 파일 삭제 포함 확인.
+- **다음 액션 1개**: 전체 스위트(BG `bqhl0xlvc`) 통과 확인 → PR → 라운드 → 머지 → **태그 v1.69** →
+  롤아웃(**소비자에서 파일 2개 삭제**) → audit → 범프 PR(**v1.69 로 직행**, v1.68 은 롤아웃하지 않음).
+- **제약**: 태그는 이동 불가라 v1.68 은 그대로 두고 v1.69 로 나간다.
+  `gh`·`git push` 모두 `env -u GITHUB_TOKEN`. 롤아웃은 `--actionlint /tmp/actionlint-v1.7.12/actionlint`.
+  라벨은 `opened` 실행 종료 후. **호스트 메모리 빠듯 — BG 작업이 이 세션에서 5회 강제종료됐다.**
+- **열린 이슈**: #145(OpenCode 진단 가시성 — 아래) · #133(잔여: `gemini-review.yml:378` 금지 문장,
+  중앙 파일 정리와 함께) · #128 · #125 · #106 · #93 · #83. #143 은 v1.68 로 해소.
 
-## OpenCode 재현 규칙 (이번에 실측)
-- **`gh run rerun --failed` 는 모델을 다시 부르지 않는다.** `opencode-review` 잡은 `REVIEW_OUTCOME=failure`
-  를 출력해도 **잡 자체는 success** 라 재실행 대상이 아니다. 다시 도는 것은 `opencode-canonicalize` 뿐이고
-  그것은 이전 출력을 읽으므로 같은 결과가 나온다 — "여러 번 실패했으니 결정적" 이라고 읽으면 오진이다.
-- **무플래그 전체 재실행도 같은 head 에서는 막힌다.** 예산이 `duplicate_head` 로 거부한다(설계대로).
-  같은 head 에서 모델을 다시 부를 방법은 없다. 재현하려면 **새 head** 가 필요하다.
-- **원문 이벤트 스트림은 보존되지 않는다.** `opencode-rejected` 아티팩트는 후보가 *생긴 뒤* 거부될 때만
-  채워진다. 후보 추출 자체가 실패하면 남는 것은 `jq` 오류 한 줄뿐이다(이슈 #145).
-
-## #143 폐기 근거 (실측)
-- `gemini-pr-review.yml` 실행 13건 vs `gemini-dispatch.yml` 3,154건(소비자 6곳 표본).
-- **2026-01-22 이후 성공 0건.** 마지막 3건(8/29·8/31×2) 전부 실패.
-- 원인은 자기 `PATH` 재정의(`gemini-review.yml:297`)가 safe-bin 래퍼를 앞에 두어,
-  **액션이 자기 출력 임시파일을 읽는 것까지 거부**한 것:
-  `ERROR: refusing to read non-text file: /home/runner/work/_temp/gemini-out.*`
-  (`grep -rln safe-bin .github/workflows/` 결과는 이 파일 하나 — 정상 동작하는 3종은 PATH 를 안 건드린다.)
-- 그 워크플로는 `pr_number` 를 받고도 범위·체크아웃에 쓰지 않아 기본 브랜치 마지막 커밋을 리뷰했다.
+## OpenCode 침묵 조사 결론 (이슈 #145)
+- head `17e4f0b` 에서 한 번 침묵했고 **재현되지 않았다** — 새 head `8a0f9d0`(48KB, 더 큼)에서 정상 리뷰.
+  프로브 2건으로 내용(1KB)과 33KB 크기를 각각 배제했다(PR #146·#147, 둘 다 정상 리뷰 후 닫음).
+- **재현 규칙(중요)**: `gh run rerun --failed` 는 모델을 다시 부르지 않는다 — 모델 잡은 실패를 출력으로
+  알리면서 **잡 수준에서는 success** 라 재실행 대상이 아니고, 다시 도는 `opencode-canonicalize` 는
+  이전 출력을 읽어 항상 같은 결과를 낸다. 이것을 독립 시도로 세면 **한 번의 실패가 여러 번으로 보인다**
+  (내가 그렇게 오판했다). 무플래그 전체 재실행은 모델을 부르지만 예산이 `duplicate_head` 로 거부한다.
+  **재현에는 새 head 가 필요하다.**
+- `candidate_contract_failed` 는 계약 위반이 아니라 **후보 추출 실패**일 수 있다. 원문 이벤트 스트림은
+  보존되지 않아(`opencode-rejected` 는 후보가 생긴 뒤 거부될 때만) 진단이 `jq` 오류 한 줄에 의존한다.
 
 ## (이전) v1.67 · v1.66 · v1.65 — 완료
-- v1.67: 태그 `88a2a115…` → `fbcbb30b`, 범프 PR #142(`d2832c5`). 수동 `/review` 에 diff 공급 + 구조 계약.
+- v1.67: 태그 `88a2a115…` → `fbcbb30b`, 범프 PR #142. 수동 `/review` 에 diff 공급 + 구조 계약.
 - v1.66: 태그 `bfdff11b…` → `14f97fb4`, 범프 PR #139. 라벨 불일치를 거절로 + opencode 문구 동등화.
 - v1.65: 태그 `35379e75…` → `3bd49095`, 범프 PR #137. skip 사유 오귀속 수정.

--- a/scripts/prepare_workflow_rollout.py
+++ b/scripts/prepare_workflow_rollout.py
@@ -722,9 +722,11 @@ def render_repository(
         central_callers = _scan_central_callers(repo, catalog)
     except RolloutError as exc:
         return block(str(exc))
-    catalog_caller_paths = frozenset(entry.path for entry in catalog.callers)
+    # A retired entry keeps its path but no longer names a central workflow, so
+    # comparing against callers alone would call a file the catalogue manages an
+    # unknown one and block the very rollout that takes it away.
     unknown = tuple(
-        path for path, _ in central_callers if path not in catalog_caller_paths
+        path for path, _ in central_callers if path not in catalog.managed_paths
     )
     if unknown:
         return block(f"unknown central caller path: {unknown[0]}")

--- a/tests/test_prepare_workflow_rollout.py
+++ b/tests/test_prepare_workflow_rollout.py
@@ -794,3 +794,41 @@ def test_missing_label_names_are_non_blocking_for_explicit_bootstrap(tmp_path: P
     )
     assert plan.status == "bootstrap_required"
     assert "non-blocking prerequisites: missing labels: review-budget-override, review:request, review:skip" in plan.reason
+
+
+def test_a_retired_caller_left_in_a_consumer_is_deleted_not_blocked(
+    tmp_path: Path,
+) -> None:
+    """A consumer still carrying a retired caller must be planned, not refused.
+
+    The catalogue knows the path; it just no longer names a central workflow for
+    it. Treating that as an unknown caller blocks every target in the fleet on
+    the one rollout that is supposed to take the file away.
+    """
+
+    repo = make_existing_repo(tmp_path)
+    retired = repo / ".github/workflows/gemini-pr-review.yml"
+    retired.write_bytes(
+        b"name: Gemini PR Review\n"
+        b"on:\n  workflow_dispatch:\n"
+        b"jobs:\n"
+        b"  review:\n"
+        b"    uses: jhw7500/automation/.github/workflows/gemini-review.yml@"
+        + COMMIT.encode()
+        + b"\n"
+    )
+
+    plan = render_repository(
+        repo,
+        CANONICAL,
+        CATALOG,
+        PROFILES["wlan-package"],
+        "v1.40",
+        COMMIT,
+        ALL_SECRETS,
+        ALL_VARIABLES,
+        label_names=ALL_LABELS,
+    )
+
+    assert plan.status != "blocked", plan.reason
+    assert plan.after(".github/workflows/gemini-pr-review.yml") is None


### PR DESCRIPTION
v1.68 retired two callers and then could not roll out. Every fleet target blocked on the first plan:

```
BLOCKED   claude-config[master]: unknown central caller path: .github/workflows/gemini-pr-review.yml
...
SUMMARY mode=plan ref=v1.68 total=17 blocked=17
```

## Why

`prepare_workflow_rollout.py` scans the consumer for files that reference the central repository and requires each to be a known caller. It compared them against `catalog.callers`, and that view keeps only entries with a central workflow:

```python
return tuple(entry for entry in self.entries if entry.central_workflow is not None)
```

A retired entry keeps its path and drops its central workflow, so it is exactly what that filter removes. The file the catalogue manages was read as one it does not, and the rollout whose whole purpose was to delete that file refused to run.

The comparison now uses the catalogue's managed paths. The guard still catches a caller the catalogue never declared, which is what it was written for, while a retired one passes through to the deletion the plan already knows how to produce.

## Why the suite missed it

Nothing had ever been retired while deployed, so no fixture had a consumer still carrying a retired caller. The full suite passed at 3084 while the real rollout blocked on all seventeen targets.

The new test builds that fixture. Reverting the one-line change turns it red with the exact message the fleet produced.

## Verification

| Check | Result |
| --- | --- |
| Full suite, run in three parts | 3085 passed, 0 failed |
| actionlint, CI flags | 0 findings, exit 0 |
| `rollout --mode plan --ref v1.68` | 17 planned, 0 blocked |
| Plan content | both retired paths appear in `changed_paths` as deletions |

v1.68 stays as it is, since a tag cannot move. This ships as v1.69 and the fleet rolls out from there.

Refs #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnEJTjxEwdMh5sPkeVZYzy
