### PR TITLE
chore(workflows): default rollout to v1.70

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.69",
+  "automation_ref": "v1.70",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.69"
+    assert config.automation_ref == "v1.70"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
플릿이 v1.70 이다 — 17개 타깃 전부 발행·머지됐고 감사 결과는 `total=17 current=17 drift=0 blocked=0`.
기본 `automation_ref` 를 따라 올려, 새 계획이 플릿이 이미 돌리고 있는 릴리스를 렌더하게 한다.

카탈로그 가드가 같은 버전을 단언하므로 둘은 함께 움직인다 — 한쪽만 되돌리면
`test_catalog_and_profiles_are_closed` 가 실패한다(양쪽 arm 확인함).

## v1.70 내용

OpenCode finding 에 안정적인 `RVW-` ID 를 부여한다 (#128 Phase 1). 리더는 이미 그 형식을
기대하고 있었으나 생성기가 없어 `remaining_finding_ids` 가 항상 비어 있었다.

- 태그 `v1.70` = `ed154b6f…` → commit `0989944`
- `PASS: v1.70 resolves to secure commit 09899443802eb3c7e6aa9cdeb315df24f3b67cb3`

## 검증

`tests/` (verify_workflow_release · review_workflow_logic 제외) **832 passed**.

Refs #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXN9uYgzFuB8UGqkC4RnQR