### PR TITLE
fix(review): validate Claude caller before budget admission

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -403,6 +403,82 @@ jobs:
           context-lines: '3'
           output-directory: ${{ runner.temp }}
 
+      # The App validates the caller against the current default branch. Check
+      # before reserving a round, using workflow identity rather than PR checkout.
+      # This is a prediction only; the upstream App remains the authority.
+      - name: Validate Claude caller workflow
+        id: claude-workflow-validation
+        if: ${{ always() && steps.prepare-review-input.outcome == 'success' && steps.prepare-diff.outputs.diff-ready == 'true' && steps.prepare-diff.outputs.diff-mode != 'unchanged' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # ratchet:actions/github-script@v7
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            core.setOutput('allowed', 'false');
+            core.setOutput('reason', 'workflow_validation_unavailable');
+            const stop = (reason) => {
+              core.setOutput('reason', reason);
+              core.setFailed(reason);
+            };
+            const { owner, repo } = context.repo;
+            const prefix = `${owner}/${repo}/`;
+            const workflowRef = process.env.WORKFLOW_REF || '';
+            const workflowSha = process.env.WORKFLOW_SHA || '';
+            const sha1 = (value) => /^[0-9a-f]{40}$/.test(value || '');
+            const relative = workflowRef.startsWith(prefix) ? workflowRef.slice(prefix.length) : '';
+            const match = relative.match(/^(\.github\/workflows\/[^/@]+\.ya?ml)@refs\/.+$/);
+            if (!match || !sha1(workflowSha)) {
+              stop('workflow_validation_unavailable');
+              return;
+            }
+            const path = match[1];
+            const options = { owner, repo, request: { timeout: 15000 } };
+            try {
+              const { data: repository } = await github.rest.repos.get(options);
+              if (typeof repository.default_branch !== 'string' || !repository.default_branch) {
+                stop('workflow_validation_unavailable');
+                return;
+              }
+              const { data: branch } = await github.rest.repos.getBranch({
+                ...options, branch: repository.default_branch,
+              });
+              const defaultSha = branch?.commit?.sha;
+              if (!sha1(defaultSha)) {
+                stop('workflow_validation_unavailable');
+                return;
+              }
+              const { data: current } = await github.rest.repos.getContent({
+                ...options, path, ref: workflowSha,
+              });
+              let baseline;
+              try {
+                const response = await github.rest.repos.getContent({
+                  ...options, path, ref: defaultSha,
+                });
+                baseline = response.data;
+              } catch (error) {
+                stop(Number(error?.status) === 404
+                  ? 'workflow_validation_mismatch' : 'workflow_validation_unavailable');
+                return;
+              }
+              const regular = (file) => file?.type === 'file' && file.path === path
+                && !file.target && !file.submodule_git_url && sha1(file.sha);
+              if (!regular(current) || !regular(baseline)) {
+                stop('workflow_validation_unavailable');
+                return;
+              }
+              if (current.sha !== baseline.sha) {
+                stop('workflow_validation_mismatch');
+                return;
+              }
+              core.setOutput('reason', '');
+              core.setOutput('allowed', 'true');
+            } catch {
+              stop('workflow_validation_unavailable');
+            }
+
       - name: Resolve Claude budget metadata
         id: claude-budget-config
         if: ${{ always() && steps.prepare-review-input.outcome == 'success' }}
@@ -454,7 +530,7 @@ jobs:
 
       - name: Claim Claude review budget
         id: review-budget-claim
-        if: ${{ always() && steps.prepare-review-input.outcome == 'success' && steps.stage-claude-budget-input.outcome == 'success' }}
+        if: ${{ always() && steps.prepare-review-input.outcome == 'success' && steps.stage-claude-budget-input.outcome == 'success' && (steps.prepare-diff.outputs.diff-ready != 'true' || steps.prepare-diff.outputs.diff-mode == 'unchanged' || steps.claude-workflow-validation.outputs.allowed == 'true') }}
         uses: $/.github/actions/review-invocation-budget
         with:
           github-token: ${{ github.token }}
@@ -548,7 +624,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          printf 'call_count=1\n' >> "$GITHUB_OUTPUT"
           printf 'started_at=%s\n' "$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code Review
@@ -652,12 +727,41 @@ jobs:
           (( now >= STARTED_AT ))
           printf 'elapsed_seconds=%s\n' "$((now - STARTED_AT))" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve Claude execution
+        id: claude-execution
+        if: ${{ always() }}
+        shell: bash
+        env:
+          ACTION_OUTCOME: ${{ steps.claude-review.outcome }}
+          EXECUTION_CONCLUSION: ${{ steps.claude-review.outputs.conclusion }}
+        run: |
+          set -euo pipefail
+          # v1.0.204 returns success without a conclusion when preparation skips.
+          # An action failure without a conclusion is uncertain: retain the
+          # conservative one-call reservation instead of granting a false refund.
+          case "$ACTION_OUTCOME:$EXECUTION_CONCLUSION" in
+            success:success) call_count=1; provider_outcome=success; failure_reason='' ;;
+            success:failure|failure:*) call_count=1; provider_outcome=failure; failure_reason=provider_failure ;;
+            success:) call_count=0; provider_outcome=skipped; failure_reason=provider_not_executed ;;
+            skipped:|:) call_count=0; provider_outcome=skipped; failure_reason='' ;;
+            *) echo '::error::provider_execution_unavailable'; exit 1 ;;
+          esac
+          {
+            printf 'call_count=%s\n' "$call_count"
+            printf 'provider_outcome=%s\n' "$provider_outcome"
+            printf 'failure_reason=%s\n' "$failure_reason"
+          } >> "$GITHUB_OUTPUT"
+          if [[ -n "$failure_reason" ]]; then
+            printf '::error::%s\n' "$failure_reason"
+            exit 1
+          fi
+
       - name: Validate Claude review metrics
         id: claude-budget-metrics
         if: ${{ always() && steps.review-budget-claim.outputs.allow-invocation == 'true' }}
         shell: bash
         env:
-          CALL_COUNT: ${{ steps.claude-budget-metrics-start.outputs.call_count }}
+          CALL_COUNT: ${{ steps.claude-execution.outputs.call_count }}
           ELAPSED_SECONDS: ${{ steps.claude-budget-elapsed.outputs.elapsed_seconds }}
           MODEL_ROUTE_JSON: ${{ steps.claude-budget-config.outputs.model_route_json }}
         run: |
@@ -684,7 +788,7 @@ jobs:
 
       - name: Canonicalize Claude review
         id: canonicalize-review
-        if: ${{ always() && steps.reset-claude-artifacts.outcome == 'success' && steps.prepare-diff.outputs.diff-ready == 'true' && steps.prepare-diff.outputs.diff-mode != 'unchanged' && steps.review-budget-claim.outputs.allow-invocation == 'true' }}
+        if: ${{ always() && steps.reset-claude-artifacts.outcome == 'success' && steps.prepare-diff.outputs.diff-ready == 'true' && steps.prepare-diff.outputs.diff-mode != 'unchanged' && steps.review-budget-claim.outputs.allow-invocation == 'true' && steps.claude-execution.outputs.call_count == '1' }}
         uses: $/.github/actions/canonicalize-review
         with:
           reviewer: claude
@@ -747,14 +851,15 @@ jobs:
       # !cancelled(): 취소된 런이 정상 sticky를 에러로 덮어쓰지 않게 한다(always()는 취소에도 true).
       - name: Upsert review comment
         id: upsert-review-comment
-        if: ${{ !cancelled() && steps.prepare-review-input.outcome == 'success' && (steps.prepare-diff.outputs.diff-ready != 'true' || steps.prepare-diff.outputs.diff-mode == 'unchanged' || steps.review-budget-claim.outputs.allow-invocation == 'true') }}
+        if: ${{ !cancelled() && steps.prepare-review-input.outcome == 'success' && (steps.prepare-diff.outputs.diff-ready != 'true' || steps.prepare-diff.outputs.diff-mode == 'unchanged' || steps.review-budget-claim.outputs.allow-invocation == 'true' || steps.claude-workflow-validation.outcome == 'failure') }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # ratchet:actions/github-script@v7
         env:
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SERVER_URL: ${{ github.server_url }}
           REPOSITORY: ${{ github.repository }}
-          REVIEW_OUTCOME: ${{ steps.claude-review.outcome }}
+          REVIEW_OUTCOME: ${{ steps.claude-execution.outputs.provider_outcome }}
+          PROVIDER_FAILURE_REASON: ${{ steps.claude-workflow-validation.outputs.reason || steps.claude-execution.outputs.failure_reason }}
           DIFF_READY: ${{ steps.prepare-diff.outputs.diff-ready }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -805,6 +910,11 @@ jobs:
             const diffMode = process.env.DIFF_MODE || (diffReady ? 'full' : 'unavailable');
             const unchangedSincePrevious = process.env.UNCHANGED_SINCE_PREVIOUS === 'true';
             const canonicalFailureReason = process.env.CANONICAL_FAILURE_REASON || '';
+            const providerFailureReason = process.env.PROVIDER_FAILURE_REASON || '';
+            const nonexecutionReasons = new Set([
+              'workflow_validation_mismatch', 'workflow_validation_unavailable',
+              'provider_not_executed',
+            ]);
             const hardReasons = new Set([
               'candidate_missing', 'invalid_utf8', 'candidate_oversize',
               'ambiguous_document', 'scope_invalid', 'canonicalizer_error',
@@ -991,7 +1101,8 @@ jobs:
               && qualityValid && review.length > 0 && reviewedInputIsValid;
             let checkpointFailed = !(currentSuccess || unchangedInputIsValid);
             let failureReason = !diffReady ? 'diff_unavailable'
-              : !ok ? 'provider_failure'
+              : !modelStepEntered && nonexecutionReasons.has(providerFailureReason) ? providerFailureReason
+                : !ok ? 'provider_failure'
                 : hardReasons.has(canonicalFailureReason) ? canonicalFailureReason
                   : 'canonicalizer_error';
             const stateDiffMode = ['full', 'delta', 'unchanged', 'unavailable'].includes(diffMode)
@@ -1078,7 +1189,7 @@ jobs:
         if: ${{ always() && steps.review-budget-claim.outputs.allow-invocation == 'true' && steps.claude-budget-metrics.outputs.metrics_valid == 'true' }}
         shell: bash
         env:
-          PROVIDER_OUTCOME: ${{ steps.claude-review.outcome }}
+          PROVIDER_OUTCOME: ${{ steps.claude-execution.outputs.provider_outcome }}
           CANONICAL_OUTCOME: ${{ steps.canonicalize-review.outcome }}
           DOCUMENT_VALID: ${{ steps.canonicalize-review.outputs.document-valid }}
           ACCEPTED_COUNT: ${{ steps.canonicalize-review.outputs.accepted-count }}

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -888,6 +888,10 @@ Claude/Gemini schema 3 additionally emits `review_execution` and the quality fie
 `filtered_max_severity`. `review_execution` is `performed` when this attempt entered the model
 step, `reused` only for authenticated unchanged reuse, and `not_performed` when the attempt failed
 before a model call. Existing schema-3 records without this additive field remain readable.
+From v1.75, Claude uses the pinned action's execution `conclusion`, because a successful
+action step can return during preparation without running Claude. Such a skip is
+`not_performed`, never a successful review. An action failure with no conclusion remains
+conservatively counted as one attempted session; it is not evidence for a zero-call refund.
 The same value appears in the trusted `- Execution:` metadata line, so a reused success cannot be
 presented as a new model review. `quality_schema` is always `1`. On full or delta
 success the counts are non-negative safe integers and the maximum is `none`, `MEDIUM`, `HIGH`, or
@@ -1217,6 +1221,32 @@ round has a 600-second provider wall-time cap. Call units and caps are one Claud
 action session, three Gemini `generate_content` requests across primary, retries, and
 configured same-reviewer fallback, and two OpenCode `opencode run` sessions including
 format repair.
+
+From v1.75, Claude compares the caller identified by `github.workflow_ref` and
+`github.workflow_sha` with the same file at a freshly resolved default-branch commit,
+before reserving a full/delta review round. Equal blob IDs allow admission even when
+the commits differ. A missing default caller or different blob fails with
+`workflow_validation_mismatch`; invalid identity or an uncertain API lookup fails with
+`workflow_validation_unavailable`. Neither path claims a round, consumes an override
+event, or invokes Claude. Authenticated unchanged reuse keeps its existing zero-call path.
+This preflight predicts a known App rejection; it does not replace or bypass upstream
+OIDC/App workflow validation.
+
+At the pinned Claude action version, a successful action step with no execution
+`conclusion` returns before Claude runs. The workflow records zero calls and
+`provider_not_executed`, skips candidate canonicalization, and fails the run. Actual
+execution with a missing candidate retains `candidate_missing`. Failures preserve a
+previous authenticated successful review instead of replacing its findings.
+
+The default branch can change between the preflight and the upstream App exchange.
+If that race causes a post-claim skip, the zero-call final checkpoint preserves the
+reservation and its original approval event; it does not refund the round. Likewise,
+historical v1.74-or-earlier `candidate_missing`/one-call records are not proof that a
+model did or did not run. Do not edit/delete the ledger, replay a consumed override,
+or rerun blindly. Preserve exact run/attempt, head/diff, claim and execution evidence;
+restoring those rounds requires a separately authenticated recovery contract. This
+change prevents known caller mismatches at admission and corrects new skip reporting;
+it does not repair already consumed canary budgets or authorize merging a blocked PR.
 
 Claude and Gemini baseline callers expose a `workflow_dispatch` input pair:
 `pr_number` (required) and `force_review` (boolean, default `false`). A force claim is accepted only

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -59,6 +59,7 @@ from scripts.workflow_release_inventory import (
     release_supports_opencode_context_budget,
     release_supports_opencode_active_section_order,
     release_supports_expanded_review_budget,
+    release_supports_claude_workflow_validation,
     release_retires_manual_pr_review,
     release_supports_same_head_cancel_guard,
     release_supports_review_policy,
@@ -834,6 +835,16 @@ EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256 = {
     "gemini": "33c15251ac3e7dd97a3c0d30c77dd40e6ac58fe087d93078ce468dba473027b2",
     "opencode": "f81db9665847aea815c8691caea7c6458011595cbed28c13809f051c381b5e91",
 }
+EXPECTED_CLAUDE_VALIDATION_WORKFLOW_SHA256 = {
+    **EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256,
+    "claude": "63c672654918c95de9636062f68d33d43845d64c4a674ff54c03bf90ec3d48ce",
+}
+EXPECTED_CLAUDE_CALLER_VALIDATION_SHA256 = (
+    "c723636ffdf202b3888c7903704353edb6367630a46b50e77412389b43d566db"
+)
+EXPECTED_CLAUDE_EXECUTION_SHA256 = (
+    "ad617b4bab75d0259ff4fe9fcd0b0f9476a7f783b336b4b977cf497cbcf816bf"
+)
 EXPECTED_REVIEW_POLICY_HELPER_SHA256 = (
     "3e0fd3c86b1dc40dc35213ca41c3d63122c9ebf757042f5a2c86f4fc1e99ac8a"
 )
@@ -1394,6 +1405,9 @@ REVIEW_PUBLICATION_CONTRACTS = {
         ),
         "upsert_sha256_v147": (
             "f23f444b3a9c7b04707779f3f8431da60107c8792558c02f5c011216ca93d805"
+        ),
+        "upsert_sha256_v175": (
+            "8678623c52a06eedea3d250fbd27ec058098ed5d3faf87b29c74dc3b92a08f07"
         ),
         "bot_login": "github-actions[bot]",
         "workflow_prefix": (
@@ -5386,12 +5400,69 @@ def require_budget_helper_contract(
         ) from None
 
 
+def _require_claude_validation_contract(job: dict, claim: dict, provider: dict) -> None:
+    validation = _named_step(job, "Validate Claude caller workflow")
+    execution = _named_step(job, "Resolve Claude execution")
+    validation_script = validation.get("with", {}).get("script", "")
+    execution_script = execution.get("run", "")
+    if validation != {
+        "name": "Validate Claude caller workflow",
+        "id": "claude-workflow-validation",
+        "if": (
+            "${{ always() && steps.prepare-review-input.outcome == 'success' "
+            "&& steps.prepare-diff.outputs.diff-ready == 'true' "
+            "&& steps.prepare-diff.outputs.diff-mode != 'unchanged' }}"
+        ),
+        "uses": "actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea",
+        "env": {
+            "WORKFLOW_REF": "${{ github.workflow_ref }}",
+            "WORKFLOW_SHA": "${{ github.workflow_sha }}",
+        },
+        "with": {"github-token": "${{ github.token }}", "script": validation_script},
+    } or hashlib.sha256(validation_script.encode()).hexdigest() != EXPECTED_CLAUDE_CALLER_VALIDATION_SHA256:
+        raise ValueError("Claude caller validation differs")
+    if execution != {
+        "name": "Resolve Claude execution",
+        "id": "claude-execution",
+        "if": "${{ always() }}",
+        "shell": "bash",
+        "env": {
+            "ACTION_OUTCOME": "${{ steps.claude-review.outcome }}",
+            "EXECUTION_CONCLUSION": "${{ steps.claude-review.outputs.conclusion }}",
+        },
+        "run": execution_script,
+    } or hashlib.sha256(execution_script.encode()).hexdigest() != EXPECTED_CLAUDE_EXECUTION_SHA256:
+        raise ValueError("Claude execution classification differs")
+    steps = job["steps"]
+    metrics = _named_step(job, "Validate Claude review metrics")
+    canonical = _named_step(job, "Canonicalize Claude review")
+    upsert = _named_step(job, "Upsert review comment")
+    outcome = _named_step(job, "Resolve Claude budget outcome")
+    if not (
+        steps.index(validation) < steps.index(claim) < steps.index(provider)
+        < steps.index(execution) < steps.index(metrics) < steps.index(canonical)
+        < steps.index(upsert) < steps.index(outcome)
+    ):
+        raise ValueError("Claude execution validation order differs")
+    resolved = "${{ steps.claude-execution.outputs.provider_outcome }}"
+    if (
+        upsert.get("env", {}).get("REVIEW_OUTCOME") != resolved
+        or outcome.get("env", {}).get("PROVIDER_OUTCOME") != resolved
+        or upsert.get("env", {}).get("PROVIDER_FAILURE_REASON") != (
+            "${{ steps.claude-workflow-validation.outputs.reason "
+            "|| steps.claude-execution.outputs.failure_reason }}"
+        )
+    ):
+        raise ValueError("Claude execution publication differs")
+
+
 def require_budget_workflow_contract(
     tree: VerifiedCommitTree,
     workflow: str,
     reviewer: str,
     *,
     review_policy: bool = False,
+    claude_validation: bool = False,
 ) -> None:
     """Require reviewer semantics from authenticated commit-tree workflow bytes."""
 
@@ -5434,7 +5505,13 @@ def require_budget_workflow_contract(
             "claude": (
                 "${{ always() && "
                 "steps.prepare-review-input.outcome == 'success' && "
-                "steps.stage-claude-budget-input.outcome == 'success' }}"
+                "steps.stage-claude-budget-input.outcome == 'success'"
+                + (
+                    " && (steps.prepare-diff.outputs.diff-ready != 'true' "
+                    "|| steps.prepare-diff.outputs.diff-mode == 'unchanged' "
+                    "|| steps.claude-workflow-validation.outputs.allowed == 'true') }}"
+                    if claude_validation else " }}"
+                )
             ),
             "gemini": (
                 "${{ always() && steps.pr-details.outcome == 'success' && "
@@ -5740,6 +5817,8 @@ def require_budget_workflow_contract(
                 raise ValueError("OpenCode sealed handoff validation differs")
 
         if reviewer == "claude":
+            if claude_validation:
+                _require_claude_validation_contract(claim_job, claim_step, provider)
             metrics_start = _named_step(
                 claim_job, "Start Claude review metrics"
             )
@@ -5753,7 +5832,9 @@ def require_budget_workflow_contract(
                 "shell": "bash",
                 "run": (
                     "set -euo pipefail\n"
-                    "printf 'call_count=1\\n' >> \"$GITHUB_OUTPUT\"\n"
+                    + ("" if claude_validation else
+                       "printf 'call_count=1\\n' >> \"$GITHUB_OUTPUT\"\n")
+                    +
                     "printf 'started_at=%s\\n' \"$(date +%s)\" "
                     ">> \"$GITHUB_OUTPUT\"\n"
                 ),
@@ -5796,6 +5877,8 @@ def require_budget_workflow_contract(
                 "shell": "bash",
                 "env": {
                     "CALL_COUNT": (
+                        "${{ steps.claude-execution.outputs.call_count }}"
+                        if claude_validation else
                         "${{ steps.claude-budget-metrics-start.outputs.call_count }}"
                     ),
                     "ELAPSED_SECONDS": (
@@ -6056,6 +6139,7 @@ def _verify_review_invocation_budget(
             workflow,
             reviewer,
             review_policy=release_supports_review_policy(ref),
+            claude_validation=release_supports_claude_workflow_validation(ref),
         )
     rounds_variable = release_supports_review_rounds_variable(ref)
     dismissals = release_supports_finding_dismissal(ref)
@@ -6084,7 +6168,9 @@ def _verify_review_invocation_budget(
         ),
     }
     workflow_digests = (
-        EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256
+        EXPECTED_CLAUDE_VALIDATION_WORKFLOW_SHA256
+        if release_supports_claude_workflow_validation(ref)
+        else EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256
         if release_supports_opencode_active_section_order(ref)
         else EXPECTED_OPENCODE_CONTEXT_BUDGET_WORKFLOW_SHA256
         if release_supports_opencode_context_budget(ref)
@@ -6421,7 +6507,8 @@ def _named_step(job: object, name: str) -> dict:
 
 
 def _expected_canonicalize_step(
-    contract: dict[str, str], *, budget: bool = False, dismissals: bool = False
+    contract: dict[str, str], *, budget: bool = False, dismissals: bool = False,
+    claude_validation: bool = False,
 ) -> dict[str, object]:
     reviewer = contract["reviewer"]
     reset = contract["reset"]
@@ -6433,10 +6520,13 @@ def _expected_canonicalize_step(
             "steps.prepare-diff.outputs.diff-ready == 'true' && "
             "steps.prepare-diff.outputs.diff-mode != 'unchanged'"
             + (
-                " && steps.review-budget-claim.outputs.allow-invocation == 'true' }}"
+                " && steps.review-budget-claim.outputs.allow-invocation == 'true'"
                 if budget
-                else " }}"
+                else ""
             )
+            + (" && steps.claude-execution.outputs.call_count == '1'"
+               if claude_validation and reviewer == "claude" else "")
+            + " }}"
         ),
         "uses": CANONICALIZE_REVIEW_ACTION,
         "with": {
@@ -6619,7 +6709,8 @@ def _verify_review_publication_contracts(
                 raise ValueError("review run provenance permission differs")
             canonical_step = _named_step(job, contract["canonical_step"])
             if canonical_step != _expected_canonicalize_step(
-                contract, budget=budget, dismissals=release_supports_finding_dismissal(ref)
+                contract, budget=budget, dismissals=release_supports_finding_dismissal(ref),
+                claude_validation=release_supports_claude_workflow_validation(ref),
             ):
                 raise ValueError("canonicalizer call differs")
             rejected_diagnostic_upload = _named_step(
@@ -6778,7 +6869,11 @@ def _verify_review_publication_contracts(
                     f"${{{{ !cancelled() && steps.{collector_id}.outcome == 'success' && "
                     + "(steps.prepare-diff.outputs.diff-ready != 'true' || "
                     "steps.prepare-diff.outputs.diff-mode == 'unchanged' || "
-                    "steps.review-budget-claim.outputs.allow-invocation == 'true') }}"
+                    "steps.review-budget-claim.outputs.allow-invocation == 'true'"
+                    + (" || steps.claude-workflow-validation.outcome == 'failure'"
+                       if contract["reviewer"] == "claude"
+                       and release_supports_claude_workflow_validation(ref) else "")
+                    + ") }}"
                 )
             if upsert.get("if") != expected_upsert_if:
                 raise ValueError("upsert prior-state guard differs")
@@ -6793,6 +6888,9 @@ def _verify_review_publication_contracts(
             if (
                 hashlib.sha256(upsert_script.encode("utf-8")).hexdigest()
                 != contract[
+                    "upsert_sha256_v175"
+                    if contract["reviewer"] == "claude"
+                    and release_supports_claude_workflow_validation(ref) else
                     "upsert_sha256_v147" if budget else "upsert_sha256"
                 ]
             ):

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -162,6 +162,7 @@ OPENCODE_DISMISSAL_RELEASE = (1, 71)
 OPENCODE_CONTEXT_BUDGET_RELEASE = (1, 72)
 OPENCODE_ACTIVE_SECTION_ORDER_RELEASE = (1, 73)
 EXPANDED_REVIEW_BUDGET_RELEASE = (1, 74)
+CLAUDE_WORKFLOW_VALIDATION_RELEASE = (1, 75)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -276,6 +277,12 @@ def release_supports_expanded_review_budget(ref: str) -> bool:
     """Return whether ``ref`` allows five automatic and two approved review rounds."""
 
     return _release_version(ref) >= EXPANDED_REVIEW_BUDGET_RELEASE
+
+
+def release_supports_claude_workflow_validation(ref: str) -> bool:
+    """Return whether Claude checks caller identity before budget admission."""
+
+    return _release_version(ref) >= CLAUDE_WORKFLOW_VALIDATION_RELEASE
 
 
 def release_retires_manual_pr_review(ref: str) -> bool:

--- a/tests/test_claude_workflow_validation.py
+++ b/tests/test_claude_workflow_validation.py
@@ -1,0 +1,187 @@
+"""Issue #169: a successful action step is not proof of a model execution."""
+
+import json
+import os
+import subprocess
+
+import pytest
+
+from test_review_workflow_logic import (
+    _claude_upsert, _github_outputs, _load, _posted_state, node_required,
+)
+
+
+def _new_step(name):
+    steps = _load("claude-code-review.yml")["jobs"]["claude-review"]["steps"]
+    return next((step for step in steps if step.get("name") == name), {})
+
+
+def _preflight(tmp_path, **changes):
+    fixture = {
+        "workflowRef": "o/r/.github/workflows/claude.yml@refs/pull/326/merge",
+        "workflowSha": "a" * 40,
+        "defaultBranch": "master",
+        "defaultSha": "b" * 40,
+        "currentBlob": "c" * 40,
+        "defaultBlob": "c" * 40,
+        **changes,
+    }
+    script = _new_step("Validate Claude caller workflow").get("with", {}).get("script", "")
+    harness = r"""
+const fx = JSON.parse(process.argv[1]);
+const script = JSON.parse(process.argv[2]);
+const calls = [], outputs = {}, failures = [];
+const context = {repo: {owner: 'o', repo: 'r'}};
+process.env.WORKFLOW_REF = fx.workflowRef;
+process.env.WORKFLOW_SHA = fx.workflowSha;
+const respond = (method, args, data) => {
+  calls.push([method, args]);
+  if (fx.errorMethod === method) {
+    const error = new Error('sensitive remote error');
+    error.status = fx.errorStatus;
+    throw error;
+  }
+  return {data};
+};
+const github = {rest: {repos: {
+  get: async args => respond('get', args, {default_branch: fx.defaultBranch}),
+  getBranch: async args => respond('branch', args, {commit: {sha: fx.defaultSha}}),
+  getContent: async args => respond(
+    args.ref === fx.workflowSha ? 'current' : 'default', args,
+    {type: fx.fileType || 'file', path: '.github/workflows/claude.yml',
+     sha: args.ref === fx.workflowSha ? fx.currentBlob : fx.defaultBlob}
+  ),
+}}};
+const core = {
+  setOutput: (key, value) => {outputs[key] = value;},
+  setFailed: message => failures.push(message),
+};
+(async () => {
+  await new Function('github', 'context', 'core',
+    'return (async () => {' + script + '})();')(github, context, core);
+  console.log(JSON.stringify({calls, outputs, failures}));
+})().catch(error => {console.error(error); process.exit(1);});
+"""
+    result = subprocess.run(
+        ["node", "-e", harness, json.dumps(fixture), json.dumps(script)],
+        text=True, capture_output=True, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+@node_required
+@pytest.mark.parametrize("ref", [
+    "refs/pull/326/merge", "refs/heads/feature", "refs/heads/release/1.x",
+])
+def test_identical_caller_bytes_allow_review_on_different_commits(tmp_path, ref):
+    result = _preflight(tmp_path, workflowRef=f"o/r/.github/workflows/claude.yml@{ref}")
+    assert result["outputs"] == {"allowed": "true", "reason": ""}
+    assert not result["failures"]
+    assert [args["ref"] for method, args in result["calls"]
+            if method in {"current", "default"}] == ["a" * 40, "b" * 40]
+    assert all(args["owner"] == "o" and args["repo"] == "r"
+               for _, args in result["calls"])
+
+
+@node_required
+def test_default_rollout_during_open_feature_pr_blocks_before_claim(tmp_path):
+    result = _preflight(tmp_path, defaultBlob="d" * 40)
+    assert result["outputs"] == {
+        "allowed": "false", "reason": "workflow_validation_mismatch",
+    }
+    assert result["failures"] == ["workflow_validation_mismatch"]
+
+
+@node_required
+@pytest.mark.parametrize(("changes", "reason"), [
+    ({"workflowRef": "other/repo/.github/workflows/claude.yml@refs/heads/main"},
+     "workflow_validation_unavailable"),
+    ({"workflowRef": "o/r/.github/workflows/../claude.yml@refs/heads/main"},
+     "workflow_validation_unavailable"),
+    ({"workflowSha": ""}, "workflow_validation_unavailable"),
+    ({"defaultBranch": ""}, "workflow_validation_unavailable"),
+    ({"defaultSha": "main"}, "workflow_validation_unavailable"),
+    ({"currentBlob": ""}, "workflow_validation_unavailable"),
+    ({"fileType": "symlink"}, "workflow_validation_unavailable"),
+    ({"errorMethod": "default", "errorStatus": 404}, "workflow_validation_mismatch"),
+    ({"errorMethod": "current", "errorStatus": 404}, "workflow_validation_unavailable"),
+    ({"errorMethod": "default", "errorStatus": 403}, "workflow_validation_unavailable"),
+    ({"errorMethod": "get", "errorStatus": 500}, "workflow_validation_unavailable"),
+    ({"errorMethod": "branch", "errorStatus": None}, "workflow_validation_unavailable"),
+])
+def test_unverifiable_caller_fails_closed_with_bounded_diagnostic(tmp_path, changes, reason):
+    result = _preflight(tmp_path, **changes)
+    assert result["outputs"] == {"allowed": "false", "reason": reason}
+    assert result["failures"] == [reason]
+    assert "sensitive remote error" not in json.dumps(result)
+
+
+def _execution(tmp_path, outcome, conclusion):
+    output = tmp_path / "outputs"
+    step = _new_step("Resolve Claude execution")
+    result = subprocess.run(
+        ["bash", "-c", step.get("run", "")],
+        env={
+            **os.environ, "GITHUB_OUTPUT": str(output),
+            "ACTION_OUTCOME": outcome, "EXECUTION_CONCLUSION": conclusion,
+        },
+        text=True, capture_output=True, check=False,
+    )
+    return result, _github_outputs(output) if output.exists() else {}
+
+
+@pytest.mark.parametrize(("outcome", "conclusion", "expected", "failed"), [
+    ("success", "", ("0", "skipped", "provider_not_executed"), True),
+    ("success", "success", ("1", "success", ""), False),
+    ("success", "failure", ("1", "failure", "provider_failure"), True),
+    ("failure", "success", ("1", "failure", "provider_failure"), True),
+    ("failure", "", ("1", "failure", "provider_failure"), True),
+    ("skipped", "", ("0", "skipped", ""), False),
+    ("", "", ("0", "skipped", ""), False),
+])
+def test_execution_accounting_uses_action_conclusion(tmp_path, outcome, conclusion, expected, failed):
+    result, outputs = _execution(tmp_path, outcome, conclusion)
+    assert outputs == dict(zip(
+        ("call_count", "provider_outcome", "failure_reason"), expected,
+    ))
+    assert (result.returncode != 0) is failed
+
+
+@pytest.mark.parametrize(("outcome", "conclusion"), [
+    ("success", "unknown"), ("cancelled", ""), ("skipped", "success"),
+])
+def test_uncertain_execution_does_not_invent_zero_call_metrics(tmp_path, outcome, conclusion):
+    result, outputs = _execution(tmp_path, outcome, conclusion)
+    assert result.returncode != 0
+    assert outputs == {}
+
+
+@node_required
+def test_skipped_action_cannot_publish_a_seeded_valid_candidate(tmp_path):
+    result, outputs = _execution(tmp_path, "success", "")
+    assert result.returncode != 0
+    calls = _claude_upsert(
+        tmp_path, outputs["provider_outcome"], [], True,
+        provider_failure_reason=outputs["failure_reason"],
+    )
+    body = next(call[1]["body"] for call in calls if call[0] == "create")
+    assert _posted_state(body)["review_execution"] == "not_performed"
+    assert _posted_state(body)["successful_head"] is None
+    assert "REVIEW BODY OK" not in body
+
+
+@node_required
+@pytest.mark.parametrize("reason", [
+    "workflow_validation_mismatch", "workflow_validation_unavailable", "provider_not_executed",
+])
+def test_nonexecution_publishes_reason_without_candidate_missing(tmp_path, reason):
+    calls = _claude_upsert(
+        tmp_path, "skipped", [], False, canonical_outcome="skipped",
+        canonical_failure_reason="candidate_missing", provider_failure_reason=reason,
+    )
+    body = next(call[1]["body"] for call in calls if call[0] == "create")
+    assert _posted_state(body)["review_execution"] == "not_performed"
+    assert _posted_state(body)["attempt_status"] == "failure"
+    assert f"`{reason}`" in body
+    assert "candidate_missing" not in body

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -1439,7 +1439,10 @@ def test_claude_budget_claim_is_durable_before_provider_and_every_model_path_is_
     claim = _step(workflow, "claude-review", "Claim Claude review budget")
     assert claim["if"] == (
         "${{ always() && steps.prepare-review-input.outcome == 'success' "
-        "&& steps.stage-claude-budget-input.outcome == 'success' }}"
+        "&& steps.stage-claude-budget-input.outcome == 'success' "
+        "&& (steps.prepare-diff.outputs.diff-ready != 'true' "
+        "|| steps.prepare-diff.outputs.diff-mode == 'unchanged' "
+        "|| steps.claude-workflow-validation.outputs.allowed == 'true') }}"
     )
     assert claim["with"] == {
         "github-token": "${{ github.token }}",
@@ -2433,7 +2436,8 @@ def test_claude_model_step_requires_prepared_diff_but_upsert_can_stamp_failure_a
         "${{ !cancelled() && steps.prepare-review-input.outcome == 'success' "
         "&& (steps.prepare-diff.outputs.diff-ready != 'true' "
         "|| steps.prepare-diff.outputs.diff-mode == 'unchanged' "
-        "|| steps.review-budget-claim.outputs.allow-invocation == 'true') }}"
+        "|| steps.review-budget-claim.outputs.allow-invocation == 'true' "
+        "|| steps.claude-workflow-validation.outcome == 'failure') }}"
     )
 
 
@@ -2462,7 +2466,8 @@ def test_claude_cleanup_rejects_seeded_candidate_when_provider_writes_nothing(tm
         "${{ always() && steps.reset-claude-artifacts.outcome == 'success' "
         "&& steps.prepare-diff.outputs.diff-ready == 'true' "
         "&& steps.prepare-diff.outputs.diff-mode != 'unchanged' "
-        "&& steps.review-budget-claim.outputs.allow-invocation == 'true' }}"
+        "&& steps.review-budget-claim.outputs.allow-invocation == 'true' "
+        "&& steps.claude-execution.outputs.call_count == '1' }}"
     )
 
     workspace = tmp_path / "workspace"
@@ -2546,7 +2551,8 @@ def test_claude_uses_one_shared_canonicalizer_and_upsert_reads_only_canonical_fi
         "${{ always() && steps.reset-claude-artifacts.outcome == 'success' "
         "&& steps.prepare-diff.outputs.diff-ready == 'true' "
         "&& steps.prepare-diff.outputs.diff-mode != 'unchanged' "
-        "&& steps.review-budget-claim.outputs.allow-invocation == 'true' }}"
+        "&& steps.review-budget-claim.outputs.allow-invocation == 'true' "
+        "&& steps.claude-execution.outputs.call_count == '1' }}"
     )
     upsert = _step(workflow, "claude-review", "Upsert review comment")
     script = upsert["with"]["script"]
@@ -4489,6 +4495,7 @@ def _claude_upsert(
     workflow_runs: list[dict] | None = None,
     workflow_run_attempt_sequences: dict[str, list[dict]] | None = None,
     candidate_artifact: str = "success",
+    provider_failure_reason: str = "",
 ) -> list:
     workdir = tmp_path / ("with-review" if with_review else "without-review")
     workdir.mkdir()
@@ -4502,6 +4509,7 @@ def _claude_upsert(
         "SERVER_URL": "https://github.com",
         "REPOSITORY": "example/repo",
         "REVIEW_OUTCOME": outcome,
+        "PROVIDER_FAILURE_REASON": provider_failure_reason,
         "DIFF_READY": diff_ready,
         "RUN_ID": run_id,
         "RUN_ATTEMPT": run_attempt,

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -248,6 +248,7 @@ def current_release_repo(tmp_path: Path) -> tuple[Path, str]:
             shutil.copytree(source, target)
         else:
             shutil.copy2(source, target)
+    restore_pre_v175_claude_validation(repo)
     restore_pre_v172_opencode_context_budget(repo)
     restore_pre_v171_opencode_dismissals(repo)
     restore_pre_v170_opencode_finding_ids(repo)
@@ -528,6 +529,18 @@ def assert_pre_v160_workflow_bytes(repo: Path) -> None:
         )
 
 
+def restore_pre_v175_claude_validation(repo: Path) -> None:
+    tree = release_verifier.VerifiedCommitTree.open(
+        ROOT, "eb460b7e547a85f831820f8f25d30f134b2c6254"
+    )
+    relative = ".github/workflows/claude-code-review.yml"
+    payload = tree.read_file(relative)
+    assert hashlib.sha256(payload).hexdigest() == (
+        "a6116cf542876a46e8401e26471324a586772398ad5d21360155e686123104be"
+    )
+    (repo / relative).write_bytes(payload)
+
+
 def copy_review_policy_release_files(repo: Path) -> None:
     for relative in (
         ".github/actions/resolve-review-policy/action.yml",
@@ -551,6 +564,7 @@ def copy_review_policy_release_files(repo: Path) -> None:
         else:
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source, target)
+    restore_pre_v175_claude_validation(repo)
 
 
 def prepare_v151(repo: Path) -> str:
@@ -2275,6 +2289,46 @@ def test_v174_accepts_expanded_review_budget_release_contract(
     candidate = prepare_v174(repo)
 
     assert release_verifier.verify_commit_content(repo, "v1.74", candidate) == candidate
+
+
+def prepare_v175(repo: Path) -> str:
+    prepare_v174(repo)
+    relative = ".github/workflows/claude-code-review.yml"
+    shutil.copy2(ROOT / relative, repo / relative)
+    return commit(repo, "v1.75 candidate")
+
+
+def test_v175_accepts_claude_validation_without_changing_v174(current_release_repo):
+    repo, _ = current_release_repo
+    old = prepare_v174(repo)
+    candidate = prepare_v175(repo)
+    assert release_verifier.verify_commit_content(repo, "v1.74", old) == old
+    assert release_verifier.verify_commit_content(repo, "v1.75", candidate) == candidate
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.75", old)
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.74", candidate)
+
+
+@pytest.mark.parametrize(("step", "old", "new"), [
+    ("Claim Claude review budget", "steps.claude-workflow-validation.outputs.allowed == 'true'", "true"),
+    ("Validate Claude caller workflow", "ref: workflowSha", "ref: 'HEAD'"),
+    ("Validate Claude caller workflow", "current.sha !== baseline.sha", "false"),
+    ("Resolve Claude execution", "success:) call_count=0", "success:) call_count=1"),
+    ("Validate Claude review metrics", "steps.claude-execution.outputs.call_count", "steps.claude-budget-metrics-start.outputs.call_count"),
+    ("Upsert review comment", "steps.claude-execution.outputs.provider_outcome", "steps.claude-review.outcome"),
+])
+def test_v175_rejects_claude_validation_wiring_drift(current_release_repo, monkeypatch, step, old, new):
+    repo, _ = current_release_repo
+    prepare_v175(repo)
+    path = repo / ".github/workflows/claude-code-review.yml"
+    mutate_named_step_text(path, step, old, new)
+    bad = commit(repo, "weaken Claude validation")
+    # A digest re-seal alone must not authorize weaker execution semantics.
+    digests = getattr(release_verifier, "EXPECTED_CLAUDE_VALIDATION_WORKFLOW_SHA256", {})
+    monkeypatch.setitem(digests, "claude", hashlib.sha256(path.read_bytes()).hexdigest())
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.75", bad)
 
 
 def test_v174_expanded_review_budget_is_rejected_on_the_v173_release_line(


### PR DESCRIPTION
기본 브랜치의 workflow rollout으로 열린 PR의 caller 파일이 달라지면 Claude App이 모델 실행 전에 종료하지만, 기존 workflow는 이를 `performed`/1 call/`candidate_missing`으로 기록하고 review 예산을 소비했습니다.

이번 변경은 caller의 workflow commit/blob을 기본 브랜치의 동일 파일과 비교하여 알려진 불일치를 budget claim 전에 차단합니다. 고정된 Claude action의 execution `conclusion`으로 실행 여부를 판정하여 준비 단계 skip은 0 call/`not_performed`/`provider_not_executed`로 기록하며, 실제 실행 뒤의 `candidate_missing`, 이전 성공 보존, unchanged 재사용은 유지합니다. 새 계약은 v1.75부터 검증하고 기존 v1.74 및 이전 릴리스 계약은 유지합니다.

기존에 소진된 예산과 사전 검사 이후 기본 브랜치 변경으로 남은 예약은 원래 증거와 승인 이벤트를 보존합니다. 이 PR은 해당 원장을 환불하거나 canary PR #326을 복구하지 않습니다. 별도의 OpenCode finalization 복구는 #179에서 다룹니다.

Fixes #169

검증:

- [GitHub CI](https://github.com/jhw7500/automation/actions/runs/34446315183): 전체 pytest 3,204 passed, 48 subtests passed. 신규 회귀 30개를 포함한 최종 커밋 전체 검증 통과.
- CI에서 workflow YAML 파싱, Bash run block 104개 구문 검사, actionlint 1.7.12를 통한 workflow 28개 검사 통과.
- v1.75/v1.74 릴리스 및 변조 검사 8개 별도 통과.
- 독립 A/B/C pre-PR tribunal Round 1 PASS, 차단 지적 0건. HEAD `652c5a546dfa6b9fc734e7e2b48b3990a1de0817`, diff SHA-256 `2f6587ca84a04636ec9af5fab284c011466d3e49bb804e82b1875bbb6c82f446`.

검증 범위: API/action-output fixture와 workflow 계약 검증을 완료했습니다. GitHub의 Claude·Gemini·OpenCode self-review는 `review_auto_false` 정책으로 skip되었습니다. 고정된 upstream action의 실제 App 교환 및 배포 후 동작은 이 PR 검증에서 실행하지 않았습니다.
