### PR TITLE
test(release): stop asserting the v1.45 fixtures' filesystem mode

### DIFF
--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -4006,7 +4006,8 @@ def test_v145_review_fixtures_match_the_immutable_release_blobs(
     assert hashlib.sha1(
         f"blob {len(payload)}\0".encode("ascii") + payload
     ).hexdigest() == oid
-    assert path.stat().st_mode & 0o777 == 0o644
+    # Mode is deliberately unasserted: no consumer of this root reads it, and
+    # path.stat() mixes the checkout's umask with the one bit Git records.
 
 
 def test_v145_review_workflows_restore_without_invoking_git(


### PR DESCRIPTION
Closes #161.

## What

Deletes one line from `test_v145_review_fixtures_match_the_immutable_release_blobs`
and puts a two-line comment in its place.

```diff
-    assert path.stat().st_mode & 0o777 == 0o644
+    # Mode is deliberately unasserted: no consumer of this root reads it, and
+    # path.stat() mixes the checkout's umask with the one bit Git records.
```

## Why

The assertion measured the checkout, not the fixture. Git records only the
executable bit — the index carries `100644` for both files — so a checkout made
under `umask 0002` materializes them at `0664` and both parametrizations fail
while the size and blob-oid assertions above them pass. The same revision passes
at 0022 and fails at 0002 and 0077 with byte-identical fixtures.

Nothing in the repository tree reads these fixtures' mode: all three
dereferences of `V145_REVIEW_FIXTURE_ROOT` go through `read_bytes()`, and
`restore_v145_review_workflows` never copies the source's mode. A Git blob
carries no mode, so the byte length and blob SHA-1 already pin the identity the
test is named for.

## The repair that was rejected first

Weakening it to `st_mode & 0o111 == 0` was tried and abandoned. That predicate
is umask-stable, so it misfires only under `core.fileMode=false`, but it is
unsound in the other direction — it passes while the committed tree holds
`100755` and the working tree does not, with a clean `git status`. Either way it
is still a working-tree read standing in for a recorded mode.

An index-based oracle was available; nothing in this module forbids a git
subprocess. It is omitted because nothing reads this mode, not because it was
unavailable.

## What the deletion gives up

A fixture path whose `stat()` permission bits are not 0644 now passes when its
bytes are correct. The old assertion compared against 0644 exactly, so what it
caught was incidental and target-dependent rather than a guarantee about any
recorded mode:

| entry | `stat()` mode | old assertion |
|---|---|---|
| `100644` regular | 0644 | passes (not caught) |
| `100755` regular | 0755 | **caught** |
| `120000` → 0644 target | 0644 | passes (**not caught**) |
| `120000` → 0755 target | 0755 | **caught** |
| `120000` → 0600 target | 0600 | **caught** |
| `040000` tree | — | `read_bytes()` raises `IsADirectoryError` |
| `160000` gitlink | — | `read_bytes()` raises `IsADirectoryError` |

Tree and gitlink entries still fail at HEAD, on `read_bytes()`.

## Verification

Measured in fresh checkouts under a controlled umask:

- fixtures at 0664, unchanged: **2 passed** (was 2 failed)
- one byte appended: 1 failed on the size assertion
- one byte flipped, length preserved: 1 failed on the blob-oid assertion
- exec bit set, bytes intact: 2 passed — mode is deliberately no longer checked
- module **609 passed**; whole suite **3113 passed**

The byte-drift arms matter more than the pass: they show the deletion leaves no
verification gap, because the surviving assertions still carry the test.

## Note for reviewers

A fixtures-only change starts no CI job — `test-fleet-tools.yml` filters on
`tests/*.py`, and there is no `.py` file under `tests/fixtures`. So the
byte-identity guard above is not CI-enforced for a change that touches only
fixture files. Pre-existing, unrelated to this diff, recorded here so it is not
mistaken for coverage this PR provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXN9uYgzFuB8UGqkC4RnQR
