### PR TITLE
chore(workflows): default rollout to v1.69

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.67",
+  "automation_ref": "v1.69",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.67"
+    assert config.automation_ref == "v1.69"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
Move the default rollout ref from `v1.67` to `v1.69`.

**Not from v1.68.** That tag exists and verifies, but it could never roll out: it retired two callers while the rollout tool still refused any repository that carried one, so the plan blocked on all seventeen targets. A tag cannot move, so v1.69 carries everything v1.68 did plus the fix, and the fleet went there directly.

## Evidence

- Tag `v1.69` → commit `31e1da1`, annotated tag object `9c62be4bc45bd11cadc82750f5dc28b27ab1c5f7`. `verify_release` passes against `origin`.
- Rollout: 17 planned, 17 published, 17 merged, 0 blocked.
- Audit: `ref=v1.69 total=17 current=17 drift=0 blocked=0`.
- The retirement actually landed: `gemini-pr-review.yml` returns 404 in max9296, redmine, pcap-analyzer and wlan-package.

## What v1.68 and v1.69 ship together

- **#133 remainder** — text written after `@gemini-cli /review` now reaches the model. It was set as an environment variable no prompt read, so a request listing five questions was answered on none of them. It travels as a file the prompt names, wrapped in untrusted framing, because a reply also carries the parent comment whose author the permission check never saw.
- **#143** — the `workflow_dispatch` pull-request review is retired. It had produced no successful review since 2026-01-22, blocked by its own `PATH` override, and it ignored the `pr_number` it was given. Thirteen runs against 3,154 for the dispatch path that answers `@gemini-cli /review`.
- **The rollout fix** — a retired caller is planned for deletion instead of being read as a caller the catalogue never declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnEJTjxEwdMh5sPkeVZYzy
