### PR TITLE
fix(review): preserve synthesized active findings

### DIFF
--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -4940,11 +4940,14 @@ jobs:
                   let stillOpenIndex = parsedReview.sections
                     .findIndex((item) => item.name === 'Still open');
                   if (stillOpenIndex === -1) {
-                    stillOpenIndex = parsedReview.sections.length;
-                    parsedReview.sections.push({ name: 'Still open', lines: [] });
+                    const firstInactiveIndex = parsedReview.sections.findIndex((item) =>
+                      item.name === 'Resolved' || item.name === 'Retracted');
+                    stillOpenIndex = firstInactiveIndex === -1
+                      ? parsedReview.sections.length : firstInactiveIndex;
+                    parsedReview.sections.splice(
+                      stillOpenIndex, 0, { name: 'Still open', lines: [] });
                   }
                   entry.section = 'Still open';
-                  entry.sectionIndex = stillOpenIndex;
                 }
                 normalizedCarryover.push({ entry, reason: 'invalid_anchor' });
               }
@@ -4954,9 +4957,9 @@ jobs:
               ...normalizedCarryover.filter((item) => item.dropped).map((item) => item.entry),
             ]);
             const canonicalReview = parsedReview
-              ? parsedReview.sections.map((section, sectionIndex) => {
+              ? parsedReview.sections.map((section) => {
                   const retained = parsedReview.blocks.filter((entry) =>
-                    entry.sectionIndex === sectionIndex && !filteredEntries.has(entry));
+                    entry.section === section.name && !filteredEntries.has(entry));
                   const sectionBody = retained.length === 0
                     ? 'None'
                     : retained.map((entry) => [renderHeading(entry), ...entry.block.lines]

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,6 @@
 # Handoff — automation
 
-_2026-09-08 · **v1.72 릴리스 완료, 플릿 롤아웃 대기** · main = `b18f992` · `automation_ref = v1.71`_
+_2026-09-08 · **v1.73 후보 작업 중 (#165 + #159), #166 합류 후 릴리스** · main = `6edfc6d` · `automation_ref = v1.72`_
 
 > 도구 비의존으로 쓴다. 다음 세션이 Codex 든 Claude Code 든 이것만 읽고 이어갈 수 있어야 한다.
 
@@ -13,30 +13,21 @@ _2026-09-08 · **v1.72 릴리스 완료, 플릿 롤아웃 대기** · main = `b1
     `python3 -m scripts.verify_workflow_release --ref v1.72 --expected-commit b18f9925…` → **PASS**.
   - CI 전체 통과(전체 스위트 + actionlint). 로컬 실측 3122 passed / 48 subtests.
   - 트리뷰널 5라운드, 최종 `pass / blocking_count 0`.
+  - v1.72 플릿 롤아웃 **17/17 머지**, audit `current=17 drift=0 blocked=0`.
+  - automation 기본 `automation_ref`를 v1.72로 올린 PR **#170** 머지
+    (`6edfc6d727c74b8df27b5bcb91fcefba4a56d791`).
   - Notion 저장 6건(KB 5 + DecisionLog 1).
 
 - **다음 구체 액션 1개**
-  **17타깃 플릿 롤아웃.** 절차 전문은 `docs/workflow-fleet-rollout.md` — 그대로 따르면 된다.
-  v1.72 고유 값만 바꾼다:
-  ```
-  export AUTOMATION_RELEASE_ROOT=/tmp/automation-v1.72-public
-  export FLEET_WORKSPACE=/tmp/automation-v1.72-fleet
-  export ACTIONLINT=/tmp/actionlint-v1.7.12/actionlint
-  ```
-  `--ref v1.72` 로 `--mode plan` → 매니페스트 확인 → `--mode publish`.
-  이어서 `automation_ref` 기본값을 v1.71 → v1.72 로 올리는 PR.
+  **#165 + #159 후보를 검증·머지한 뒤 #166을 별도 PR로 합류시킨다.**
+  세 변경이 main에 모이기 전에는 v1.73 태그를 만들지 않는다. 태그 검증이 통과하면
+  `docs/workflow-fleet-rollout.md` 절차로 v1.73 플릿 롤아웃을 한 번만 수행한다.
 
-- **먼저 결정할 것 (롤아웃 전)**
+- **결정 완료**
 
-  v1.72 는 **알려진 결함 #165 를 안고 나간다.** 롤아웃하면 17개 저장소가 그 코드를 실행한다.
-  두 갈래 중 하나를 고르고 시작할 것:
-
-  1. **#165 를 먼저 고쳐 v1.73 으로 묶어 롤아웃** — 배포 1회로 끝나지만 릴리스가 늦어진다.
-  2. **v1.72 를 지금 롤아웃하고 #165 는 v1.73 으로** — #162/#158 이익을 먼저 얻지만,
-     예산이 바인딩되는 PR 에서는 active set 이 먼저 잘릴 수 있는 상태로 운영된다.
-
-  판단 근거: #165 는 예산이 실제로 바인딩될 때만(이전 리뷰 20,000자 초과) 드러난다.
-  빈도는 측정된 바 없다 — 리뷰어도 "메커니즘은 주장하되 빈도는 주장하지 않는다"고 명시했다.
+  v1.72를 먼저 플릿에 배포했고, #165 수정은 #159 릴리스 픽스처 정리 및 #166 shell 문법
+  게이트와 함께 **v1.73 릴리스 한 번**으로 묶는다. #165와 #159는 파일 중첩이 커서 같은
+  구현 PR, #166은 독립 CI 경계라 별도 PR로 유지한다.
 
 ## 이 작업에서 생성한 이슈 2건 (독립 착수 가능)
 

--- a/docs/superpowers/plans/2026-09-08-opencode-active-section-order-v173.md
+++ b/docs/superpowers/plans/2026-09-08-opencode-active-section-order-v173.md
@@ -1,0 +1,261 @@
+# OpenCode Active Section Order v1.73 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve demoted OpenCode carryover findings ahead of inactive sections when the previous-review budget binds, while simplifying the historical release fixtures needed to authenticate v1.73.
+
+**Architecture:** The OpenCode canonicalizer will synthesize `Still open` before the first inactive section and bind rendered blocks by section name instead of mutable array position. Historical release reconstruction will copy current files first and apply each restore chain once, then a new v1.73 capability rung will authenticate the changed workflow without changing the immutable v1.72 contract.
+
+**Tech Stack:** GitHub Actions YAML, embedded JavaScript, Bash/AWK, Python 3, pytest, PyYAML, actionlint
+
+**Spec:** `HANDOFF.md`; GitHub Issues [#165](https://github.com/jhw7500/automation/issues/165) and [#159](https://github.com/jhw7500/automation/issues/159)
+
+## Global Constraints
+
+- Preserve annotated release tags; never move or recreate v1.72.
+- Keep the 20,000-character previous-review budget and finding-boundary clipping behavior unchanged.
+- Preserve model-authored section order except when the workflow must synthesize `Still open`; insert that section before the first `Resolved` or `Retracted` section.
+- Bind blocks to sections by the parsed section name so array insertion cannot silently reassign a block.
+- Preserve every historical release verifier rung and add v1.73 as a new rung.
+- Use behavior tests against the extracted workflow steps; do not assert source-text presence as the primary regression proof.
+
+---
+
+### Task 1: Make Historical Release Preparation Single-Pass
+
+**Files:**
+- Modify: `tests/test_verify_workflow_release.py:2031-2145`
+
+**Interfaces:**
+- Consumes: existing `restore_pre_v172_opencode_context_budget`, `restore_pre_v171_opencode_dismissals`, and `restore_pre_v170_opencode_finding_ids` helpers.
+- Produces: `prepare_v163` through `prepare_v168` fixtures whose copy phase always precedes one ordered restore phase.
+
+- [ ] **Step 1: Record the passing characterization baseline**
+
+Run:
+
+```bash
+rtk python3 -m pytest -q tests/test_verify_workflow_release.py -k 'v163 or v164 or v165 or v166 or v167 or v168'
+```
+
+Expected: all selected historical release-verification tests pass before the refactor.
+
+- [ ] **Step 2: Move the restore chain after all current-tree copies**
+
+For each of `prepare_v163` through `prepare_v168`, retain the exact version-specific copies and retirements, then place the ordered restore chain once immediately before `commit(...)`:
+
+```python
+restore_pre_v172_opencode_context_budget(repo)
+restore_pre_v171_opencode_dismissals(repo)
+restore_pre_v170_opencode_finding_ids(repo)
+```
+
+Do not change `prepare_v162`: its `restore_pre_v163_finding_dismissal(repo, budget=True)` is a distinct historical boundary.
+
+- [ ] **Step 3: Verify historical behavior stayed green**
+
+Run the Step 1 command again.
+
+Expected: the same selected historical releases pass with no digest or hunk-restoration failure.
+
+### Task 2: Prove the Active Finding Loss
+
+**Files:**
+- Modify: `tests/test_review_workflow_logic.py:14863`
+
+**Interfaces:**
+- Consumes: `_run_opencode_canonicalize`, `_run_opencode_ctx`, `_opencode_v2_body`, `_state_line`, and `_bot`.
+- Produces: two regression tests covering section assignment/order and the 20,000-character collector budget.
+
+- [ ] **Step 1: Add a failing canonicalizer ordering test**
+
+Create `test_opencode_invalid_anchor_synthesizes_still_open_before_inactive_sections`. Construct a prior active finding, then submit a candidate containing `New findings` and `Retracted` but no `Still open`; give the carried finding an out-of-scope current anchor so canonicalization demotes it.
+
+Assert these hand-derived outcomes:
+
+```python
+assert body.index("### New findings") < body.index("### Still open")
+assert body.index("### Still open") < body.index("### Retracted")
+still_open = body.split("### Still open", 1)[1].split("### Retracted", 1)[0]
+retracted = body.split("### Retracted", 1)[1]
+assert "Persisting problem" in still_open
+assert "Unrelated disproven problem" in retracted
+assert "Unrelated disproven problem" not in still_open
+```
+
+The unrelated retracted block must carry valid evidence and bind to a second prior active heading, so the real canonicalizer retains it.
+
+- [ ] **Step 2: Run the ordering test and observe RED**
+
+Run:
+
+```bash
+rtk python3 -m pytest -q tests/test_review_workflow_logic.py::test_opencode_invalid_anchor_synthesizes_still_open_before_inactive_sections
+```
+
+Expected: FAIL because the current body renders `Retracted` before the synthesized `Still open`.
+
+- [ ] **Step 3: Add a failing budget-integration test**
+
+Create `test_opencode_demoted_carryover_survives_previous_review_budget`. Generate enough retained `Retracted` blocks to exceed 20,000 characters, obtain the published body from `_run_opencode_canonicalize`, and feed that body to `_run_opencode_ctx`.
+
+Assert:
+
+```python
+assert "previous review truncated to fit the budget" in context
+assert "Persisting problem" in context
+assert "Retracted filler 59" not in context
+```
+
+- [ ] **Step 4: Run the budget test and observe RED**
+
+Run:
+
+```bash
+rtk python3 -m pytest -q tests/test_review_workflow_logic.py::test_opencode_demoted_carryover_survives_previous_review_budget
+```
+
+Expected: FAIL because tail clipping removes the synthesized active block before the fix.
+
+### Task 3: Render Synthesized Active Sections Safely
+
+**Files:**
+- Modify: `.github/workflows/opencode-auto-review.yml:4940-4965`
+- Test: `tests/test_review_workflow_logic.py`
+
+**Interfaces:**
+- Consumes: parsed section records with unique names and parsed block records with `entry.section`.
+- Produces: a canonical review whose synthesized `Still open` precedes inactive sections and whose block membership is invariant under section-array insertion.
+
+- [ ] **Step 1: Insert a missing active section before inactive sections**
+
+Replace append-only synthesis with:
+
+```javascript
+const firstInactiveIndex = parsedReview.sections.findIndex((item) =>
+  item.name === 'Resolved' || item.name === 'Retracted');
+stillOpenIndex = firstInactiveIndex === -1
+  ? parsedReview.sections.length : firstInactiveIndex;
+parsedReview.sections.splice(stillOpenIndex, 0, { name: 'Still open', lines: [] });
+```
+
+Keep `entry.section = 'Still open'`; no renderer behavior may depend on the shifted numeric index.
+
+- [ ] **Step 2: Bind rendered blocks by section name**
+
+Change the retained-block selection to:
+
+```javascript
+const retained = parsedReview.blocks.filter((entry) =>
+  entry.section === section.name && !filteredEntries.has(entry));
+```
+
+Remove the now-unnecessary renderer `sectionIndex` callback parameter and the reassignment of `entry.sectionIndex` during demotion.
+
+- [ ] **Step 3: Verify both regressions are GREEN**
+
+Run:
+
+```bash
+rtk python3 -m pytest -q tests/test_review_workflow_logic.py \
+  -k 'invalid_anchor_synthesizes or demoted_carryover_survives or out_of_scope_carryover_anchor'
+```
+
+Expected: all three tests pass.
+
+### Task 4: Add the Immutable v1.73 Release Rung
+
+**Files:**
+- Modify: `scripts/workflow_release_inventory.py:145-265`
+- Modify: `scripts/verify_workflow_release.py:817-830,5950-5975`
+- Modify: `tests/release_fixture_helpers.py:760`
+- Modify: `tests/test_verify_workflow_release.py:1-35,2140-2245`
+
+**Interfaces:**
+- Produces: `OPENCODE_ACTIVE_SECTION_ORDER_RELEASE = (1, 73)`, `release_supports_opencode_active_section_order(ref: str) -> bool`, `restore_pre_v173_opencode_active_section_order(repo: Path) -> None`, and `prepare_v173(repo: Path) -> str`.
+- Preserves: the v1.72 OpenCode workflow digest and fixture bytes.
+
+- [ ] **Step 1: Add failing v1.73 boundary tests**
+
+Add these behavior checks:
+
+```python
+assert release_inventory.release_supports_opencode_active_section_order("v1.72") is False
+assert release_inventory.release_supports_opencode_active_section_order("v1.73") is True
+```
+
+Add a `prepare_v173` fixture and tests proving:
+
+- the current workflow passes the v1.73 verifier;
+- the current workflow is rejected on the v1.72 release line;
+- a workflow restored with `restore_pre_v173_opencode_active_section_order` is rejected on the v1.73 line;
+- the restored workflow still passes the v1.72 line.
+
+- [ ] **Step 2: Run the new release tests and observe RED**
+
+Run:
+
+```bash
+rtk python3 -m pytest -q tests/test_verify_workflow_release.py -k 'v172 or v173'
+```
+
+Expected: FAIL because the v1.73 predicate, restore helper, and authenticated digest rung do not exist.
+
+- [ ] **Step 3: Implement the capability and historical restore**
+
+Add the v1.73 constant/predicate. Add one exact current-to-v1.72 workflow hunk for the insertion and name-based renderer change, applying it before the v1.72 restore. Import the predicate into the verifier and select a new `EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256` only for v1.73 and later.
+
+- [ ] **Step 4: Compute and pin the authenticated current workflow digest**
+
+Run:
+
+```bash
+rtk sha256sum .github/workflows/opencode-auto-review.yml
+```
+
+Copy the observed lowercase digest into the v1.73 OpenCode digest entry; retain the v1.72 digest constant unchanged.
+
+- [ ] **Step 5: Verify v1.72 and v1.73 are both GREEN**
+
+Run the Step 2 command again.
+
+Expected: all selected v1.72/v1.73 release tests pass.
+
+### Task 5: Update the Active Contract and Validate the Release Candidate
+
+**Files:**
+- Modify: `docs/workflows/contracts.md:590-617`
+- Modify: `HANDOFF.md`
+
+**Interfaces:**
+- Produces: an operator-facing contract that distinguishes the remaining model-authored order freedom from the fixed workflow-synthesized order.
+
+- [ ] **Step 1: Update the contract**
+
+State that from v1.73 a synthesized `Still open` is inserted before `Resolved`/`Retracted`, rendering binds by section name, and the active block therefore precedes inactive tail blocks. Retain the documented limitation that a model-authored existing `Still open` may still appear in any grammar-valid relative order.
+
+- [ ] **Step 2: Update the handoff**
+
+Record #165 and #159 as implemented in the candidate, identify #166 as the separate pre-tag PR, and do not claim v1.73 released or rolled out before those external actions occur.
+
+- [ ] **Step 3: Run focused validation**
+
+```bash
+rtk python3 -m pytest -q tests/test_review_workflow_logic.py tests/test_verify_workflow_release.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Run repository validation**
+
+```bash
+rtk python3 -m pytest -q
+rtk python3 -c 'from pathlib import Path; import yaml; [yaml.safe_load(path.read_text()) for path in Path(".github/workflows").glob("*.yml")]'
+rtk /tmp/actionlint-v1.7.12/actionlint -shellcheck= -pyflakes= .github/workflows/*.yml examples/baseline-workflows/.github/workflows/*.yml
+```
+
+Expected: the full pytest summary reports zero failures, YAML parsing exits 0, and actionlint exits 0.
+
+- [ ] **Step 5: Run the pre-PR tribunal and create the PR only after zero blockers**
+
+Use the repository pre-PR tribunal workflow against the committed head. Any code change invalidates the verdict and requires a fresh round.

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -606,6 +606,15 @@ then spends the active set first. That second cause is a defect, not a design; s
 count therefore mixes whatever the tail reached, and the notice says only that those findings
 must not be treated as resolved. Do not read a rarity argument into the budget size.
 
+From `v1.73` the workflow-owned second cause is removed. When anchor normalization has to create
+a missing `Still open` section, it inserts that section before the first `Resolved` or
+`Retracted` section, and canonical rendering binds each block by section name rather than by the
+array position that the insertion changes. The demoted active block therefore stays in
+`Still open`, ahead of the inactive tail the budget spends first. This does not reorder a
+`Still open` section the model already supplied: the candidate grammar still leaves its relative
+position free, so model-authored ordering can still put either `Still open` or `Retracted` in
+the tail. The truncation count therefore remains status-neutral.
+
 The notice is not sufficient on its own, and this is the one place where `v1.72` is worse than
 what it replaces. Because the cut lands on a finding boundary, a section whose every block is
 spent is emitted as a bare heading — the old character-offset clip left a partial block, which at

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -57,6 +57,7 @@ from scripts.workflow_release_inventory import (
     release_supports_opencode_finding_ids,
     release_supports_opencode_dismissals,
     release_supports_opencode_context_budget,
+    release_supports_opencode_active_section_order,
     release_retires_manual_pr_review,
     release_supports_same_head_cancel_guard,
     release_supports_review_policy,
@@ -821,6 +822,13 @@ EXPECTED_OPENCODE_CONTEXT_BUDGET_WORKFLOW_SHA256 = {
     "claude": "a6116cf542876a46e8401e26471324a586772398ad5d21360155e686123104be",
     "gemini": "33c15251ac3e7dd97a3c0d30c77dd40e6ac58fe087d93078ce468dba473027b2",
     "opencode": "9c7dfd5afc5ce5dea9fcaf51c1e3c0c362ef93ebca757621e82ba12c0bc12263",
+}
+# v1.73 keeps a workflow-synthesized active section ahead of inactive sections and
+# renders block membership by section name. Claude and Gemini are unchanged.
+EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256 = {
+    "claude": "a6116cf542876a46e8401e26471324a586772398ad5d21360155e686123104be",
+    "gemini": "33c15251ac3e7dd97a3c0d30c77dd40e6ac58fe087d93078ce468dba473027b2",
+    "opencode": "f81db9665847aea815c8691caea7c6458011595cbed28c13809f051c381b5e91",
 }
 EXPECTED_REVIEW_POLICY_HELPER_SHA256 = (
     "3e0fd3c86b1dc40dc35213ca41c3d63122c9ebf757042f5a2c86f4fc1e99ac8a"
@@ -2519,6 +2527,7 @@ def verify_opencode_runtime(
         EXPECTED_OPENCODE_FINDING_ID_WORKFLOW_SHA256["opencode"],
         EXPECTED_OPENCODE_DISMISSAL_WORKFLOW_SHA256["opencode"],
         EXPECTED_OPENCODE_CONTEXT_BUDGET_WORKFLOW_SHA256["opencode"],
+        EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256["opencode"],
     }
     initial_validation_argument = " initial" if current_diagnostics_contract else ""
     repair_validation_argument = " repair" if current_diagnostics_contract else ""
@@ -2557,6 +2566,7 @@ def verify_opencode_runtime(
             EXPECTED_OPENCODE_FINDING_ID_WORKFLOW_SHA256["opencode"],
             EXPECTED_OPENCODE_DISMISSAL_WORKFLOW_SHA256["opencode"],
             EXPECTED_OPENCODE_CONTEXT_BUDGET_WORKFLOW_SHA256["opencode"],
+            EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256["opencode"],
         }
         and run_step.get("shell") == "bash"
         and run_env.get("CANDIDATE_NONCE")
@@ -5952,7 +5962,9 @@ def _verify_review_invocation_budget(
         ),
     }
     workflow_digests = (
-        EXPECTED_OPENCODE_CONTEXT_BUDGET_WORKFLOW_SHA256
+        EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256
+        if release_supports_opencode_active_section_order(ref)
+        else EXPECTED_OPENCODE_CONTEXT_BUDGET_WORKFLOW_SHA256
         if release_supports_opencode_context_budget(ref)
         else EXPECTED_OPENCODE_DISMISSAL_WORKFLOW_SHA256
         if release_supports_opencode_dismissals(ref)

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -160,6 +160,7 @@ MANUAL_PR_REVIEW_RETIRED_RELEASE = (1, 68)
 OPENCODE_FINDING_ID_RELEASE = (1, 70)
 OPENCODE_DISMISSAL_RELEASE = (1, 71)
 OPENCODE_CONTEXT_BUDGET_RELEASE = (1, 72)
+OPENCODE_ACTIVE_SECTION_ORDER_RELEASE = (1, 73)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -262,6 +263,12 @@ def release_supports_opencode_context_budget(ref: str) -> bool:
     """Return whether ``ref`` gives the previous review its own clipped context budget."""
 
     return _release_version(ref) >= OPENCODE_CONTEXT_BUDGET_RELEASE
+
+
+def release_supports_opencode_active_section_order(ref: str) -> bool:
+    """Return whether ``ref`` renders a synthesized active section before inactive ones."""
+
+    return _release_version(ref) >= OPENCODE_ACTIVE_SECTION_ORDER_RELEASE
 
 
 def release_retires_manual_pr_review(ref: str) -> bool:

--- a/tests/release_fixture_helpers.py
+++ b/tests/release_fixture_helpers.py
@@ -711,6 +711,58 @@ def restore_pre_v166_label_mismatch_decline(repo: Path) -> None:
         helper.write_text(text.replace(current, historical), encoding="utf-8")
 
 
+PRE_V173_OPENCODE_ACTIVE_SECTION_ORDER_HUNKS = (
+    (
+        """                  let stillOpenIndex = parsedReview.sections
+                    .findIndex((item) => item.name === 'Still open');
+                  if (stillOpenIndex === -1) {
+                    const firstInactiveIndex = parsedReview.sections.findIndex((item) =>
+                      item.name === 'Resolved' || item.name === 'Retracted');
+                    stillOpenIndex = firstInactiveIndex === -1
+                      ? parsedReview.sections.length : firstInactiveIndex;
+                    parsedReview.sections.splice(
+                      stillOpenIndex, 0, { name: 'Still open', lines: [] });
+                  }
+                  entry.section = 'Still open';
+""",
+        """                  let stillOpenIndex = parsedReview.sections
+                    .findIndex((item) => item.name === 'Still open');
+                  if (stillOpenIndex === -1) {
+                    stillOpenIndex = parsedReview.sections.length;
+                    parsedReview.sections.push({ name: 'Still open', lines: [] });
+                  }
+                  entry.section = 'Still open';
+                  entry.sectionIndex = stillOpenIndex;
+""",
+    ),
+    (
+        """            const canonicalReview = parsedReview
+              ? parsedReview.sections.map((section) => {
+                  const retained = parsedReview.blocks.filter((entry) =>
+                    entry.section === section.name && !filteredEntries.has(entry));
+""",
+        """            const canonicalReview = parsedReview
+              ? parsedReview.sections.map((section, sectionIndex) => {
+                  const retained = parsedReview.blocks.filter((entry) =>
+                    entry.sectionIndex === sectionIndex && !filteredEntries.has(entry));
+""",
+    ),
+)
+
+
+def restore_pre_v173_opencode_active_section_order(repo: Path) -> None:
+    """Restore the v1.72 positional renderer and append-only active section."""
+
+    path = repo / ".github/workflows/opencode-auto-review.yml"
+    if not path.exists():
+        return
+    text = path.read_text(encoding="utf-8")
+    for current, historical in reversed(PRE_V173_OPENCODE_ACTIVE_SECTION_ORDER_HUNKS):
+        assert text.count(current) <= 1
+        text = text.replace(current, historical)
+    path.write_text(text, encoding="utf-8")
+
+
 PRE_V172_OPENCODE_CONTEXT_BUDGET_HUNKS = {
     '.github/workflows/opencode-auto-review.yml': (
         (
@@ -766,6 +818,7 @@ def restore_pre_v172_opencode_context_budget(repo: Path) -> None:
     (newest release first) so the older restores still find their text.
     """
 
+    restore_pre_v173_opencode_active_section_order(repo)
     for relative, hunks in PRE_V172_OPENCODE_CONTEXT_BUDGET_HUNKS.items():
         path = repo / relative
         if not path.exists():

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -14925,6 +14925,136 @@ def test_opencode_out_of_scope_carryover_anchor_no_longer_kills_the_review(tmp_p
 
 
 @node_required
+def test_opencode_invalid_anchor_synthesizes_still_open_before_inactive_sections(
+    tmp_path,
+):
+    """A synthesized active section must precede inactive sections without stealing blocks."""
+    head = "ab" * 20
+    in_scope = json.dumps(
+        {"path": OPENCODE_SCOPE_PATH, "line": 1},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    out_of_scope = json.dumps(
+        {"path": ".github/workflows/gemini-auto-review.yml", "line": 74},
+        separators=(",", ":"),
+    )
+    active = "RVW-aaaaaaaaaaaa"
+    inactive = "RVW-bbbbbbbbbbbb"
+    prior_body = (
+        "### New findings\n"
+        f"#### {active} [HIGH] Persisting problem\n"
+        f"- Changed anchor: {in_scope}\nprior active evidence\n\n"
+        f"#### {inactive} [MEDIUM] Unrelated disproven problem\n"
+        f"- Changed anchor: {in_scope}\nprior inactive evidence"
+    )
+    prior = _bot(
+        "github-actions[bot]",
+        _opencode_v2_body(_state_line("opencode", 7, 1, head), prior_body),
+        1,
+    )
+    current = (
+        f"{OPENCODE_MARKER}\n### New findings\nNone\n"
+        f"### Retracted\n#### {active} [HIGH] Persisting problem\n"
+        f"- Changed anchor: {out_of_scope}\n"
+        '- Current line: "outside line"\n'
+        "unsupported disposition\n\n"
+        f"#### {inactive} [MEDIUM] Unrelated disproven problem\n"
+        f"- Changed anchor: {in_scope}\n"
+        '- Current line: "added line 1"\n'
+        "verified retraction evidence"
+    )
+
+    calls = _run_opencode_canonicalize(
+        tmp_path,
+        [prior],
+        [prior, _bot("github-actions[bot]", current, 10, updated="u2")],
+    )
+
+    body = next(call[1]["body"] for call in calls if call[0] == "create")
+    assert body.index("### New findings") < body.index("### Still open")
+    assert body.index("### Still open") < body.index("### Retracted")
+    still_open = body.split("### Still open", 1)[1].split("### Retracted", 1)[0]
+    retracted = body.split("### Retracted", 1)[1]
+    assert "Persisting problem" in still_open
+    assert "Unrelated disproven problem" in retracted
+    assert "Unrelated disproven problem" not in still_open
+
+
+@node_required
+def test_opencode_demoted_carryover_survives_previous_review_budget(tmp_path):
+    """Tail clipping must spend inactive blocks before a workflow-demoted active block."""
+    head = "ab" * 20
+    in_scope = json.dumps(
+        {"path": OPENCODE_SCOPE_PATH, "line": 1},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    out_of_scope = json.dumps(
+        {"path": ".github/workflows/gemini-auto-review.yml", "line": 74},
+        separators=(",", ":"),
+    )
+    active = "RVW-aaaaaaaaaaaa"
+    filler_count = 60
+    prior_fillers = "\n\n".join(
+        f"#### RVW-{index:012x} [MEDIUM] Retracted filler {index}\n"
+        f"- Changed anchor: {in_scope}\nprior filler evidence {index}"
+        for index in range(1, filler_count + 1)
+    )
+    prior_body = (
+        "### New findings\n"
+        f"#### {active} [HIGH] Persisting problem\n"
+        f"- Changed anchor: {in_scope}\nprior active evidence\n\n"
+        f"{prior_fillers}"
+    )
+    prior = _bot(
+        "github-actions[bot]",
+        _opencode_v2_body(_state_line("opencode", 7, 1, head), prior_body),
+        1,
+    )
+    filler_prose = "Retraction evidence remains available for audit. " * 12
+    current_fillers = "\n\n".join(
+        f"#### RVW-{index:012x} [MEDIUM] Retracted filler {index}\n"
+        f"- Changed anchor: {in_scope}\n"
+        '- Current line: "added line 1"\n'
+        f"{filler_prose}{index}"
+        for index in range(1, filler_count + 1)
+    )
+    current = (
+        f"{OPENCODE_MARKER}\n### New findings\nNone\n"
+        f"### Retracted\n#### {active} [HIGH] Persisting problem\n"
+        f"- Changed anchor: {out_of_scope}\n"
+        '- Current line: "outside line"\n'
+        "unsupported disposition\n\n"
+        f"{current_fillers}"
+    )
+    calls = _run_opencode_canonicalize(
+        tmp_path,
+        [prior],
+        [prior, _bot("github-actions[bot]", current, 10, updated="u2")],
+    )
+    published = next(call[1]["body"] for call in calls if call[0] == "create")
+    published_comment = _bot(
+        "github-actions[bot]", published, 20, updated="u3"
+    )
+    attestation_id = int(
+        re.search(r"^- Attestation: ([1-9][0-9]*)$", published, re.MULTILINE).group(1)
+    )
+
+    context = _run_opencode_ctx(
+        tmp_path,
+        [published_comment],
+        check_runs=[
+            _opencode_attestation(published_comment, check_id=attestation_id)
+        ],
+    )
+
+    assert "previous review truncated to fit the budget" in context
+    assert "Persisting problem" in context
+    assert "Retracted filler 59" not in context
+
+
+@node_required
 @pytest.mark.parametrize("section", ["Resolved", "Retracted"])
 def test_opencode_rereview_rejects_carryover_without_current_evidence(
     tmp_path, section

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -31,6 +31,7 @@ from release_fixture_helpers import (
     restore_pre_v164_label_trigger,
     restore_pre_v171_opencode_dismissals,
     restore_pre_v172_opencode_context_budget,
+    restore_pre_v173_opencode_active_section_order,
     restore_pre_v170_opencode_finding_ids,
     restore_retired_manual_pr_review,
     restore_pre_v166_label_mismatch_decline,
@@ -2030,9 +2031,6 @@ def prepare_v162(repo: Path) -> str:
 
 def prepare_v163(repo: Path) -> str:
     copy_review_policy_release_files(repo)
-    restore_pre_v172_opencode_context_budget(repo)
-    restore_pre_v171_opencode_dismissals(repo)
-    restore_pre_v170_opencode_finding_ids(repo)
     restore_retired_manual_pr_review(repo)
     restore_pre_v166_label_mismatch_decline(repo)
     restore_pre_v165_skip_reason_notice(repo)
@@ -2044,15 +2042,14 @@ def prepare_v163(repo: Path) -> str:
         ".github/actions/canonicalize-review/canonicalize_review.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v172_opencode_context_budget(repo)
     restore_pre_v171_opencode_dismissals(repo)
+    restore_pre_v170_opencode_finding_ids(repo)
     return commit(repo, "v1.63 candidate")
 
 
 def prepare_v164(repo: Path) -> str:
     copy_review_policy_release_files(repo)
-    restore_pre_v172_opencode_context_budget(repo)
-    restore_pre_v171_opencode_dismissals(repo)
-    restore_pre_v170_opencode_finding_ids(repo)
     restore_retired_manual_pr_review(repo)
     restore_pre_v166_label_mismatch_decline(repo)
     restore_pre_v165_skip_reason_notice(repo)
@@ -2063,15 +2060,14 @@ def prepare_v164(repo: Path) -> str:
         ".github/actions/canonicalize-review/canonicalize_review.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v172_opencode_context_budget(repo)
     restore_pre_v171_opencode_dismissals(repo)
+    restore_pre_v170_opencode_finding_ids(repo)
     return commit(repo, "v1.64 candidate")
 
 
 def prepare_v165(repo: Path) -> str:
     copy_review_policy_release_files(repo)
-    restore_pre_v172_opencode_context_budget(repo)
-    restore_pre_v171_opencode_dismissals(repo)
-    restore_pre_v170_opencode_finding_ids(repo)
     restore_retired_manual_pr_review(repo)
     restore_pre_v166_label_mismatch_decline(repo)
     for relative in (
@@ -2081,15 +2077,14 @@ def prepare_v165(repo: Path) -> str:
         ".github/actions/canonicalize-review/canonicalize_review.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v172_opencode_context_budget(repo)
     restore_pre_v171_opencode_dismissals(repo)
+    restore_pre_v170_opencode_finding_ids(repo)
     return commit(repo, "v1.65 candidate")
 
 
 def prepare_v166(repo: Path) -> str:
     copy_review_policy_release_files(repo)
-    restore_pre_v172_opencode_context_budget(repo)
-    restore_pre_v171_opencode_dismissals(repo)
-    restore_pre_v170_opencode_finding_ids(repo)
     restore_retired_manual_pr_review(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",
@@ -2099,15 +2094,14 @@ def prepare_v166(repo: Path) -> str:
         ".github/actions/resolve-review-policy/resolve_review_policy.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v172_opencode_context_budget(repo)
     restore_pre_v171_opencode_dismissals(repo)
+    restore_pre_v170_opencode_finding_ids(repo)
     return commit(repo, "v1.66 candidate")
 
 
 def prepare_v167(repo: Path) -> str:
     copy_review_policy_release_files(repo)
-    restore_pre_v172_opencode_context_budget(repo)
-    restore_pre_v171_opencode_dismissals(repo)
-    restore_pre_v170_opencode_finding_ids(repo)
     restore_retired_manual_pr_review(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",
@@ -2118,15 +2112,14 @@ def prepare_v167(repo: Path) -> str:
         ".github/workflows/gemini-dispatch.yml",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v172_opencode_context_budget(repo)
     restore_pre_v171_opencode_dismissals(repo)
+    restore_pre_v170_opencode_finding_ids(repo)
     return commit(repo, "v1.67 candidate")
 
 
 def prepare_v168(repo: Path) -> str:
     copy_review_policy_release_files(repo)
-    restore_pre_v172_opencode_context_budget(repo)
-    restore_pre_v171_opencode_dismissals(repo)
-    restore_pre_v170_opencode_finding_ids(repo)
     for relative in (
         ".github/actions/review-invocation-budget/action.yml",
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
@@ -2151,7 +2144,9 @@ def prepare_v168(repo: Path) -> str:
         encoding="utf-8",
     )
     shutil.copy2(ROOT / "scripts/workflow-catalog.json", repo / "scripts/workflow-catalog.json")
+    restore_pre_v172_opencode_context_budget(repo)
     restore_pre_v171_opencode_dismissals(repo)
+    restore_pre_v170_opencode_finding_ids(repo)
     return commit(repo, "v1.68 candidate")
 
 
@@ -2186,7 +2181,18 @@ def prepare_v172(repo: Path) -> str:
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v173_opencode_active_section_order(repo)
     return commit(repo, "v1.72 candidate")
+
+
+def prepare_v173(repo: Path) -> str:
+    prepare_v168(repo)
+    for relative in (
+        ".github/workflows/opencode-auto-review.yml",
+        ".github/actions/review-invocation-budget/review_invocation_budget.py",
+    ):
+        shutil.copy2(ROOT / relative, repo / relative)
+    return commit(repo, "v1.73 candidate")
 
 
 def test_v171_accepts_current_opencode_dismissal_release_contract(
@@ -2205,6 +2211,46 @@ def test_v172_accepts_current_opencode_context_budget_release_contract(
     candidate = prepare_v172(repo)
 
     assert release_verifier.verify_commit_content(repo, "v1.72", candidate) == candidate
+
+
+def test_opencode_active_section_order_release_boundary() -> None:
+    assert (
+        release_inventory.release_supports_opencode_active_section_order("v1.72")
+        is False
+    )
+    assert (
+        release_inventory.release_supports_opencode_active_section_order("v1.73")
+        is True
+    )
+
+
+def test_v173_accepts_current_opencode_active_section_order_release_contract(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v173(repo)
+
+    assert release_verifier.verify_commit_content(repo, "v1.73", candidate) == candidate
+
+
+def test_v173_opencode_active_section_order_is_rejected_on_the_v172_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v173(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.72", candidate)
+
+
+def test_pre_v173_opencode_section_order_is_rejected_on_the_v173_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v172(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.73", candidate)
 
 
 def test_v172_opencode_context_budget_is_rejected_on_the_v171_release_line(


### PR DESCRIPTION
## Summary

- synthesize a missing `Still open` section before inactive sections
- retain workflow-demoted active findings when the previous-review context hits its budget
- simplify the historical release fixture restore chain and add the v1.73 digest/capability rung
- update the workflow contract and release handoff

## Validation

- 3,128 tests passed
- 48 subtests passed
- YAML parse passed
- actionlint passed
- pre-PR tribunal round 1 passed with 0 blocking findings

Closes #165
Closes #159
