### PR TITLE
chore(workflows): default rollout to v1.73

### DIFF
--- a/scripts/workflow-config.json
+++ b/scripts/workflow-config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "gh_owner": "jhw7500",
-  "automation_ref": "v1.72",
+  "automation_ref": "v1.73",
   "canonical_dir": "examples/baseline-workflows/.github",
   "catalog": "scripts/workflow-catalog.json",
   "repos": {

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -39,7 +39,7 @@ def test_catalog_and_profiles_are_closed() -> None:
     catalog = load_catalog(ROOT)
     config = load_fleet_config(ROOT, catalog)
     assert config.owner == "jhw7500"
-    assert config.automation_ref == "v1.72"
+    assert config.automation_ref == "v1.73"
     assert config.canonical_dir == PurePosixPath("examples/baseline-workflows/.github")
     assert set(config.profiles) == set(EXPECTED)
     for name, (optional, auth, bootstrap) in EXPECTED.items():


### PR DESCRIPTION
## Summary

- default new workflow rollout configuration to immutable automation ref v1.73
- update the closed catalog contract to match the new default

## Validation

- focused catalog contract: 1 passed
- pre-PR tribunal: pass, 0 blockers
- v1.73 fleet audit: current=17, drift=0, blocked=0