### PR TITLE
fix(review): expand invocation budget and repair later-round handoffs

### DIFF
--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -85,8 +85,9 @@ def _exact_keys(value: object, keys: set[str], name: str) -> Mapping[str, object
 
 
 MAX_ROUNDS_VARIABLE = "REVIEW_MAX_ROUNDS"
-MAX_ROUNDS_DEFAULT = 2
+MAX_ROUNDS_DEFAULT = 5
 MAX_ROUNDS_CEILING = 5
+MAX_OVERRIDE_ROUNDS = 2
 
 
 def configured_max_rounds() -> int:
@@ -114,8 +115,8 @@ def configured_max_rounds() -> int:
 
 @dataclass(frozen=True)
 class BudgetPolicy:
-    max_rounds: int = 2
-    max_override_rounds: int = 1
+    max_rounds: int = 5
+    max_override_rounds: int = 2
     max_calls_per_round: int = 1
     max_wall_seconds_per_round: int = 600
     max_estimated_tokens_per_round: int = 200_000
@@ -433,7 +434,10 @@ class Handoff:
                 not all(isinstance(item, str) and _FINDING.fullmatch(item) for item in findings)):
             raise BudgetStateError("handoff_invalid")
         usage = value["round_usage"]
-        if not isinstance(usage, list) or len(usage) > 3:
+        if (
+            not isinstance(usage, list)
+            or len(usage) > MAX_ROUNDS_CEILING + MAX_OVERRIDE_ROUNDS
+        ):
             raise BudgetStateError("handoff_invalid")
         parsed_usage: list[tuple[int, int, int, int]] = []
         for item in usage:
@@ -598,6 +602,10 @@ def effective_budgets(state: LedgerState) -> BudgetPolicy:
     return replace(
         state.budgets,
         max_rounds=max(state.budgets.max_rounds, configured_max_rounds()),
+        max_override_rounds=max(
+            state.budgets.max_override_rounds,
+            MAX_OVERRIDE_ROUNDS,
+        ),
     )
 
 
@@ -607,9 +615,22 @@ def _validate_state_shape(state: LedgerState) -> None:
     _integer(state.pr, "pr", positive=True)
     BudgetPolicy.from_dict(state.budgets.to_dict())
     budgets = effective_budgets(state)
-    recorded = {key: value for key, value in state.budgets.to_dict().items() if key != "max_rounds"}
-    expected = {key: value for key, value in BudgetPolicy.for_reviewer(state.reviewer).to_dict().items() if key != "max_rounds"}
-    if recorded != expected or not 1 <= state.budgets.max_rounds <= MAX_ROUNDS_CEILING:
+    variable_budgets = {"max_rounds", "max_override_rounds"}
+    recorded = {
+        key: value
+        for key, value in state.budgets.to_dict().items()
+        if key not in variable_budgets
+    }
+    expected = {
+        key: value
+        for key, value in BudgetPolicy.for_reviewer(state.reviewer).to_dict().items()
+        if key not in variable_budgets
+    }
+    if (
+        recorded != expected
+        or not 1 <= state.budgets.max_rounds <= MAX_ROUNDS_CEILING
+        or not 1 <= state.budgets.max_override_rounds <= MAX_OVERRIDE_ROUNDS
+    ):
         raise BudgetStateError("budgets_invalid")
     if len(state.invocations) > budgets.max_rounds + budgets.max_override_rounds or len(state.consumed_override_event_ids) != len(set(state.consumed_override_event_ids)):
         raise BudgetStateError("ledger_invalid")
@@ -639,36 +660,45 @@ def _validate_state_shape(state: LedgerState) -> None:
         raise BudgetStateError("duplicate_run_identity")
     automatic = [item for item in state.invocations if item.override_event_id is None]
     overrides = [item for item in state.invocations if item.override_event_id is not None]
-    forced_override = next(
-        (item for item in overrides if item.caller_event == "workflow_dispatch"), None
-    )
+    if state.reviewer == "opencode" and overrides:
+        raise BudgetStateError("override_invalid")
     for attribute, reason in (
         ("head_sha", "duplicate_head"),
         ("full_diff_sha256", "duplicate_effective_diff"),
     ):
         values = [getattr(item, attribute) for item in state.invocations]
         duplicates = {value for value in values if values.count(value) > 1}
-        if duplicates and (
-            forced_override is None
-            or any(values.count(value) != 2 for value in duplicates)
-            or any(getattr(forced_override, attribute) != value for value in duplicates)
-            or all(getattr(item, attribute) not in duplicates for item in automatic)
-        ):
-            raise BudgetStateError(reason)
+        for value in duplicates:
+            repeated = [
+                item
+                for item in state.invocations
+                if getattr(item, attribute) == value
+            ]
+            if any(
+                item.override_event_id is None
+                or item.caller_event != "workflow_dispatch"
+                for item in repeated[1:]
+            ):
+                raise BudgetStateError(reason)
     if len(automatic) > budgets.max_rounds or len(overrides) > budgets.max_override_rounds:
         raise BudgetStateError("rounds_invalid")
     if [item.round_number for item in automatic] != list(range(1, len(automatic) + 1)):
         raise BudgetStateError("rounds_invalid")
     if overrides:
-        item = overrides[0]
+        first_override = overrides[0]
         expected_automatic_rounds = (
-            range(0, state.budgets.max_rounds + 1)
-            if item.caller_event == "workflow_dispatch"
-            else (state.budgets.max_rounds,)
+            range(0, budgets.max_rounds + 1)
+            if first_override.caller_event == "workflow_dispatch"
+            else range(state.budgets.max_rounds, budgets.max_rounds + 1)
         )
-        if (len(automatic) not in expected_automatic_rounds or state.invocations[-1] != item or
-                item.round_number != len(automatic) + 1 or
-                item.override_event_id not in state.consumed_override_event_ids):
+        if (
+            len(automatic) not in expected_automatic_rounds
+            or tuple(state.invocations) != tuple(automatic + overrides)
+            or [item.round_number for item in overrides]
+            != list(range(len(automatic) + 1, len(state.invocations) + 1))
+            or tuple(item.override_event_id for item in overrides)
+            != state.consumed_override_event_ids
+        ):
             raise BudgetStateError("override_invalid")
     if len(state.consumed_override_event_ids) != len(overrides):
         raise BudgetStateError("override_invalid")
@@ -676,8 +706,7 @@ def _validate_state_shape(state: LedgerState) -> None:
     total_limit = state.budgets.max_estimated_tokens_total
     if automatic_total > total_limit:
         raise BudgetStateError("total_usage_budget_exhausted")
-    if overrides:
-        total_limit += state.budgets.max_estimated_tokens_per_round
+    total_limit += len(overrides) * state.budgets.max_estimated_tokens_per_round
     if sum(item.estimated_input_tokens for item in state.invocations) > total_limit:
         raise BudgetStateError("total_usage_budget_exhausted")
     _validate_dismissed_findings(state.dismissed_findings)
@@ -1038,7 +1067,10 @@ def choose_override(state: LedgerState, events: Sequence[OverrideEvent]) -> Over
     # consuming it for a verdict that is then thrown away.
     if state.reviewer == "opencode":
         return None
-    if any(item.override_event_id is not None for item in state.invocations):
+    if (
+        sum(item.override_event_id is not None for item in state.invocations)
+        >= effective_budgets(state).max_override_rounds
+    ):
         return None
     eligible: list[OverrideEvent] = []
     for event in events:
@@ -1137,10 +1169,11 @@ def claim(state: LedgerState | None, request: ClaimRequest,
         return refuse(validated, request, "duplicate_effective_diff")
     if request.estimated_input_tokens > validated.budgets.max_estimated_tokens_per_round:
         return refuse(validated, request, "input_budget_exhausted")
+    override_count = sum(
+        item.override_event_id is not None for item in validated.invocations
+    )
     override = None
-    if any(item.override_event_id is not None for item in validated.invocations):
-        return refuse(validated, request, "round_budget_exhausted")
-    if request.force_review:
+    if override_count or request.force_review:
         override = choose_override(validated, request.override_events)
         if override is None:
             return refuse(validated, request, "round_budget_exhausted")
@@ -1148,7 +1181,11 @@ def claim(state: LedgerState | None, request: ClaimRequest,
         override = choose_override(validated, request.override_events)
         if override is None:
             return refuse(validated, request, "round_budget_exhausted")
-    total_limit = 600_000 if override is not None else 400_000
+    total_limit = (
+        validated.budgets.max_estimated_tokens_total
+        + (override_count + int(override is not None))
+        * validated.budgets.max_estimated_tokens_per_round
+    )
     if estimated_total(validated) + request.estimated_input_tokens > total_limit:
         return refuse(validated, request, "total_usage_budget_exhausted")
     return append_claim(
@@ -1287,6 +1324,8 @@ _REVIEWER_TITLES = {"claude": "Claude", "gemini": "Gemini", "opencode": "OpenCod
 def _summary(state: LedgerState, *, server_url: str) -> str:
     _validate_state_shape(state)
     handoff = state.handoff
+    budgets = effective_budgets(state)
+    override_limit = 0 if state.reviewer == "opencode" else budgets.max_override_rounds
     if handoff.repository is None:
         raise BudgetStateError("handoff_missing")
     if not isinstance(server_url, str) or not server_url or "\n" in server_url or "\r" in server_url:
@@ -1306,8 +1345,8 @@ def _summary(state: LedgerState, *, server_url: str) -> str:
     return (
         f"## {_REVIEWER_TITLES[state.reviewer]} review invocation budget\n"
         f"- Decision: {handoff.decision}\n"
-        f"- Automatic rounds: {handoff.automatic_rounds}/{state.budgets.max_rounds}\n"
-        f"- Override rounds: {handoff.override_rounds}/{state.budgets.max_override_rounds}\n"
+        f"- Automatic rounds: {handoff.automatic_rounds}/{budgets.max_rounds}\n"
+        f"- Override rounds: {handoff.override_rounds}/{override_limit}\n"
         f"- Current run: {run_url}\n"
         f"- Stop reason: {handoff.stop_reason}\n"
         f"{dismissed_line}\n"
@@ -2030,7 +2069,7 @@ def _list_run_identities(
     current = {"run_id": request["run_id"], "run_attempt": request["run_attempt"]}
     if current not in runs:
         runs.append(current)
-    if len(runs) > 4:
+    if len(runs) > MAX_ROUNDS_CEILING + MAX_OVERRIDE_ROUNDS:
         error = "ledger_invalid"
         runs = []
     write_private(output_directory / "run-identities.json", _json_bytes({

--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -702,6 +702,14 @@ def _validate_state_shape(state: LedgerState) -> None:
             raise BudgetStateError("override_invalid")
     if len(state.consumed_override_event_ids) != len(overrides):
         raise BudgetStateError("override_invalid")
+    if any(
+        current <= previous
+        for previous, current in zip(
+            state.consumed_override_event_ids,
+            state.consumed_override_event_ids[1:],
+        )
+    ):
+        raise BudgetStateError("override_invalid")
     automatic_total = sum(item.estimated_input_tokens for item in automatic)
     total_limit = state.budgets.max_estimated_tokens_total
     if automatic_total > total_limit:
@@ -1072,11 +1080,13 @@ def choose_override(state: LedgerState, events: Sequence[OverrideEvent]) -> Over
         >= effective_budgets(state).max_override_rounds
     ):
         return None
+    newest_consumed = max(state.consumed_override_event_ids, default=0)
     eligible: list[OverrideEvent] = []
     for event in events:
         if (isinstance(event, OverrideEvent) and isinstance(event.event_id, int) and not isinstance(event.event_id, bool) and
                 event.event_id > 0 and event.event == "labeled" and event.label == "review-budget-override" and
-                event.actor_permission in {"admin", "maintain", "write"} and event.event_id not in state.consumed_override_event_ids):
+                event.actor_permission in {"admin", "maintain", "write"} and
+                event.event_id > newest_consumed):
             eligible.append(event)
     return max(eligible, key=lambda item: item.event_id, default=None)
 
@@ -1173,11 +1183,14 @@ def claim(state: LedgerState | None, request: ClaimRequest,
         item.override_event_id is not None for item in validated.invocations
     )
     override = None
-    if override_count or request.force_review:
-        override = choose_override(validated, request.override_events)
-        if override is None:
+    needs_override = (
+        override_count > 0
+        or request.force_review
+        or automatic_rounds(validated) >= effective_budgets(validated).max_rounds
+    )
+    if needs_override:
+        if not request.force_review:
             return refuse(validated, request, "round_budget_exhausted")
-    elif automatic_rounds(validated) >= effective_budgets(validated).max_rounds:
         override = choose_override(validated, request.override_events)
         if override is None:
             return refuse(validated, request, "round_budget_exhausted")
@@ -2069,7 +2082,7 @@ def _list_run_identities(
     current = {"run_id": request["run_id"], "run_attempt": request["run_attempt"]}
     if current not in runs:
         runs.append(current)
-    if len(runs) > MAX_ROUNDS_CEILING + MAX_OVERRIDE_ROUNDS:
+    if len(runs) > MAX_ROUNDS_CEILING + MAX_OVERRIDE_ROUNDS + 1:
         error = "ledger_invalid"
         runs = []
     write_private(output_directory / "run-identities.json", _json_bytes({

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -247,7 +247,9 @@ ready head — `/jhw:pr --review` labels the draft and then marks it ready — o
 pull request needed a `workflow_dispatch` carrying `force_review: true`.
 
 A bounded override round (`review-budget-override` plus a `workflow_dispatch` carrying
-`force_review: true`) is available for Claude and Gemini only; from `v1.64` the callers'
+`force_review: true`) is available for Claude and Gemini only. Starting with `v1.74`, each
+reviewer may consume at most two such rounds, and each round requires a distinct unconsumed
+label timeline-event ID. From `v1.64` the callers'
 `force_review` input says so ("Perform one authorized same-HEAD override round; requires the
 review-budget-override label"), because a dispatch without the label is refused as
 `round_budget_exhausted` even on a first review. From `v1.62` the budget refuses it
@@ -1198,14 +1200,19 @@ comment may match a reviewer marker. Invalid, duplicate, or provenance-unverifia
 state fails closed. The effective-diff identity is the SHA-256 of the immutable
 `review-full.diff`, including when a provider consumes a delta. A normal invocation by
 the same reviewer with the same head SHA or full-diff hash is an absolute zero-call
-gate. Only the explicit force-review contract below may consume the one override round
+gate. Only the explicit force-review contract below may consume an override round
 to review that input again.
 
-A round is one distinct effective diff claimed by one reviewer. Each reviewer has two
-automatic rounds. One `review-budget-override` label timeline-event ID can authorize
-one additional round for that PR/reviewer and is consumed exactly once. Estimated
+A round is one distinct effective diff claimed by one reviewer. The automatic-round default
+is five and `REVIEW_MAX_ROUNDS` may lower it to 1 through 5. Claude and Gemini may consume
+up to two additional rounds; each requires a different `review-budget-override` label
+timeline-event ID and each ID is consumed exactly once. Once the first override is consumed,
+automatic rounds do not resume: another round requires another explicit approval event.
+OpenCode remains automatic-only because its canonicalizer cannot publish a dispatch override.
+Estimated
 input is `ceil(sum(input_file_bytes) / 4) + 20_000`, capped at 200,000 tokens per
-round, 400,000 across automatic rounds, and 600,000 only after the override. Every
+round, 400,000 across automatic rounds, 600,000 after the first override, and 800,000
+after the second. Every
 round has a 600-second provider wall-time cap. Call units and caps are one Claude
 action session, three Gemini `generate_content` requests across primary, retries, and
 configured same-reviewer fallback, and two OpenCode `opencode run` sessions including
@@ -1216,8 +1223,9 @@ Claude and Gemini baseline callers expose a `workflow_dispatch` input pair:
 when the run event is `workflow_dispatch` and the PR timeline contains an unconsumed
 `review-budget-override` label event created by an actor with write, maintain, or admin permission.
 It prepares the current full PR diff, binds publication and budget state to the fetched current
-head plus the exact run ID/attempt, consumes the override immediately, and is terminal for that
-reviewer budget. A label alone never bypasses the normal same-head zero-call gate.
+head plus the exact run ID/attempt, and consumes one approval event immediately. A label alone
+never bypasses the normal same-head zero-call gate. The next override needs a new `labeled`
+timeline event; an earlier event is never reused or carried forward automatically.
 
 `/jhw:ship` or an operator uses the stable sequence below, substituting the repository, PR, and
 caller filename. The Gemini caller uses `gemini-auto-review.yml` with the same inputs.
@@ -1227,6 +1235,9 @@ gh pr edit 26 --repo OWNER/REPO --add-label review-budget-override
 gh workflow run claude-code-review.yml --repo OWNER/REPO \
   -f pr_number=26 -f force_review=true
 ```
+
+For a second override, remove and re-add `review-budget-override` to create a distinct approval
+event, then dispatch the reviewer again. Re-running with only an already-consumed event is refused.
 
 The caller job is skipped when `force_review` is omitted or false. A missing, unauthorized,
 already-consumed, or otherwise unavailable override returns `round_budget_exhausted` and performs

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -58,6 +58,7 @@ from scripts.workflow_release_inventory import (
     release_supports_opencode_dismissals,
     release_supports_opencode_context_budget,
     release_supports_opencode_active_section_order,
+    release_supports_expanded_review_budget,
     release_retires_manual_pr_review,
     release_supports_same_head_cancel_guard,
     release_supports_review_policy,
@@ -751,6 +752,9 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V163 = (
 # comment — no longer describe anything true.
 EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V171 = (
     "0435025c49ec29357220ee934abc9946440c7019a6d5a47e1586632851de1cbd"
+)
+EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V174 = (
+    "d70f6a0be5e1168c192d62388f210af6efed8fe3272e071b7baad49803faee6f"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
     "claude": "d4db53b86603a3a113999409e2e4e35c397adf276981e7f68c0ea57a6198faa2",
@@ -4331,6 +4335,7 @@ def require_budget_helper_contract(
     rounds_variable: bool = False,
     filter_reasons: bool = False,
     dismissals: bool = False,
+    expanded_budget: bool = False,
 ) -> None:
     """Require the authenticated schema-1 helper and every fixed policy gate."""
 
@@ -4390,6 +4395,12 @@ def require_budget_helper_contract(
                 "_DISMISS_COMMAND", "DismissEvent", "DismissedFinding",
                 "parse_dismiss_command", "choose_dismissals",
             }
+        if expanded_budget:
+            expected_literals.update({
+                "MAX_ROUNDS_DEFAULT": 5,
+                "MAX_ROUNDS_CEILING": 5,
+                "MAX_OVERRIDE_ROUNDS": 2,
+            })
         _require_unique_module_bindings(
             module,
             frozenset(
@@ -4450,9 +4461,11 @@ def require_budget_helper_contract(
             and isinstance(item.target, ast.Name)
             and item.value is not None
         }
+        expected_max_rounds = 5 if expanded_budget else 2
+        expected_max_override_rounds = 2 if expanded_budget else 1
         if policy_defaults != {
-            "max_rounds": 2,
-            "max_override_rounds": 1,
+            "max_rounds": expected_max_rounds,
+            "max_override_rounds": expected_max_override_rounds,
             "max_calls_per_round": 1,
             "max_wall_seconds_per_round": 600,
             "max_estimated_tokens_per_round": 200_000,
@@ -4461,8 +4474,12 @@ def require_budget_helper_contract(
             raise ValueError("budget defaults differ")
         expected_records = {
             "BudgetPolicy": (
-                ("max_rounds", "int", "2"),
-                ("max_override_rounds", "int", "1"),
+                ("max_rounds", "int", str(expected_max_rounds)),
+                (
+                    "max_override_rounds",
+                    "int",
+                    str(expected_max_override_rounds),
+                ),
                 ("max_calls_per_round", "int", "1"),
                 ("max_wall_seconds_per_round", "int", "600"),
                 ("max_estimated_tokens_per_round", "int", "200_000"),
@@ -4805,6 +4822,37 @@ def require_budget_helper_contract(
             if dismissals
             else ""
         )
+        claim_budget_policy = (
+            "    override_count = sum(item.override_event_id is not None "
+            "for item in validated.invocations)\n"
+            "    override = None\n"
+            "    if override_count or request.force_review:\n"
+            "        override = choose_override(validated, request.override_events)\n"
+            "        if override is None:\n"
+            "            return refuse(validated, request, 'round_budget_exhausted')\n"
+            f"    elif automatic_rounds(validated) >= {claim_rounds}:\n"
+            "        override = choose_override(validated, request.override_events)\n"
+            "        if override is None:\n"
+            "            return refuse(validated, request, 'round_budget_exhausted')\n"
+            "    total_limit = (validated.budgets.max_estimated_tokens_total "
+            "+ (override_count + int(override is not None)) * "
+            "validated.budgets.max_estimated_tokens_per_round)\n"
+            if expanded_budget
+            else
+            "    override = None\n"
+            "    if any(item.override_event_id is not None "
+            "for item in validated.invocations):\n"
+            "        return refuse(validated, request, 'round_budget_exhausted')\n"
+            "    if request.force_review:\n"
+            "        override = choose_override(validated, request.override_events)\n"
+            "        if override is None:\n"
+            "            return refuse(validated, request, 'round_budget_exhausted')\n"
+            f"    elif automatic_rounds(validated) >= {claim_rounds}:\n"
+            "        override = choose_override(validated, request.override_events)\n"
+            "        if override is None:\n"
+            "            return refuse(validated, request, 'round_budget_exhausted')\n"
+            "    total_limit = 600_000 if override is not None else 400_000\n"
+        )
         expected_claim = ast.parse(
             "def expected(state, request, provenances):\n"
             "    try:\n"
@@ -4840,19 +4888,7 @@ def require_budget_helper_contract(
             "    if request.estimated_input_tokens > "
             "validated.budgets.max_estimated_tokens_per_round:\n"
             "        return refuse(validated, request, 'input_budget_exhausted')\n"
-            "    override = None\n"
-            "    if any(item.override_event_id is not None "
-            "for item in validated.invocations):\n"
-            "        return refuse(validated, request, 'round_budget_exhausted')\n"
-            "    if request.force_review:\n"
-            "        override = choose_override(validated, request.override_events)\n"
-            "        if override is None:\n"
-            "            return refuse(validated, request, 'round_budget_exhausted')\n"
-            f"    elif automatic_rounds(validated) >= {claim_rounds}:\n"
-            "        override = choose_override(validated, request.override_events)\n"
-            "        if override is None:\n"
-            "            return refuse(validated, request, 'round_budget_exhausted')\n"
-            "    total_limit = 600_000 if override is not None else 400_000\n"
+            f"{claim_budget_policy}"
             "    if estimated_total(validated) + request.estimated_input_tokens "
             "> total_limit:\n"
             "        return refuse(validated, request, "
@@ -4922,7 +4958,48 @@ def require_budget_helper_contract(
             != ast.dump(expected_invocation_loop, include_attributes=False)
         ):
             raise ValueError("stored cap policy differs")
-        expected_duplicate_policy = ast.parse(
+        expanded_duplicate_policy = (
+            "automatic = [item for item in state.invocations "
+            "if item.override_event_id is None]\n"
+            "overrides = [item for item in state.invocations "
+            "if item.override_event_id is not None]\n"
+            "if state.reviewer == 'opencode' and overrides:\n"
+            "    raise BudgetStateError('override_invalid')\n"
+            "for attribute, reason in (('head_sha', 'duplicate_head'), "
+            "('full_diff_sha256', 'duplicate_effective_diff')):\n"
+            "    values = [getattr(item, attribute) for item in state.invocations]\n"
+            "    duplicates = {value for value in values "
+            "if values.count(value) > 1}\n"
+            "    for value in duplicates:\n"
+            "        repeated = [item for item in state.invocations "
+            "if getattr(item, attribute) == value]\n"
+            "        if any(item.override_event_id is None or "
+            "item.caller_event != 'workflow_dispatch' "
+            "for item in repeated[1:]):\n"
+            "            raise BudgetStateError(reason)\n"
+            f"if len(automatic) > {rounds_owner}.max_rounds or "
+            f"len(overrides) > {rounds_owner}.max_override_rounds:\n"
+            "    raise BudgetStateError('rounds_invalid')\n"
+            "if [item.round_number for item in automatic] != "
+            "list(range(1, len(automatic) + 1)):\n"
+            "    raise BudgetStateError('rounds_invalid')\n"
+            "if overrides:\n"
+            "    first_override = overrides[0]\n"
+            "    expected_automatic_rounds = ("
+            "range(0, budgets.max_rounds + 1) "
+            "if first_override.caller_event == 'workflow_dispatch' "
+            "else range(state.budgets.max_rounds, budgets.max_rounds + 1))\n"
+            "    if (len(automatic) not in expected_automatic_rounds or "
+            "tuple(state.invocations) != tuple(automatic + overrides) or "
+            "[item.round_number for item in overrides] != "
+            "list(range(len(automatic) + 1, len(state.invocations) + 1)) or "
+            "tuple(item.override_event_id for item in overrides) != "
+            "state.consumed_override_event_ids):\n"
+            "        raise BudgetStateError('override_invalid')\n"
+            "if len(state.consumed_override_event_ids) != len(overrides):\n"
+            "    raise BudgetStateError('override_invalid')\n"
+        )
+        legacy_duplicate_policy = (
             "automatic = [item for item in state.invocations "
             "if item.override_event_id is None]\n"
             "overrides = [item for item in state.invocations "
@@ -4960,9 +5037,19 @@ def require_budget_helper_contract(
             "        raise BudgetStateError('override_invalid')\n"
             "if len(state.consumed_override_event_ids) != len(overrides):\n"
             "    raise BudgetStateError('override_invalid')\n"
+        )
+        expected_duplicate_policy = ast.parse(
+            expanded_duplicate_policy
+            if expanded_budget
+            else legacy_duplicate_policy
         ).body
+        duplicate_policy_start = 13 if expanded_budget else 9 + shape_offset
+        duplicate_policy_end = 21 if expanded_budget else 17 + shape_offset
         if ast.dump(
-            ast.Module(body=state_shape.body[9 + shape_offset:17 + shape_offset], type_ignores=[]),
+            ast.Module(
+                body=state_shape.body[duplicate_policy_start:duplicate_policy_end],
+                type_ignores=[],
+            ),
             include_attributes=False,
         ) != ast.dump(
             ast.Module(body=expected_duplicate_policy, type_ignores=[]),
@@ -5181,6 +5268,11 @@ def require_budget_helper_contract(
             "input_files_empty",
         )
         list_identities = _function_node(module, "_list_run_identities")
+        run_identity_limit = (
+            "MAX_ROUNDS_CEILING + MAX_OVERRIDE_ROUNDS"
+            if expanded_budget
+            else "4"
+        )
         if (
             len(list_identities.body) != 8
             or not _ast_statement_matches(
@@ -5194,7 +5286,7 @@ def require_budget_helper_contract(
             )
             or not _ast_statement_matches(
                 list_identities.body[6],
-                "if len(runs) > 4:\n"
+                f"if len(runs) > {run_identity_limit}:\n"
                 "    error = 'ledger_invalid'\n"
                 "    runs = []",
             )
@@ -5212,6 +5304,16 @@ def require_budget_helper_contract(
                 and not _ast_statement_matches(
                     choose_override.body[0],
                     "if state.reviewer == 'opencode':\n    return None",
+                )
+            )
+            or (
+                expanded_budget
+                and not _ast_statement_matches(
+                    choose_override.body[1],
+                    "if sum(item.override_event_id is not None "
+                    "for item in state.invocations) >= "
+                    "effective_budgets(state).max_override_rounds:\n"
+                    "    return None",
                 )
             )
             or not isinstance(choose_override.body[2 + override_offset], ast.For)
@@ -5929,6 +6031,7 @@ def _verify_review_invocation_budget(
         release_supports_review_rounds_variable(ref),
         release_supports_filter_reason_surface(ref),
         release_supports_finding_dismissal(ref),
+        release_supports_expanded_review_budget(ref),
     )
     for reviewer, workflow in REVIEWER_WORKFLOWS.items():
         require_budget_workflow_contract(
@@ -5950,7 +6053,9 @@ def _verify_review_invocation_budget(
         ),
         REVIEW_INVOCATION_BUDGET_HELPER_ROOT.path.as_posix(): (
             helper_payload,
-            EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V171
+            EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V174
+            if release_supports_expanded_review_budget(ref)
+            else EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V171
             if release_supports_opencode_dismissals(ref)
             else EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V163
             if dismissals

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -754,7 +754,7 @@ EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V171 = (
     "0435025c49ec29357220ee934abc9946440c7019a6d5a47e1586632851de1cbd"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V174 = (
-    "d70f6a0be5e1168c192d62388f210af6efed8fe3272e071b7baad49803faee6f"
+    "9be3f16b8254a3268788ffecdf653cd821a3ed3452022dceebed67e1c90f1aad"
 )
 EXPECTED_REVIEW_INVOCATION_BUDGET_WORKFLOW_SHA256 = {
     "claude": "d4db53b86603a3a113999409e2e4e35c397adf276981e7f68c0ea57a6198faa2",
@@ -4826,11 +4826,11 @@ def require_budget_helper_contract(
             "    override_count = sum(item.override_event_id is not None "
             "for item in validated.invocations)\n"
             "    override = None\n"
-            "    if override_count or request.force_review:\n"
-            "        override = choose_override(validated, request.override_events)\n"
-            "        if override is None:\n"
+            "    needs_override = (override_count > 0 or request.force_review or "
+            f"automatic_rounds(validated) >= {claim_rounds})\n"
+            "    if needs_override:\n"
+            "        if not request.force_review:\n"
             "            return refuse(validated, request, 'round_budget_exhausted')\n"
-            f"    elif automatic_rounds(validated) >= {claim_rounds}:\n"
             "        override = choose_override(validated, request.override_events)\n"
             "        if override is None:\n"
             "            return refuse(validated, request, 'round_budget_exhausted')\n"
@@ -4998,6 +4998,10 @@ def require_budget_helper_contract(
             "        raise BudgetStateError('override_invalid')\n"
             "if len(state.consumed_override_event_ids) != len(overrides):\n"
             "    raise BudgetStateError('override_invalid')\n"
+            "if any(current <= previous for previous, current in zip("
+            "state.consumed_override_event_ids, "
+            "state.consumed_override_event_ids[1:])):\n"
+            "    raise BudgetStateError('override_invalid')\n"
         )
         legacy_duplicate_policy = (
             "automatic = [item for item in state.invocations "
@@ -5044,7 +5048,7 @@ def require_budget_helper_contract(
             else legacy_duplicate_policy
         ).body
         duplicate_policy_start = 13 if expanded_budget else 9 + shape_offset
-        duplicate_policy_end = 21 if expanded_budget else 17 + shape_offset
+        duplicate_policy_end = 22 if expanded_budget else 17 + shape_offset
         if ast.dump(
             ast.Module(
                 body=state_shape.body[duplicate_policy_start:duplicate_policy_end],
@@ -5269,7 +5273,7 @@ def require_budget_helper_contract(
         )
         list_identities = _function_node(module, "_list_run_identities")
         run_identity_limit = (
-            "MAX_ROUNDS_CEILING + MAX_OVERRIDE_ROUNDS"
+            "MAX_ROUNDS_CEILING + MAX_OVERRIDE_ROUNDS + 1"
             if expanded_budget
             else "4"
         )
@@ -5297,8 +5301,10 @@ def require_budget_helper_contract(
         # v1.62 refuses the OpenCode override up front, which adds one guard ahead of
         # the eligibility loop.
         override_offset = 1 if rounds_variable and filter_reasons else 0
+        override_loop_index = 4 if expanded_budget else 2 + override_offset
+        override_return_index = 5 if expanded_budget else 3 + override_offset
         if (
-            len(choose_override.body) != 4 + override_offset
+            len(choose_override.body) != (6 if expanded_budget else 4 + override_offset)
             or (
                 filter_reasons
                 and not _ast_statement_matches(
@@ -5316,14 +5322,22 @@ def require_budget_helper_contract(
                     "    return None",
                 )
             )
-            or not isinstance(choose_override.body[2 + override_offset], ast.For)
-            or not _ast_expression_matches(
-                choose_override.body[2 + override_offset].iter, "events"
+            or (
+                expanded_budget
+                and not _ast_statement_matches(
+                    choose_override.body[2],
+                    "newest_consumed = max("
+                    "state.consumed_override_event_ids, default=0)",
+                )
             )
-            or len(choose_override.body[2 + override_offset].body) != 1
-            or not isinstance(choose_override.body[2 + override_offset].body[0], ast.If)
+            or not isinstance(choose_override.body[override_loop_index], ast.For)
             or not _ast_expression_matches(
-                choose_override.body[2 + override_offset].body[0].test,
+                choose_override.body[override_loop_index].iter, "events"
+            )
+            or len(choose_override.body[override_loop_index].body) != 1
+            or not isinstance(choose_override.body[override_loop_index].body[0], ast.If)
+            or not _ast_expression_matches(
+                choose_override.body[override_loop_index].body[0].test,
                 "isinstance(event, OverrideEvent) "
                 "and isinstance(event.event_id, int) "
                 "and not isinstance(event.event_id, bool) "
@@ -5331,15 +5345,18 @@ def require_budget_helper_contract(
                 "and event.event == 'labeled' "
                 "and event.label == 'review-budget-override' "
                 "and event.actor_permission in {'admin', 'maintain', 'write'} "
-                "and event.event_id not in "
-                "state.consumed_override_event_ids",
+                + (
+                    "and event.event_id > newest_consumed"
+                    if expanded_budget
+                    else "and event.event_id not in state.consumed_override_event_ids"
+                ),
             )
             or not _ast_statement_matches(
-                choose_override.body[2 + override_offset].body[0].body[0],
+                choose_override.body[override_loop_index].body[0].body[0],
                 "eligible.append(event)",
             )
             or not _ast_statement_matches(
-                choose_override.body[3 + override_offset],
+                choose_override.body[override_return_index],
                 "return max(eligible, key=lambda item: item.event_id, "
                 "default=None)",
             )

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -161,6 +161,7 @@ OPENCODE_FINDING_ID_RELEASE = (1, 70)
 OPENCODE_DISMISSAL_RELEASE = (1, 71)
 OPENCODE_CONTEXT_BUDGET_RELEASE = (1, 72)
 OPENCODE_ACTIVE_SECTION_ORDER_RELEASE = (1, 73)
+EXPANDED_REVIEW_BUDGET_RELEASE = (1, 74)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -269,6 +270,12 @@ def release_supports_opencode_active_section_order(ref: str) -> bool:
     """Return whether ``ref`` renders a synthesized active section before inactive ones."""
 
     return _release_version(ref) >= OPENCODE_ACTIVE_SECTION_ORDER_RELEASE
+
+
+def release_supports_expanded_review_budget(ref: str) -> bool:
+    """Return whether ``ref`` allows five automatic and two approved review rounds."""
+
+    return _release_version(ref) >= EXPANDED_REVIEW_BUDGET_RELEASE
 
 
 def release_retires_manual_pr_review(ref: str) -> bool:

--- a/tests/test_review_invocation_budget.py
+++ b/tests/test_review_invocation_budget.py
@@ -190,6 +190,13 @@ def claim_provenances(state, claim_request):
     return provenances
 
 
+def force_claim_provenances(state, claim_request):
+    provenances = claim_provenances(state, claim_request)
+    key = (claim_request.run_id, claim_request.run_attempt)
+    provenances[key] = replace(provenances[key], caller_event="workflow_dispatch")
+    return provenances
+
+
 def ledger_body(state):
     payload = json.dumps(state.to_dict(), ensure_ascii=True, separators=(",", ":"), sort_keys=True)
     return f"{budget.MARKERS[state.reviewer]}\n{budget.STATE_PREFIX}{payload}{budget.STATE_SUFFIX}"
@@ -205,7 +212,8 @@ def assert_stored_state_rejected(state, reason):
 
 
 @pytest.fixture
-def two_round_state():
+def two_round_state(monkeypatch):
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, "2")
     return state_for("two-successes")
 
 
@@ -224,7 +232,8 @@ def unchanged_request():
     return request(diff_mode="unchanged")
 
 
-def test_fixed_claim_vectors():
+def test_fixed_claim_vectors(monkeypatch):
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, "2")
     vectors = json.loads((Path(__file__).parent / "fixtures/review-invocation-budget/cases.json").read_text())
     for vector in (item for item in vectors if item.get("kind", "claim") == "claim"):
         events = ()
@@ -448,6 +457,35 @@ def test_force_review_claims_same_head_once_with_dispatch_and_authorized_overrid
     assert result.state.invocations[-1].caller_event == "workflow_dispatch"
 
 
+def test_two_early_force_reviews_on_the_same_head_use_distinct_events():
+    state = budget.LedgerState.initial(REPOSITORY, PR, "claude")
+    first_request = request(
+        run_id=700,
+        force_review=True,
+        override_events=(override_event(9001),),
+    )
+    first = budget.claim(
+        state,
+        first_request,
+        force_claim_provenances(state, first_request),
+    )
+    second_request = request(
+        run_id=701,
+        force_review=True,
+        override_events=(override_event(9002),),
+    )
+
+    second = budget.claim(
+        first.state,
+        second_request,
+        force_claim_provenances(first.state, second_request),
+    )
+
+    assert second.allow_invocation
+    assert second.state.consumed_override_event_ids == (9001, 9002)
+    assert budget.load_checkpoint(budget.render_checkpoint(second.state)) == second.state
+
+
 def test_force_review_fails_closed_without_dispatch_or_authorized_override():
     existing = budget.LedgerState.initial(
         REPOSITORY,
@@ -642,8 +680,8 @@ def test_comment_summary_and_handoff_are_exact_and_workflow_owned():
     visible = (
         "## Claude review invocation budget\n"
         "- Decision: duplicate_head\n"
-        "- Automatic rounds: 1/2\n"
-        "- Override rounds: 0/1\n"
+        "- Automatic rounds: 1/5\n"
+        "- Override rounds: 0/2\n"
         "- Current run: https://github.com/example/repo/actions/runs/700\n"
         "- Stop reason: duplicate_head\n"
         "- Dismissed findings: none\n\n"
@@ -1012,6 +1050,14 @@ def test_stored_automatic_and_override_aggregate_boundaries():
         REPOSITORY, PR, "claude", invocations=(first, second, third),
         consumed_override_event_ids=(9001,),
     )
+    override_limit = replace(
+        override_limit,
+        budgets=replace(
+            override_limit.budgets,
+            max_rounds=2,
+            max_override_rounds=1,
+        ),
+    )
     assert budget.parse_ledger(
         ledger_body(override_limit), repository=REPOSITORY, pr=PR, reviewer="claude",
     ) == override_limit
@@ -1047,8 +1093,34 @@ def rounds(count):
     )
 
 
-def test_round_budget_defaults_to_two_without_the_variable():
-    assert budget.BudgetPolicy.for_reviewer("claude").max_rounds == 2
+def test_round_budget_defaults_to_five_without_the_variable():
+    state = budget.LedgerState.initial(REPOSITORY, PR, "claude", invocations=rounds(4))
+    fifth_request = request(head="e" * 40, full_hash="5" * 64, run_id=604)
+
+    fifth = budget.claim(
+        state,
+        fifth_request,
+        claim_provenances(state, fifth_request),
+    )
+
+    assert fifth.allow_invocation
+    assert fifth.round_number == 5
+
+    at_limit = budget.LedgerState.initial(
+        REPOSITORY,
+        PR,
+        "claude",
+        invocations=rounds(5),
+    )
+    sixth_request = request(head="0" * 40, full_hash="6" * 64, run_id=605)
+    sixth = budget.claim(
+        at_limit,
+        sixth_request,
+        claim_provenances(at_limit, sixth_request),
+    )
+
+    assert not sixth.allow_invocation
+    assert sixth.decision == "round_budget_exhausted"
 
 
 @pytest.mark.parametrize("reviewer", ("claude", "gemini", "opencode"))
@@ -1062,7 +1134,7 @@ def test_round_budget_honours_the_configured_variable(monkeypatch, reviewer, raw
 def test_round_budget_ignores_an_empty_variable_without_warning(monkeypatch, capsys):
     monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, "")
 
-    assert budget.BudgetPolicy.for_reviewer("claude").max_rounds == 2
+    assert budget.BudgetPolicy.for_reviewer("claude").max_rounds == 5
     assert capsys.readouterr().err == ""
 
 
@@ -1070,7 +1142,7 @@ def test_round_budget_ignores_an_empty_variable_without_warning(monkeypatch, cap
 def test_round_budget_falls_back_and_warns_on_an_unusable_variable(monkeypatch, capsys, raw):
     monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, raw)
 
-    assert budget.BudgetPolicy.for_reviewer("claude").max_rounds == 2
+    assert budget.BudgetPolicy.for_reviewer("claude").max_rounds == 5
     assert budget.MAX_ROUNDS_VARIABLE in capsys.readouterr().err
 
 
@@ -1081,8 +1153,51 @@ def test_ledger_capacity_follows_the_configured_round_budget(monkeypatch):
     budget._validate_state_shape(state)
 
 
+def test_fourth_claim_checkpoint_round_trips(monkeypatch):
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, "5")
+    state = budget.LedgerState.initial(REPOSITORY, PR, "claude", invocations=rounds(3))
+    fourth_request = request(
+        head="d" * 40,
+        full_hash="4" * 64,
+        run_id=703,
+    )
+
+    claimed = budget.claim(
+        state,
+        fourth_request,
+        claim_provenances(state, fourth_request),
+    )
+
+    assert claimed.allow_invocation
+    assert claimed.round_number == 4
+    assert budget.load_checkpoint(budget.render_checkpoint(claimed.state)) == claimed.state
+
+
+def test_legacy_ledger_can_finish_the_raised_automatic_budget_before_override(monkeypatch):
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, "2")
+    state = budget.LedgerState.initial(REPOSITORY, PR, "claude")
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, "5")
+    state = replace(state, invocations=rounds(5))
+    override_request = request(
+        head="f" * 40,
+        full_hash="6" * 64,
+        run_id=705,
+        override_events=(override_event(9001),),
+    )
+
+    claimed = budget.claim(
+        state,
+        override_request,
+        claim_provenances(state, override_request),
+    )
+
+    assert claimed.allow_invocation
+    assert claimed.round_number == 6
+    assert budget.load_checkpoint(budget.render_checkpoint(claimed.state)) == claimed.state
+
+
 def test_ledger_capacity_still_rejects_more_rounds_than_budgeted():
-    state = budget.LedgerState.initial(REPOSITORY, PR, "claude", invocations=rounds(4))
+    state = budget.LedgerState.initial(REPOSITORY, PR, "claude", invocations=rounds(6))
 
     with pytest.raises(budget.BudgetStateError):
         budget._validate_state_shape(state)
@@ -1111,7 +1226,7 @@ def test_round_budget_rejects_non_ascii_digits(monkeypatch, capsys, raw):
 
     monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, raw)
 
-    assert budget.BudgetPolicy.for_reviewer("claude").max_rounds == 2
+    assert budget.BudgetPolicy.for_reviewer("claude").max_rounds == 5
     assert budget.MAX_ROUNDS_VARIABLE in capsys.readouterr().err
 
 
@@ -1122,12 +1237,20 @@ def overridden_state():
     override = invocation(
         head=HEAD_C, full_hash=HASH_3, run_id=700, round_number=3, override_event_id=9001
     )
-    return budget.LedgerState.initial(
+    state = budget.LedgerState.initial(
         REPOSITORY,
         PR,
         "claude",
         invocations=automatic + (override,),
         consumed_override_event_ids=(9001,),
+    )
+    return replace(
+        state,
+        budgets=replace(
+            state.budgets,
+            max_rounds=2,
+            max_override_rounds=1,
+        ),
     )
 
 
@@ -1144,6 +1267,29 @@ def test_recorded_override_survives_a_raised_round_budget(monkeypatch):
     budget._validate_state_shape(state)
 
 
+def test_legacy_ledger_uses_the_expanded_budget_for_a_second_approval():
+    state = overridden_state()
+    second_request = request(
+        head=HEAD_C,
+        full_hash=HASH_3,
+        run_id=701,
+        override_events=(override_event(9002),),
+        force_review=True,
+    )
+
+    second = budget.claim(
+        state,
+        second_request,
+        force_claim_provenances(state, second_request),
+    )
+
+    assert second.allow_invocation
+    assert second.state.consumed_override_event_ids == (9001, 9002)
+    assert "- Automatic rounds: 2/5\n- Override rounds: 2/2\n" in budget.render_summary(
+        second.state
+    )
+
+
 # --- OpenCode cannot publish a dispatch round, so it must not spend one (issue #118) ---
 
 
@@ -1158,6 +1304,59 @@ def test_override_stays_available_for_the_publishing_reviewers(reviewer):
     assert budget.choose_override(state, (override_event(),)) is not None
 
 
+def test_two_distinct_override_events_each_unlock_one_extra_round(monkeypatch):
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, "5")
+    state = budget.LedgerState.initial(REPOSITORY, PR, "claude", invocations=rounds(5))
+    first_request = request(
+        head="e" * 40,
+        full_hash="5" * 64,
+        run_id=706,
+        override_events=(override_event(9101),),
+        force_review=True,
+    )
+
+    first = budget.claim(state, first_request, force_claim_provenances(state, first_request))
+
+    assert first.allow_invocation
+    assert first.round_number == 6
+    assert first.state.consumed_override_event_ids == (9101,)
+
+    first_state = replace(first.state, handoff=budget.Handoff())
+    second_request = request(
+        head="e" * 40,
+        full_hash="5" * 64,
+        run_id=707,
+        override_events=(override_event(9102),),
+        force_review=True,
+    )
+    second = budget.claim(
+        first_state,
+        second_request,
+        force_claim_provenances(first_state, second_request),
+    )
+
+    assert second.allow_invocation
+    assert second.round_number == 7
+    assert second.state.consumed_override_event_ids == (9101, 9102)
+
+    reused_request = request(
+        head="e" * 40,
+        full_hash="5" * 64,
+        run_id=708,
+        override_events=(override_event(9102),),
+        force_review=True,
+    )
+    reused = budget.claim(
+        second.state,
+        reused_request,
+        force_claim_provenances(second.state, reused_request),
+    )
+
+    assert not reused.allow_invocation
+    assert reused.decision == "round_budget_exhausted"
+    assert reused.state.consumed_override_event_ids == (9101, 9102)
+
+
 def test_override_is_refused_for_opencode():
     """OpenCode's canonicalizer only accepts pull_request provenance, so a dispatch
     round can never publish. Spending the override there loses the verdict."""
@@ -1165,6 +1364,43 @@ def test_override_is_refused_for_opencode():
     state = budget.LedgerState.initial(REPOSITORY, PR, "opencode")
 
     assert budget.choose_override(state, (override_event(),)) is None
+
+
+def test_stored_override_is_invalid_for_opencode():
+    automatic = tuple(
+        invocation(
+            reviewer="opencode",
+            head=chr(ord("a") + index) * 40,
+            full_hash=str(index + 1) * 64,
+            run_id=800 + index,
+            round_number=index + 1,
+        )
+        for index in range(5)
+    )
+    override = invocation(
+        reviewer="opencode",
+        head="f" * 40,
+        full_hash="6" * 64,
+        run_id=805,
+        round_number=6,
+        override_event_id=9201,
+    )
+    state = budget.LedgerState.initial(
+        REPOSITORY,
+        PR,
+        "opencode",
+        invocations=automatic + (override,),
+        consumed_override_event_ids=(9201,),
+    )
+
+    with pytest.raises(budget.BudgetStateError, match="override_invalid"):
+        budget._validate_state_shape(state)
+
+
+def test_opencode_summary_reports_no_override_capacity():
+    state = claimed_state("opencode")
+
+    assert "- Override rounds: 0/0\n" in budget.render_summary(state)
 
 
 # --- A collaborator can dismiss a false-positive finding by comment (issue #112) ---
@@ -1360,9 +1596,10 @@ def test_claim_records_authorized_dismissals_and_drops_them_from_remaining_ids()
     budget.serialize_ledger(transition.state)
 
 
-def test_refused_claim_still_records_dismissals_and_updates_the_handoff():
+def test_refused_claim_still_records_dismissals_and_updates_the_handoff(monkeypatch):
     """The issue #112 shape: both rounds are spent, then a human dismisses the false positive."""
 
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, "2")
     state = claimed_state()
     first = budget.finalize(
         state, finalize_request(remaining=(FINDING_1, FINDING_2)), current_provenances(state),
@@ -1437,8 +1674,8 @@ def test_comment_summary_lists_dismissals_and_documents_the_command():
     assert budget.render_summary(state) == (
         "## Claude review invocation budget\n"
         "- Decision: claimed\n"
-        "- Automatic rounds: 1/2\n"
-        "- Override rounds: 0/1\n"
+        "- Automatic rounds: 1/5\n"
+        "- Override rounds: 0/2\n"
         "- Current run: https://github.com/example/repo/actions/runs/700\n"
         "- Stop reason: claimed\n"
         "- Dismissed findings: "

--- a/tests/test_review_invocation_budget.py
+++ b/tests/test_review_invocation_budget.py
@@ -243,9 +243,15 @@ def test_fixed_claim_vectors(monkeypatch):
         claim_request = request(
             head=vector["head"], full_hash=vector["full_hash"],
             override_events=events,
+            force_review=bool(events),
+        )
+        provenances = (
+            force_claim_provenances(prior_state, claim_request)
+            if events
+            else claim_provenances(prior_state, claim_request)
         )
         result = budget.claim(
-            prior_state, claim_request, claim_provenances(prior_state, claim_request),
+            prior_state, claim_request, provenances,
         )
         assert result.decision == vector["expected"], vector["name"]
         assert result.allow_invocation is vector["allow"], vector["name"]
@@ -1183,12 +1189,13 @@ def test_legacy_ledger_can_finish_the_raised_automatic_budget_before_override(mo
         full_hash="6" * 64,
         run_id=705,
         override_events=(override_event(9001),),
+        force_review=True,
     )
 
     claimed = budget.claim(
         state,
         override_request,
-        claim_provenances(state, override_request),
+        force_claim_provenances(state, override_request),
     )
 
     assert claimed.allow_invocation
@@ -1355,6 +1362,120 @@ def test_two_distinct_override_events_each_unlock_one_extra_round(monkeypatch):
     assert not reused.allow_invocation
     assert reused.decision == "round_budget_exhausted"
     assert reused.state.consumed_override_event_ids == (9101, 9102)
+
+
+def test_second_override_requires_an_explicit_force_dispatch():
+    state = budget.LedgerState.initial(REPOSITORY, PR, "claude")
+    first_request = request(
+        run_id=706,
+        force_review=True,
+        override_events=(override_event(9101),),
+    )
+    first = budget.claim(
+        state,
+        first_request,
+        force_claim_provenances(state, first_request),
+    )
+    second_request = request(
+        head=HEAD_B,
+        full_hash=HASH_2,
+        run_id=707,
+        override_events=(override_event(9102),),
+    )
+
+    second = budget.claim(
+        first.state,
+        second_request,
+        claim_provenances(first.state, second_request),
+    )
+
+    assert not second.allow_invocation
+    assert second.decision == "round_budget_exhausted"
+    assert second.state.consumed_override_event_ids == (9101,)
+
+
+def test_exhausted_automatic_budget_requires_force_to_consume_an_approval(monkeypatch):
+    monkeypatch.setenv(budget.MAX_ROUNDS_VARIABLE, "2")
+    state = budget.LedgerState.initial(
+        REPOSITORY,
+        PR,
+        "claude",
+        invocations=rounds(2),
+    )
+    claim_request = request(
+        head=HEAD_C,
+        full_hash=HASH_3,
+        run_id=703,
+        override_events=(override_event(9101),),
+    )
+
+    claimed = budget.claim(
+        state,
+        claim_request,
+        claim_provenances(state, claim_request),
+    )
+
+    assert not claimed.allow_invocation
+    assert claimed.decision == "round_budget_exhausted"
+    assert claimed.state.consumed_override_event_ids == ()
+
+
+def test_older_unconsumed_approval_cannot_follow_a_newer_consumed_event():
+    state = budget.LedgerState.initial(REPOSITORY, PR, "claude")
+    first_request = request(
+        run_id=706,
+        force_review=True,
+        override_events=(override_event(9101), override_event(9102)),
+    )
+    first = budget.claim(
+        state,
+        first_request,
+        force_claim_provenances(state, first_request),
+    )
+    second_request = request(
+        head=HEAD_B,
+        full_hash=HASH_2,
+        run_id=707,
+        force_review=True,
+        override_events=(override_event(9101),),
+    )
+
+    second = budget.claim(
+        first.state,
+        second_request,
+        force_claim_provenances(first.state, second_request),
+    )
+
+    assert not second.allow_invocation
+    assert second.decision == "round_budget_exhausted"
+    assert second.state.consumed_override_event_ids == (9102,)
+
+
+def test_stored_override_events_must_be_consumed_in_increasing_order():
+    first = replace(
+        invocation(round_number=1, override_event_id=9102),
+        caller_event="workflow_dispatch",
+    )
+    second = replace(
+        invocation(
+            head=HEAD_B,
+            full_hash=HASH_2,
+            run_id=502,
+            round_number=2,
+            override_event_id=9101,
+        ),
+        caller_event="workflow_dispatch",
+    )
+    state = budget.LedgerState.initial(
+        REPOSITORY,
+        PR,
+        "claude",
+        invocations=(first, second),
+        consumed_override_event_ids=(9102, 9101),
+    )
+
+    with pytest.raises(budget.BudgetStateError, match="override_invalid"):
+        budget._validate_state_shape(state)
 
 
 def test_override_is_refused_for_opencode():

--- a/tests/test_review_invocation_budget_action.py
+++ b/tests/test_review_invocation_budget_action.py
@@ -31,31 +31,39 @@ sys.modules[SPEC.name] = budget
 SPEC.loader.exec_module(budget)
 
 
-def _prior_comment() -> str:
-    invocation = budget.Invocation(
-        run_id=501,
-        run_attempt=1,
-        head_sha=HEAD_A,
-        full_diff_sha256=HASH_1,
-        caller_workflow_path=".github/workflows/claude-review-caller.yml",
-        caller_event="pull_request",
-        referenced_workflow_path=CENTRAL_PATH,
-        referenced_workflow_ref=CENTRAL_REF,
-        referenced_workflow_sha=CENTRAL_SHA,
-        round_number=1,
-        override_event_id=None,
-        model_route=("route-v1",),
-        effort="medium",
-        call_unit="claude-code-action review session",
-        call_count=1,
-        estimated_input_tokens=20_002,
-        elapsed_seconds=12,
-        status="finalized",
-        outcome="provider_failure",
-        stop_reason="provider_failure",
-        remaining_finding_ids=(),
+def _prior_comment(round_count: int = 1) -> str:
+    invocations = tuple(
+        budget.Invocation(
+            run_id=501 + index,
+            run_attempt=1,
+            head_sha=chr(ord("a") + index) * 40,
+            full_diff_sha256=str(index + 1) * 64,
+            caller_workflow_path=".github/workflows/claude-review-caller.yml",
+            caller_event="pull_request",
+            referenced_workflow_path=CENTRAL_PATH,
+            referenced_workflow_ref=CENTRAL_REF,
+            referenced_workflow_sha=CENTRAL_SHA,
+            round_number=index + 1,
+            override_event_id=None,
+            model_route=("route-v1",),
+            effort="medium",
+            call_unit="claude-code-action review session",
+            call_count=1,
+            estimated_input_tokens=20_002,
+            elapsed_seconds=12,
+            status="finalized",
+            outcome="provider_failure",
+            stop_reason="provider_failure",
+            remaining_finding_ids=(),
+        )
+        for index in range(round_count)
     )
-    state = budget.LedgerState.initial("example/repo", 52, "claude", invocations=(invocation,))
+    state = budget.LedgerState.initial(
+        "example/repo",
+        52,
+        "claude",
+        invocations=invocations,
+    )
     return (
         f"{budget.MARKERS['claude']}\n"
         f"{budget.STATE_PREFIX}{budget.serialize_ledger(state)}{budget.STATE_SUFFIX}\n\nprior"
@@ -568,6 +576,31 @@ def test_cli_uses_only_file_based_transport_operations(tmp_path):
         assert parsed.operation == operation
     with pytest.raises(SystemExit):
         parser.parse_args(["claim", "--request", "{}"])
+
+
+def test_run_identity_manifest_allows_a_fifth_automatic_claim(tmp_path):
+    comments_file = tmp_path / "comments.json"
+    comments_file.write_text(json.dumps([_bot_comment(_prior_comment(4))]))
+    (tmp_path / "timeline.json").write_text("[]")
+    request = {
+        "repository": "example/repo",
+        "pr": 52,
+        "reviewer": "claude",
+        "run_id": 700,
+        "run_attempt": 1,
+    }
+
+    budget._list_run_identities(request, comments_file, tmp_path)
+
+    manifest = json.loads((tmp_path / "run-identities.json").read_text())
+    assert manifest["error"] is None
+    assert manifest["runs"] == [
+        {"run_id": 501, "run_attempt": 1},
+        {"run_id": 502, "run_attempt": 1},
+        {"run_id": 503, "run_attempt": 1},
+        {"run_id": 504, "run_attempt": 1},
+        {"run_id": 700, "run_attempt": 1},
+    ]
 
 
 def test_direct_main_invalid_request_writes_canonical_refusal(tmp_path, monkeypatch):

--- a/tests/test_review_invocation_budget_action.py
+++ b/tests/test_review_invocation_budget_action.py
@@ -36,15 +36,15 @@ def _prior_comment(round_count: int = 1) -> str:
         budget.Invocation(
             run_id=501 + index,
             run_attempt=1,
-            head_sha=chr(ord("a") + index) * 40,
+            head_sha="abcdef0"[index] * 40,
             full_diff_sha256=str(index + 1) * 64,
             caller_workflow_path=".github/workflows/claude-review-caller.yml",
-            caller_event="pull_request",
+            caller_event="workflow_dispatch" if index >= 5 else "pull_request",
             referenced_workflow_path=CENTRAL_PATH,
             referenced_workflow_ref=CENTRAL_REF,
             referenced_workflow_sha=CENTRAL_SHA,
             round_number=index + 1,
-            override_event_id=None,
+            override_event_id=9001 + index - 5 if index >= 5 else None,
             model_route=("route-v1",),
             effort="medium",
             call_unit="claude-code-action review session",
@@ -63,13 +63,14 @@ def _prior_comment(round_count: int = 1) -> str:
         52,
         "claude",
         invocations=invocations,
+        consumed_override_event_ids=tuple(
+            9001 + index for index in range(max(0, round_count - 5))
+        ),
     )
     return (
         f"{budget.MARKERS['claude']}\n"
         f"{budget.STATE_PREFIX}{budget.serialize_ledger(state)}{budget.STATE_SUFFIX}\n\nprior"
     )
-
-
 def _claimed_comment() -> str:
     invocation = budget.Invocation(
         run_id=700,
@@ -601,6 +602,26 @@ def test_run_identity_manifest_allows_a_fifth_automatic_claim(tmp_path):
         {"run_id": 504, "run_attempt": 1},
         {"run_id": 700, "run_attempt": 1},
     ]
+
+
+def test_run_identity_manifest_allows_current_request_after_seven_stored_rounds(tmp_path):
+    comments_file = tmp_path / "comments.json"
+    comments_file.write_text(json.dumps([_bot_comment(_prior_comment(7))]))
+    (tmp_path / "timeline.json").write_text("[]")
+    request = {
+        "repository": "example/repo",
+        "pr": 52,
+        "reviewer": "claude",
+        "run_id": 700,
+        "run_attempt": 1,
+    }
+
+    budget._list_run_identities(request, comments_file, tmp_path)
+
+    manifest = json.loads((tmp_path / "run-identities.json").read_text())
+    assert manifest["error"] is None
+    assert len(manifest["runs"]) == 8
+    assert manifest["runs"][-1] == {"run_id": 700, "run_attempt": 1}
 
 
 def test_direct_main_invalid_request_writes_canonical_refusal(tmp_path, monkeypatch):

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -112,6 +112,7 @@ V158_REVIEW_POLICY_HELPER_COMMIT = "1b98172325533ef6ad37f3d2cfc3870073fac26d"
 V159_ROUND_BUDGET_COMMIT = "96d66e1d17952f01b19bb957057830a2b2a6318b"
 V161_FILTER_SURFACE_COMMIT = "08f96e3244bfe8bdd569fb926b26d3086bab125d"
 V162_FINDING_DISMISSAL_COMMIT = "1cbb6df4590fb6be8a5012de31d98dc1f1cd3fa8"
+V173_REVIEW_BUDGET_COMMIT = "ac406e263f9bdc6d83e3d135d1c31b257ed57fa9"
 V1462_WORKFLOW_FIXTURE_SHA256 = {
     "claude-code-review.yml": (
         "008bbdcdeacdaf7796c1e3b59d22194d3f1ce380735d36dada5efab8ff52d112"
@@ -501,6 +502,19 @@ def restore_pre_v160_round_budget(repo: Path) -> None:
             text.replace("          max-rounds: ${{ vars.REVIEW_MAX_ROUNDS }}\n", ""),
             encoding="utf-8",
         )
+
+
+def restore_pre_v174_expanded_review_budget(repo: Path) -> None:
+    """Restore the authenticated v1.73 invocation-budget helper bytes."""
+
+    relative = ".github/actions/review-invocation-budget/review_invocation_budget.py"
+    tree = release_verifier.VerifiedCommitTree.open(ROOT, V173_REVIEW_BUDGET_COMMIT)
+    payload = tree.read_file(relative)
+    assert (
+        hashlib.sha256(payload).hexdigest()
+        == release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V171
+    )
+    (repo / relative).write_bytes(payload)
 
 
 def assert_pre_v160_workflow_bytes(repo: Path) -> None:
@@ -2042,6 +2056,7 @@ def prepare_v163(repo: Path) -> str:
         ".github/actions/canonicalize-review/canonicalize_review.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v174_expanded_review_budget(repo)
     restore_pre_v172_opencode_context_budget(repo)
     restore_pre_v171_opencode_dismissals(repo)
     restore_pre_v170_opencode_finding_ids(repo)
@@ -2060,6 +2075,7 @@ def prepare_v164(repo: Path) -> str:
         ".github/actions/canonicalize-review/canonicalize_review.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v174_expanded_review_budget(repo)
     restore_pre_v172_opencode_context_budget(repo)
     restore_pre_v171_opencode_dismissals(repo)
     restore_pre_v170_opencode_finding_ids(repo)
@@ -2077,6 +2093,7 @@ def prepare_v165(repo: Path) -> str:
         ".github/actions/canonicalize-review/canonicalize_review.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v174_expanded_review_budget(repo)
     restore_pre_v172_opencode_context_budget(repo)
     restore_pre_v171_opencode_dismissals(repo)
     restore_pre_v170_opencode_finding_ids(repo)
@@ -2094,6 +2111,7 @@ def prepare_v166(repo: Path) -> str:
         ".github/actions/resolve-review-policy/resolve_review_policy.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v174_expanded_review_budget(repo)
     restore_pre_v172_opencode_context_budget(repo)
     restore_pre_v171_opencode_dismissals(repo)
     restore_pre_v170_opencode_finding_ids(repo)
@@ -2112,6 +2130,7 @@ def prepare_v167(repo: Path) -> str:
         ".github/workflows/gemini-dispatch.yml",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v174_expanded_review_budget(repo)
     restore_pre_v172_opencode_context_budget(repo)
     restore_pre_v171_opencode_dismissals(repo)
     restore_pre_v170_opencode_finding_ids(repo)
@@ -2129,6 +2148,7 @@ def prepare_v168(repo: Path) -> str:
         ".github/workflows/gemini-dispatch.yml",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v174_expanded_review_budget(repo)
     for name in ("gemini-pr-review.yml", "gemini-review.yml"):
         (repo / "examples/baseline-workflows/.github/workflows" / name).unlink(
             missing_ok=True
@@ -2168,6 +2188,7 @@ def prepare_v171(repo: Path) -> str:
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v174_expanded_review_budget(repo)
     # The copy above brings in the current tree, which is v1.72. Restore after it, not
     # before: a restore that runs first is silently undone by the copy.
     restore_pre_v172_opencode_context_budget(repo)
@@ -2181,6 +2202,7 @@ def prepare_v172(repo: Path) -> str:
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v174_expanded_review_budget(repo)
     restore_pre_v173_opencode_active_section_order(repo)
     return commit(repo, "v1.72 candidate")
 
@@ -2192,7 +2214,15 @@ def prepare_v173(repo: Path) -> str:
         ".github/actions/review-invocation-budget/review_invocation_budget.py",
     ):
         shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v174_expanded_review_budget(repo)
     return commit(repo, "v1.73 candidate")
+
+
+def prepare_v174(repo: Path) -> str:
+    prepare_v173(repo)
+    relative = ".github/actions/review-invocation-budget/review_invocation_budget.py"
+    shutil.copy2(ROOT / relative, repo / relative)
+    return commit(repo, "v1.74 candidate")
 
 
 def test_v171_accepts_current_opencode_dismissal_release_contract(
@@ -2224,6 +2254,11 @@ def test_opencode_active_section_order_release_boundary() -> None:
     )
 
 
+def test_review_budget_expansion_release_boundary() -> None:
+    assert release_inventory.release_supports_expanded_review_budget("v1.73") is False
+    assert release_inventory.release_supports_expanded_review_budget("v1.74") is True
+
+
 def test_v173_accepts_current_opencode_active_section_order_release_contract(
     current_release_repo: tuple[Path, str],
 ) -> None:
@@ -2231,6 +2266,35 @@ def test_v173_accepts_current_opencode_active_section_order_release_contract(
     candidate = prepare_v173(repo)
 
     assert release_verifier.verify_commit_content(repo, "v1.73", candidate) == candidate
+
+
+def test_v174_accepts_expanded_review_budget_release_contract(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v174(repo)
+
+    assert release_verifier.verify_commit_content(repo, "v1.74", candidate) == candidate
+
+
+def test_v174_expanded_review_budget_is_rejected_on_the_v173_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v174(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.73", candidate)
+
+
+def test_pre_v174_review_budget_is_rejected_on_the_v174_release_line(
+    current_release_repo: tuple[Path, str],
+) -> None:
+    repo, _ = current_release_repo
+    candidate = prepare_v173(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.74", candidate)
 
 
 def test_v173_opencode_active_section_order_is_rejected_on_the_v172_release_line(
@@ -3115,7 +3179,13 @@ def test_v147_budget_helper_semantics_reject_authenticated_mutations(
     with pytest.raises(
         ReleaseVerificationError, match="invocation-budget helper contract"
     ):
-        release_verifier.require_budget_helper_contract(source)
+        release_verifier.require_budget_helper_contract(
+            source,
+            rounds_variable=True,
+            filter_reasons=True,
+            dismissals=True,
+            expanded_budget=True,
+        )
 
 
 @pytest.mark.parametrize(
@@ -3236,7 +3306,13 @@ def test_v147_budget_helper_semantics_bind_live_ast_relationships(
     with pytest.raises(
         ReleaseVerificationError, match="invocation-budget helper contract"
     ):
-        release_verifier.require_budget_helper_contract(source)
+        release_verifier.require_budget_helper_contract(
+            source,
+            rounds_variable=True,
+            filter_reasons=True,
+            dismissals=True,
+            expanded_budget=True,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #175

The handoff reader rejected the fourth review round even though the writer could emit it, preventing configured five-round reviews from continuing. Align handoff and provenance-history bounds with the supported budget, default to five automatic rounds, and allow Claude/Gemini two explicitly authorized override rounds. OpenCode remains automatic-only.

Each override consumes a newer authorized label event. Automatic reviews stay stopped after the first override, and the existing 400,000-token automatic budget remains unchanged; the first and second overrides raise total capacity to 600,000 and 800,000 tokens. Existing ledgers retain their recorded policy while gaining the expanded effective capacity. Update the v1.74 release verifier and compatibility regressions.

Validation:
- Pre-PR tribunal round 1: PASS, zero CRITICAL/HIGH findings, at HEAD `5d376f4a3cb07d32adae853711961f4ebb5ad19e`.
- 201 budget/action tests and 20 focused release-policy tests passed.
- 28 workflow YAML files parsed; 103 Bash run blocks passed syntax checks.
- Full Python suite: 3,167 tests and 48 subtests passed in 946.24 seconds (15m 46s). The initial 300-second run was too short for the suite.
- CI-pinned actionlint 1.7.12: all 28 workflow files passed; downloaded archive SHA-256 matched the CI pin.

Known nonblocking finding: the stored-state parser accepts a constructed legacy history whose second override has `pull_request` provenance on distinct inputs. The live claim path requires an explicit forced dispatch. Reviewer A recommends requiring dispatch provenance for every stored override after the first while retaining compatibility with a legacy first override.
