### PR TITLE
chore(workflows): default rollout to v1.71

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.70",
+  "automation_ref": "v1.71",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.70"
+    assert config.automation_ref == "v1.71"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
## What

Bump the fleet default `automation_ref` from `v1.70` to `v1.71`.

## Why

v1.71 is tagged at `b24074e` and the whole fleet has already adopted it:

- `verify_workflow_release --ref v1.71 --expected-commit b24074e` → `PASS: v1.71 resolves to secure commit`
- fleet plan → 17 targets `PLANNED`, `blocked=0`
- 17/17 rollout PRs merged
- `audit_workflow_fleet --ref v1.71` → **`current=17 drift=0 blocked=0`**

v1.71 ships #128 Phase 2: OpenCode applies dismissals (closing #112) and a single
malformed block no longer discards the whole review.

## Verification

`scripts/workflow-config.json` and the `test_catalog_and_profiles_are_closed`
assertion pin the same value, so they move together. Verified two-sided with the
pyc cache disabled — `"v1.70"` and `"v1.71"` are the same byte length, so
same-second in-place edits otherwise reuse a stale `.pyc` and silently score the
previous state:

| arm | config | test asserts | result |
|---|---|---|---|
| 0 | v1.71 | v1.71 | PASS |
| 1 | v1.71 | v1.70 | FAIL |
| 2 | v1.70 | v1.71 | FAIL |
| base | v1.70 | v1.70 | PASS |

Full suite **3113 passed / 0 failed** (832 + 609 + 1672), actionlint clean.

Normalizing the ref token makes each changed blob byte-identical to its base
version, so the diff is exactly the version substitution and nothing else — the
same 2-file / 2-insertion / 2-deletion shape as the v1.69 and v1.70 bumps.

## Review

Pre-PR tribunal round 1 — gate `pass`, `blocking_count=0`. Three LOW,
non-blocking findings, all accepted as-is:

- `HANDOFF.md:13` still reads `automation_ref = v1.70`. Nothing in `scripts/` or
  `tests/` reads it; the repo closes this out in a separate `docs(handoff)`
  commit per release (`2e0d2b2` for v1.70, `45edd1e` for v1.69), and this
  release follows that pattern.
- The guard pins a string literal and does not itself prove the ref resolves to
  an annotated tag. The compensating control is fail-closed and was exercised:
  `--ref v1.99` is refused with `release tag identity is unavailable` (exit 1),
  and a mismatched `--expected-commit` is refused too.
- The literal pin at `tests/test_workflow_catalog.py:42` is the only reason this
  bump touches two files. Divergence is fail-loud in both directions, so the
  submitted diff is minimal under the current design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXN9uYgzFuB8UGqkC4RnQR