### PR TITLE
chore(workflows): default rollout to v1.72

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.71",
+  "automation_ref": "v1.72",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.71"
+    assert config.automation_ref == "v1.72"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
## Summary\n\n- set the workflow-fleet default release to v1.72\n- update the catalog invariant to lock the new default\n- record the default only after all 17 branch targets were rolled out\n\n## Rollout evidence\n\n- release verifier: v1.72 resolved to b18f99256bc2bd41e4fc70c3025805b7682217a0\n- fleet audit: current=17 drift=0 blocked=0\n- scope: 16 repositories / 17 branch targets\n\n## Validation\n\n- RED: focused catalog invariant failed while the config still read v1.71\n- GREEN: tests/test_workflow_catalog.py — 20 passed\n- full suite: 3122 passed, 48 subtests passed\n- pre-PR tribunal: round 1 pass, blocking_count=0\n- tribunal snapshot: HEAD 8efb60aedae7033e630fa16d319415e492b49f07\n- tribunal diff SHA-256: 712f7ade8b9229bd433f6aa0a7714a459da73d85c938238fd252aacdee515bdc\n\nCloses #168