### PR TITLE
fix(opencode): recover published review finalization without provider rerun

### DIFF
--- a/.github/actions/recover-opencode-review/evidence.py
+++ b/.github/actions/recover-opencode-review/evidence.py
@@ -1,0 +1,466 @@
+"""Bounded, side-effect-free evidence checks for OpenCode finalization recovery."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+
+class RecoveryError(ValueError):
+    """A bounded refusal; untrusted evidence text never becomes a diagnostic."""
+
+
+def require(condition: bool, reason: str) -> None:
+    if not condition:
+        raise RecoveryError(reason)
+
+
+def integer(value: object, *, minimum: int = 1) -> bool:
+    return type(value) is int and minimum <= value <= 9007199254740991
+
+
+def sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def strict_json(payload: bytes | str) -> object:
+    def pairs(items):
+        result = {}
+        for key, value in items:
+            require(key not in result, "evidence_json_duplicate_key")
+            result[key] = value
+        return result
+
+    def constant(_):
+        raise RecoveryError("evidence_json_nonfinite")
+
+    try:
+        return json.loads(payload, object_pairs_hook=pairs, parse_constant=constant)
+    except (UnicodeError, ValueError, TypeError, RecursionError) as exc:
+        if isinstance(exc, RecoveryError):
+            raise
+        raise RecoveryError("evidence_json_invalid") from exc
+
+
+def read_artifact(metadata: dict, payload: bytes, expected_name: str, run_id: int) -> dict[str, bytes]:
+    """Verify a ZIP in memory. Never extract attacker-selected paths."""
+    require(isinstance(metadata, dict) and isinstance(payload, bytes), "artifact_invalid")
+    require(integer(metadata.get("id")), "artifact_identity_invalid")
+    require(metadata.get("name") == expected_name, "artifact_identity_invalid")
+    require(metadata.get("expired") is False, "artifact_expired_or_unavailable")
+    require(isinstance(metadata.get("workflow_run"), dict)
+            and metadata["workflow_run"].get("id") == run_id, "artifact_identity_invalid")
+    require(integer(metadata.get("size_in_bytes"))
+            and metadata["size_in_bytes"] == len(payload)
+            and len(payload) <= 8_000_000, "artifact_size_invalid")
+    require(metadata.get("digest") == "sha256:" + sha256(payload), "artifact_digest_invalid")
+    try:
+        with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+            entries = archive.infolist()
+            require(1 <= len(entries) <= 8, "artifact_inventory_invalid")
+            require(len({entry.filename for entry in entries}) == len(entries),
+                    "artifact_inventory_invalid")
+            require(sum(entry.file_size for entry in entries) <= 8_000_000,
+                    "artifact_size_invalid")
+            for entry in entries:
+                require(re.fullmatch(r"[a-z][a-z0-9-]*\.(?:json|md|diff)", entry.filename) is not None,
+                        "artifact_path_invalid")
+                mode = entry.external_attr >> 16
+                require(not entry.is_dir() and stat.S_IFMT(mode) in (0, stat.S_IFREG)
+                        and not entry.flag_bits & 1, "artifact_type_invalid")
+                require(0 <= entry.file_size <= 4_000_000, "artifact_size_invalid")
+            return {entry.filename: archive.read(entry) for entry in entries}
+    except (zipfile.BadZipFile, NotImplementedError, RuntimeError, OSError) as exc:
+        raise RecoveryError("artifact_zip_invalid") from exc
+
+# Only the reviewed v1.74/v1.75 and v1.76 canonicalizers are executable in recovery.
+# Future formats must add a reviewed replay contract; unknown source fails closed.
+APPROVED_REPLAY_SHA256 = frozenset({
+    "b8804d0c387e4f7e554443a1d0edd5862d9c4b1c1435de4140c621c241a25df5",
+    "3915f9bc32985745996d2246017cff9122460d25a071ca72568ac73c75339371",
+})
+APPROVED_WORKFLOW_SHA256 = frozenset({
+    "f81db9665847aea815c8691caea7c6458011595cbed28c13809f051c381b5e91",
+    "9cc171e9c11de4c6719d73922fed0373c5db0281feae7488c55c7447025bf0ab",
+})
+
+def _budget_module():
+    name = "_opencode_recovery_budget"
+    if name not in sys.modules:
+        path = Path(__file__).parents[1] / "review-invocation-budget/review_invocation_budget.py"
+        spec = importlib.util.spec_from_file_location(name, path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+    return sys.modules[name]
+
+
+@dataclass(frozen=True)
+class RecoveryTarget:
+    repository: str
+    pr: int
+    run_id: int
+    run_attempt: int
+    head_sha: str
+    base_sha: str
+
+    def __post_init__(self):
+        require(isinstance(self.repository, str)
+                and re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", self.repository) is not None,
+                "recovery_identity_invalid")
+        require(all(integer(value) for value in (self.pr, self.run_id, self.run_attempt)),
+                "recovery_identity_invalid")
+        require(all(isinstance(value, str) and re.fullmatch(r"[0-9a-f]{40}", value)
+                    for value in (self.head_sha, self.base_sha)), "recovery_identity_invalid")
+
+
+@dataclass(frozen=True)
+class ValidatedEvidence:
+    claim_state: object
+    original_claim: object
+    request: object
+    canonical_body: str
+    state: dict
+    attestation: dict
+    evidence_digests: dict
+
+
+def validate_pr(target: RecoveryTarget, pr: dict) -> None:
+    require(isinstance(pr, dict) and pr.get("number") == target.pr
+            and pr.get("state") == "open" and pr.get("merged") is False, "pr_not_open")
+    require(pr.get("head", {}).get("sha") == target.head_sha
+            and pr.get("base", {}).get("sha") == target.base_sha, "pr_identity_changed")
+    require(pr["head"].get("repo", {}).get("full_name") == target.repository
+            and pr["head"]["repo"].get("fork") is False
+            and pr["base"].get("repo", {}).get("full_name") == target.repository,
+            "pr_repository_invalid")
+
+
+def validate_original_run(target: RecoveryTarget, run: dict, jobs: list) -> None:
+    require(isinstance(run, dict) and run.get("id") == target.run_id
+            and run.get("run_attempt") == target.run_attempt
+            and integer(run.get("id")) and integer(run.get("run_attempt"))
+            and isinstance(run.get("head_sha"), str)
+            and re.fullmatch(r"[0-9a-f]{40}", run["head_sha"])
+            and run.get("event") == "pull_request"
+            and run.get("status") == "completed" and run.get("conclusion") == "failure"
+            and run.get("repository", {}).get("full_name") == target.repository,
+            "original_run_invalid")
+    bindings = run.get("pull_requests")
+    require(isinstance(bindings, list) and len(bindings) == 1, "original_pr_binding_invalid")
+    binding = bindings[0]
+    require(binding.get("number") == target.pr
+            and binding.get("head", {}).get("sha") == target.head_sha
+            and binding.get("base", {}).get("sha") == target.base_sha, "original_pr_binding_invalid")
+    require(isinstance(jobs, list) and 1 <= len(jobs) <= 100, "original_jobs_invalid")
+    expected = {
+        "opencode-prepare": ("success", {
+            "Claim OpenCode review budget": "success",
+            "Build sealed canonicalization handoff": "success",
+            "Upload sealed canonicalization handoff": "success",
+        }),
+        "opencode-review": ("success", {
+            "Run OpenCode PR review": "success",
+            "Materialize sealed OpenCode candidate": "success",
+            "Upload untrusted OpenCode candidate": "success",
+        }),
+        "opencode-canonicalize": ("failure", {
+            "Canonicalize OpenCode review": "success",
+            "Resolve OpenCode budget outcome": "success",
+            "Finalize OpenCode review budget": "failure",
+        }),
+    }
+    for name, (conclusion, required_steps) in expected.items():
+        matches = [job for job in jobs if isinstance(job, dict)
+                   and re.search(r"(?:^|\s/\s)" + re.escape(name) + r"$", job.get("name", ""))]
+        require(len(matches) == 1, "original_job_ambiguous")
+        job = matches[0]
+        require(job.get("status") == "completed" and job.get("conclusion") == conclusion
+                and job.get("run_id") == target.run_id, "original_job_invalid")
+        # GitHub's jobs response does not always include run_attempt; its exact-attempt
+        # endpoint is mandatory in the collector. If present it must agree.
+        require("run_attempt" not in job or job["run_attempt"] == target.run_attempt,
+                "original_job_invalid")
+        steps = job.get("steps")
+        require(isinstance(steps, list) and len(steps) <= 100, "original_steps_invalid")
+        numbers = [step.get("number") for step in steps if isinstance(step, dict)]
+        require(len(numbers) == len(steps) and all(integer(number) for number in numbers)
+                and numbers == sorted(set(numbers)), "original_step_order_invalid")
+        previous_number = 0
+        for step_name, step_conclusion in required_steps.items():
+            found = [s for s in steps if isinstance(s, dict) and s.get("name") == step_name]
+            require(len(found) == 1 and found[0].get("status") == "completed"
+                    and found[0].get("conclusion") == step_conclusion, "original_step_invalid")
+            require(found[0]["number"] > previous_number, "original_step_order_invalid")
+            previous_number = found[0]["number"]
+        failed = [s.get("name") for s in steps if s.get("conclusion") not in ("success", "skipped")]
+        require(failed == (["Finalize OpenCode review budget"] if conclusion == "failure" else []),
+                "original_failure_not_finalizer")
+
+
+def validate_canonical(target: RecoveryTarget, comment: dict, check: dict,
+                       workflow_head: str | None = None) -> tuple[dict, dict]:
+    workflow_head = target.head_sha if workflow_head is None else workflow_head
+    require(isinstance(comment, dict) and integer(comment.get("id"))
+            and comment.get("user", {}).get("login") == "github-actions[bot]"
+            and comment["user"].get("type") == "Bot", "canonical_author_invalid")
+    body = comment.get("body")
+    require(isinstance(body, str) and len(body.encode("utf-8")) <= 65536, "canonical_body_invalid")
+    lines = body.split("\n")
+    require(len(lines) > 3 and lines[:2] == [
+        "## OpenCode Review (latest)", "<!-- automation:opencode-auto-review:v2 -->"],
+        "canonical_body_invalid")
+    match = re.fullmatch(r"<!-- automation-state:(\{.*\}) -->", lines[2])
+    require(match is not None, "canonical_state_invalid")
+    state_text = match[1]
+    state = strict_json(state_text)
+    require(isinstance(state, dict) and set(state) == {
+        "schema", "reviewer", "pr", "run_id", "run_attempt", "attempt_head",
+        "successful_head", "attempt_status", "diff_mode", "full_diff_sha256"},
+        "canonical_state_invalid")
+    require(state["schema"] == 2 and state["reviewer"] == "opencode"
+            and state["pr"] == target.pr and state["run_id"] == target.run_id
+            and state["run_attempt"] == target.run_attempt
+            and state["attempt_head"] == state["successful_head"] == target.head_sha
+            and state["attempt_status"] == "success" and state["diff_mode"] in ("full", "delta")
+            and re.fullmatch(r"[0-9a-f]{64}", str(state["full_diff_sha256"])),
+            "canonical_state_invalid")
+    require(isinstance(check, dict) and integer(check.get("id"))
+            and check.get("name") == "automation/opencode-canonical-review"
+            and check.get("status") == "completed" and check.get("conclusion") == "success"
+            and check.get("head_sha") == workflow_head
+            and check.get("app", {}).get("slug") == "github-actions"
+            and check["app"].get("id") == 15368, "canonical_check_invalid")
+    raw = check.get("output", {}).get("text")
+    match = re.fullmatch(r"<!-- automation-attestation:(\{.*\}) -->", raw or "")
+    require(match is not None, "canonical_attestation_invalid")
+    attestation = strict_json(match[1])
+    expected_keys = {"schema", "repository", "workflow", "pr", "caller_workflow_path",
+        "caller_event", "referenced_workflow_path", "referenced_workflow_sha", "attempt_head",
+        "workflow_head", "successful_head", "run_id", "run_attempt", "comment_id",
+        "prepared_run_attempt", "body_sha256", "state_sha256"}
+    require(isinstance(attestation, dict) and set(attestation) == expected_keys,
+            "canonical_attestation_invalid")
+    require(all(integer(attestation[key]) for key in (
+        "schema", "pr", "run_id", "run_attempt", "prepared_run_attempt", "comment_id")),
+        "canonical_attestation_invalid")
+    expected = {"schema": 1, "repository": target.repository,
+        "workflow": ".github/workflows/opencode-auto-review.yml", "pr": target.pr,
+        "caller_event": "pull_request", "run_id": target.run_id, "run_attempt": target.run_attempt,
+        "prepared_run_attempt": target.run_attempt, "attempt_head": target.head_sha,
+        "workflow_head": workflow_head, "successful_head": target.head_sha,
+        "comment_id": comment["id"], "body_sha256": sha256(body.encode()),
+        "state_sha256": sha256(state_text.encode())}
+    require(all(attestation.get(key) == value for key, value in expected.items()),
+            "canonical_attestation_invalid")
+    require(check.get("external_id") == (
+        f"automation-opencode-canonical:{target.repository}:pr:{target.pr}:"
+        f"run:{target.run_id}:{target.run_attempt}:comment:{comment['id']}"),
+        "canonical_attestation_invalid")
+    require([line for line in lines if line.startswith("- Attestation: ")]
+            == [f"- Attestation: {check['id']}"], "canonical_attestation_invalid")
+    return state, attestation
+
+
+def replay_source(workflow: str) -> str:
+    require(isinstance(workflow, str) and len(workflow.encode()) <= 2_000_000,
+            "original_workflow_invalid")
+    require(sha256(workflow.encode()) in APPROVED_WORKFLOW_SHA256,
+            "original_replay_unsupported")
+    lines = workflow.splitlines(keepends=True)
+    names = [i for i, line in enumerate(lines)
+             if line == "      - name: Canonicalize OpenCode review\n"]
+    require(len(names) == 1, "original_workflow_invalid")
+    start = next((i for i in range(names[0], len(lines))
+                  if lines[i] == "          script: |\n"), None)
+    require(start is not None, "original_workflow_invalid")
+    collected = []
+    for line in lines[start + 1:]:
+        require(line.startswith("            ") or not line.strip(), "original_workflow_invalid")
+        line = line[12:] if line.startswith("            ") else line
+        if line == "if (!(await repairComments())) return;\n":
+            source = "".join(collected)
+            require(sha256(source.encode()) in APPROVED_REPLAY_SHA256, "original_replay_unsupported")
+            return source
+        collected.append(line)
+    raise RecoveryError("original_workflow_invalid")
+
+
+def git_environment() -> dict[str, str]:
+    return {"PATH": "/usr/bin:/bin", "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8",
+        "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_SYSTEM": "/dev/null", "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_TERMINAL_PROMPT": "0", "GIT_ASKPASS": "/bin/false", "SSH_ASKPASS": "/bin/false",
+        "GIT_NO_REPLACE_OBJECTS": "1", "GIT_OPTIONAL_LOCKS": "0"}
+
+
+def git_read(workspace: Path, *arguments: str) -> bytes:
+    try:
+        result = subprocess.run(["/usr/bin/git", "--no-replace-objects", "--literal-pathspecs",
+            "-c", "diff.external=", "-c", "color.ui=false", *arguments], cwd=workspace,
+            env=git_environment(), check=True, capture_output=True, timeout=30)
+        require(len(result.stdout) <= 8_000_000, "recovery_git_output_limit")
+        return result.stdout
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RecoveryError("recovery_git_unavailable") from exc
+
+
+def _replay(target, bundle, workspace, handoff, files, candidate_files, candidate) -> dict:
+    with tempfile.TemporaryDirectory(prefix="opencode-recovery-") as directory:
+        root = Path(directory)
+        for dirname, inventory in (("handoff", files), ("candidate", candidate_files)):
+            folder = root / dirname
+            folder.mkdir(mode=0o700)
+            for name, payload in inventory.items():
+                path = folder / name
+                descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+                with os.fdopen(descriptor, "wb") as stream:
+                    stream.write(payload)
+        environment = {
+            "OPENCODE_RECOVERY_HELPER": str(Path(__file__).with_name("receipt.js").resolve()),
+            "PR_NUMBER": str(target.pr), "RUN_ID": str(target.run_id),
+            "RUN_ATTEMPT": str(target.run_attempt), "ATTEMPT_HEAD": target.head_sha,
+            "WORKFLOW_HEAD": handoff["workflow_head"], "FULL_DIFF_SHA256": handoff["full_diff_sha256"],
+            "RUN_URL": f"https://github.com/{target.repository}/actions/runs/{target.run_id}",
+            "SERVER_URL": "https://github.com", "REPOSITORY": target.repository,
+            "WORKFLOW_NAME": ".github/workflows/opencode-auto-review.yml",
+            "TRUSTED_WORKSPACE": str(workspace.resolve()), "DIFF_READY": "true",
+            "DIFF_MODE": handoff["diff_mode"], "UNCHANGED_SINCE_PREVIOUS": "false",
+            "BUDGET_ALLOW_INVOCATION": "true", "BUDGET_DECISION": "claimed",
+            "BUDGET_CHECKPOINT_SHA256": handoff["budget_checkpoint_sha256"],
+            "REVIEW_CALL_COUNT": str(candidate["call_count"]),
+            "REVIEW_ELAPSED_SECONDS": str(candidate["elapsed_seconds"]),
+            "REVIEW_MODEL_ROUTE_JSON": json.dumps(candidate["model_route"]),
+            "REVIEW_OUTCOME": "success", "REVIEW_FAILURE_REASON": "none",
+            "CANDIDATE_DOWNLOAD_OUTCOME": "success",
+        }
+        path_names = {"HANDOFF_PATH": "handoff/handoff.json",
+            "SNAPSHOT_PATH": "handoff/opencode-comments-before.json",
+            "ATTESTATIONS_PATH": "handoff/opencode-attestations-before.json",
+            "BUDGET_CLAIM_PATH": "handoff/review-budget-claim.json",
+            "REVIEW_DIFF_PATH": "handoff/review-full.diff", "REVIEW_SCOPE_PATH": "handoff/review-scope.json",
+            "CANDIDATE_PATH": "candidate/review.md", "CANDIDATE_ENVELOPE_PATH": "candidate/candidate.json"}
+        environment.update({key: str(root / path) for key, path in path_names.items()})
+        for role in ("handoff", "candidate"):
+            metadata = bundle["artifacts"][role]["metadata"]
+            environment[role.upper() + "_ARTIFACT_ID"] = str(metadata["id"])
+            environment[role.upper() + "_ARTIFACT_DIGEST"] = metadata["digest"][7:]
+            environment[role.upper() + "_ARTIFACT_NAME"] = metadata["name"]
+        payload = {"source": replay_source(bundle["workflow_source"]), "env": environment,
+            "target": target.__dict__, "run": bundle["original_run"], "pr": bundle["pr"],
+            "artifacts": [item["metadata"] for item in bundle["artifacts"].values()],
+            "history": bundle["history"], "check_id": bundle["original_check"]["id"]}
+        try:
+            node = shutil.which("node")
+            require(node is not None, "recovery_node_unavailable")
+            result = subprocess.run([str(Path(node).resolve()), str(Path(__file__).with_name("replay.js"))],
+                input=json.dumps(payload).encode(), env=git_environment(), cwd=root,
+                capture_output=True, timeout=45, check=True)
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise RecoveryError("canonical_replay_failed") from exc
+        require(len(result.stdout) <= 131072, "canonical_replay_output_limit")
+        return strict_json(result.stdout)
+
+
+def validate_evidence(target: RecoveryTarget, bundle: dict, workspace: Path) -> ValidatedEvidence:
+    try:
+        validate_pr(target, bundle["pr"])
+        validate_original_run(target, bundle["original_run"], bundle["original_jobs"])
+        state, attestation = validate_canonical(target, bundle["canonical_comment"],
+            bundle["original_check"], bundle["original_run"]["head_sha"])
+        artifacts = bundle["artifacts"]
+        require(set(artifacts) == {"handoff", "claim", "candidate"}, "artifact_inventory_invalid")
+        inventories = {}
+        for role, prefix in (("handoff", "opencode-handoff"), ("claim", "opencode-review-budget-claim"),
+                             ("candidate", "opencode-candidate")):
+            item = artifacts[role]
+            inventories[role] = read_artifact(item["metadata"], item["payload"],
+                f"{prefix}-{target.run_id}-{target.run_attempt}", target.run_id)
+        files = inventories["handoff"]
+        require(set(files) == {"handoff.json", "opencode-comments-before.json",
+            "opencode-attestations-before.json", "review-budget-claim.json",
+            "review-full.diff", "review-scope.json"}, "handoff_inventory_invalid")
+        require(set(inventories["candidate"]) == {"candidate.json", "review.md"}
+                and set(inventories["claim"]) == {"opencode-review-budget-claim.json"},
+                "artifact_inventory_invalid")
+        handoff = strict_json(files["handoff.json"])
+        require(isinstance(handoff, dict) and isinstance(handoff.get("files"), dict),
+                "handoff_invalid")
+        require(set(handoff["files"]) == set(files) - {"handoff.json"}, "handoff_inventory_invalid")
+        require(all(handoff["files"][name] == sha256(payload) for name, payload in files.items()
+                    if name != "handoff.json"), "handoff_digest_invalid")
+        require(files["review-budget-claim.json"] == inventories["claim"]["opencode-review-budget-claim.json"],
+                "claim_checkpoint_mismatch")
+        run = bundle["original_run"]
+        central = [entry for entry in run.get("referenced_workflows", [])
+                   if entry.get("path") == handoff.get("referenced_workflow_path")
+                   and entry.get("sha") == handoff.get("referenced_workflow_sha")]
+        require(len(central) == 1 and attestation["referenced_workflow_path"] == central[0]["path"]
+                and attestation["referenced_workflow_sha"] == central[0]["sha"]
+                and attestation["caller_workflow_path"] == run["path"] == handoff["caller_workflow_path"],
+                "original_workflow_identity_invalid")
+        require(handoff.get("run_attempt") == target.run_attempt
+                and handoff.get("run_id") == target.run_id, "original_claim_identity_invalid")
+        candidate = strict_json(inventories["candidate"]["candidate.json"])
+        require(isinstance(candidate, dict) and candidate.get("run_attempt") == target.run_attempt
+                and candidate.get("run_id") == target.run_id, "original_candidate_identity_invalid")
+        budget = _budget_module()
+        claim_state = budget.load_checkpoint(files["review-budget-claim.json"])
+        require(claim_state.repository == target.repository and claim_state.pr == target.pr
+                and claim_state.reviewer == "opencode" and claim_state.invocations,
+                "original_claim_identity_invalid")
+        original_claim = claim_state.invocations[-1]
+        require(original_claim.status == "claimed" and original_claim.run_id == target.run_id
+                and original_claim.run_attempt == target.run_attempt
+                and original_claim.head_sha == target.head_sha
+                and original_claim.full_diff_sha256 == state["full_diff_sha256"],
+                "original_claim_identity_invalid")
+        require(original_claim.caller_workflow_path == run["path"] == handoff.get("caller_workflow_path")
+                and original_claim.caller_event == run.get("event") == handoff.get("caller_event") == "pull_request"
+                and original_claim.referenced_workflow_path == central[0]["path"]
+                and original_claim.referenced_workflow_sha == central[0]["sha"]
+                and original_claim.referenced_workflow_ref == central[0].get("ref", central[0]["sha"]),
+                "original_claim_provenance_invalid")
+        require(git_read(workspace, "rev-parse", "HEAD").decode().strip() == target.head_sha,
+                "workspace_head_invalid")
+        base = git_read(workspace, "merge-base", target.base_sha, target.head_sha).decode().strip()
+        require(base == handoff["merge_base_sha"], "original_merge_base_invalid")
+        diff = git_read(workspace, "diff", "--no-ext-diff", "--no-textconv", "--find-renames=50%",
+                        "--ignore-submodules=none", "-U3", base + ".." + target.head_sha)
+        require(diff == files["review-full.diff"]
+                and sha256(diff) == state["full_diff_sha256"], "original_diff_invalid")
+        replay = _replay(target, bundle, workspace, handoff, files, inventories["candidate"], candidate)
+        require(isinstance(replay, dict) and replay.get("succeeded") is True
+                and replay.get("body") == bundle["canonical_comment"]["body"]
+                and replay.get("state") == state, "canonical_replay_mismatch")
+        require(integer(candidate.get("call_count")) and candidate["call_count"] <= 2
+                and integer(candidate.get("elapsed_seconds"), minimum=0)
+                and candidate["elapsed_seconds"] <= 600, "original_metrics_invalid")
+        remaining = tuple(replay["remaining_finding_ids"])
+        outcome = "quality_filtered" if replay["quality_filtered"] else "success"
+        request = budget.FinalizeRequest(target.repository, target.pr, "opencode", target.run_id,
+            target.run_attempt, target.head_sha, state["full_diff_sha256"],
+            tuple(candidate["model_route"]), original_claim.effort, candidate["call_count"],
+            candidate["elapsed_seconds"], outcome, outcome,
+            budget.AuthenticatedReview(True, target.head_sha, state["full_diff_sha256"], remaining),
+            remaining)
+        budget._validate_finalize_request(request)
+        digests = {role: {"id": item["metadata"]["id"], "sha256": sha256(item["payload"])}
+                   for role, item in artifacts.items()}
+        digests["claim_checkpoint_sha256"] = sha256(files["review-budget-claim.json"])
+        return ValidatedEvidence(claim_state, original_claim, request, replay["body"], state,
+                                 attestation, digests)
+    except RecoveryError:
+        raise
+    except (KeyError, TypeError, AttributeError, ValueError, IndexError) as exc:
+        raise RecoveryError("recovery_evidence_invalid") from exc

--- a/.github/actions/recover-opencode-review/receipt.js
+++ b/.github/actions/recover-opencode-review/receipt.js
@@ -1,0 +1,339 @@
+'use strict';
+
+// This module is loaded only from the current run's server-resolved central SHA.
+// Receipt bytes are claims until the independent server run/job/Check facts agree.
+const crypto = require('crypto');
+const WORKFLOW = '.github/workflows/opencode-auto-review.yml';
+const CENTRAL = `jhw7500/automation/${WORKFLOW}@`;
+const RECOVERY = 'jhw7500/automation/.github/workflows/opencode-recover-finalization.yml@';
+const CHECK = 'automation/opencode-finalization-recovery';
+const LEDGER = '<!-- automation:review-invocation-budget:opencode:v1 -->';
+const positive = (v) => Number.isSafeInteger(v) && v > 0;
+const terminalConclusion = (value) => ['success', 'failure', 'cancelled', 'skipped',
+  'timed_out', 'neutral', 'action_required', 'stale', 'startup_failure'].includes(value);
+const head = (v) => typeof v === 'string' && /^[0-9a-f]{40}$/.test(v);
+const hash = (v) => typeof v === 'string' && /^[0-9a-f]{64}$/.test(v);
+const sha = (v) => crypto.createHash('sha256').update(v).digest('hex');
+const exact = (v, keys) => v !== null && typeof v === 'object' && !Array.isArray(v)
+  && JSON.stringify(Object.keys(v).sort()) === JSON.stringify([...keys].sort());
+const ORIGINAL_KEYS = ['run_id', 'run_attempt', 'head_sha', 'base_sha', 'workflow_head',
+  'full_diff_sha256', 'caller_workflow_path', 'referenced_workflow_path', 'referenced_workflow_sha',
+  'comment_id', 'attestation_id', 'body_sha256', 'state_sha256', 'claim_checkpoint_sha256',
+  'finalized_invocation_sha256', 'artifacts'];
+const RECOVERY_KEYS = ['run_id', 'run_attempt', 'workflow_head', 'caller_workflow_path',
+  'referenced_workflow_path', 'referenced_workflow_sha', 'provider_calls'];
+const STATE_KEYS = ['schema', 'reviewer', 'pr', 'run_id', 'run_attempt', 'attempt_head',
+  'successful_head', 'attempt_status', 'diff_mode', 'full_diff_sha256'];
+const ATTESTATION_KEYS = ['schema', 'repository', 'workflow', 'caller_workflow_path', 'caller_event',
+  'referenced_workflow_path', 'referenced_workflow_sha', 'pr', 'attempt_head', 'workflow_head',
+  'successful_head', 'run_id', 'run_attempt', 'prepared_run_attempt', 'comment_id', 'body_sha256', 'state_sha256'];
+const INVOCATION_KEYS = ['run_id', 'run_attempt', 'head_sha', 'full_diff_sha256', 'caller_workflow_path',
+  'caller_event', 'referenced_workflow_path', 'referenced_workflow_ref', 'referenced_workflow_sha',
+  'round_number', 'override_event_id', 'model_route', 'effort', 'call_unit', 'call_count',
+  'estimated_input_tokens', 'elapsed_seconds', 'status', 'outcome', 'stop_reason', 'remaining_finding_ids'];
+
+// Python's ensure_ascii=True and recursive code-point key ordering, including
+// numeric-looking keys (which JSON.stringify on a reconstructed object reorders).
+function canonicalJson(value) {
+  if (Array.isArray(value)) return '[' + value.map(canonicalJson).join(',') + ']';
+  if (value && typeof value === 'object') {
+    const compare = (a, b) => {
+      const aa = Array.from(a, (c) => c.codePointAt(0)), bb = Array.from(b, (c) => c.codePointAt(0));
+      for (let i = 0; i < Math.min(aa.length, bb.length); i++) if (aa[i] !== bb[i]) return aa[i] - bb[i];
+      return aa.length - bb.length;
+    };
+    return '{' + Object.keys(value).sort(compare).map((k) => canonicalJson(k) + ':' + canonicalJson(value[k])).join(',') + '}';
+  }
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined || (typeof value === 'number' && !Number.isSafeInteger(value))) {
+    throw new Error('unsupported canonical JSON value');
+  }
+  return encoded.replace(/[\u007f-\uffff]/g, (c) => '\\u' + c.charCodeAt(0).toString(16).padStart(4, '0'));
+}
+
+// JSON.parse alone silently accepts duplicate object keys. Tokenize validated JSON
+// first so duplicate escaped keys are rejected at every nesting level.
+function strictJson(text) {
+  if (typeof text !== 'string' || text.length > 1000000) throw new Error('JSON bound exceeded');
+  const parsed = JSON.parse(text);
+  const tokens = text.match(/"(?:[^"\\]|\\.)*"|[{}\[\]:,]|[^\s{}\[\]:,]+/g) || [];
+  let at = 0;
+  function walk() {
+    const token = tokens[at++];
+    if (token === '{') {
+      const keys = new Set();
+      while (tokens[at] !== '}') {
+        const key = JSON.parse(tokens[at++]);
+        if (keys.has(key)) throw new Error('duplicate JSON key');
+        keys.add(key);
+        at++; // colon; syntax has already been validated
+        walk();
+        if (tokens[at] !== ',') break;
+        at++;
+      }
+      at++;
+    } else if (token === '[') {
+      while (tokens[at] !== ']') {
+        walk();
+        if (tokens[at] !== ',') break;
+        at++;
+      }
+      at++;
+    }
+  }
+  walk();
+  return parsed;
+}
+function envelope(text, marker) {
+  if (typeof text !== 'string' || text.includes('\n') || !text.startsWith(`<!-- ${marker}:`)
+    || !text.endsWith(' -->')) throw new Error('invalid envelope');
+  const parsed = strictJson(text.slice(marker.length + 6, -4));
+  if (marker === 'automation-opencode-recovery'
+    && text !== `<!-- ${marker}:${JSON.stringify(parsed)} -->`) throw new Error('noncompact recovery receipt');
+  return parsed;
+}
+function receiptShape(r) {
+  if (!exact(r, ['schema', 'repository', 'pr', 'original', 'recovery']) || r.schema !== 1
+    || typeof r.repository !== 'string' || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(r.repository)
+    || !positive(r.pr) || !exact(r.original, ORIGINAL_KEYS) || !exact(r.recovery, RECOVERY_KEYS)) return false;
+  const o = r.original, d = r.recovery;
+  return [o.run_id, o.run_attempt, o.comment_id, o.attestation_id, d.run_id, d.run_attempt].every(positive)
+    && o.run_id !== d.run_id
+    && [o.head_sha, o.base_sha, o.workflow_head, o.referenced_workflow_sha, d.workflow_head, d.referenced_workflow_sha].every(head)
+    && [o.full_diff_sha256, o.body_sha256, o.state_sha256, o.claim_checkpoint_sha256, o.finalized_invocation_sha256].every(hash)
+    && [o.caller_workflow_path, d.caller_workflow_path].every((p) => typeof p === 'string'
+      && /^\.github\/workflows\/[^/]+\.ya?ml$/.test(p))
+    && typeof o.referenced_workflow_path === 'string' && o.referenced_workflow_path.startsWith(CENTRAL)
+    && o.referenced_workflow_path.length > CENTRAL.length
+    && d.referenced_workflow_path === RECOVERY + d.referenced_workflow_sha && d.provider_calls === 0
+    && exact(o.artifacts, ['handoff', 'claim', 'candidate'])
+    && Object.values(o.artifacts).every((a) => exact(a, ['id', 'sha256']) && positive(a.id) && hash(a.sha256))
+    && new Set(Object.values(o.artifacts).map((a) => a.id)).size === 3;
+}
+function runMatches(run, binding, repository, event) {
+  return run?.id === binding.run_id && run.run_attempt === binding.run_attempt
+    && run.repository?.full_name === repository && run.head_sha === binding.workflow_head
+    && run.event === event && run.path === binding.caller_workflow_path
+    && Array.isArray(run.referenced_workflows)
+    && run.referenced_workflows.filter((r) => r.path.startsWith(event === 'pull_request' ? CENTRAL : RECOVERY)).length === 1
+    && run.referenced_workflows.some((r) => r.path === binding.referenced_workflow_path && r.sha === binding.referenced_workflow_sha);
+}
+function successfulCheck(check, name, workflowHead) {
+  return positive(check?.id) && check.name === name && check.head_sha === workflowHead
+    && check.status === 'completed' && check.conclusion === 'success'
+    && check.app?.id === 15368 && check.app.slug === 'github-actions';
+}
+function jobMatches(jobs, name, binding, conclusion, requiredSteps) {
+  if (!Array.isArray(jobs) || jobs.length > 100) return false;
+  const matched = jobs.filter((j) => new RegExp(`(?:^|\\s/\\s)${name}$`).test(j?.name || ''));
+  if (matched.length !== 1) return false;
+  const j = matched[0];
+  if (!positive(j.id) || j.run_id !== binding.run_id || ('run_attempt' in j && j.run_attempt !== binding.run_attempt)
+    || j.status !== 'completed' || j.conclusion !== conclusion) return false;
+  if (!requiredSteps) return true;
+  if (!Array.isArray(j.steps) || j.steps.length > 100) return false;
+  if (j.steps.some((step, index) => !positive(step.number)
+    || (index > 0 && step.number <= j.steps[index - 1].number))) return false;
+  let previousNumber = 0;
+  return Object.entries(requiredSteps).every(([name, conclusion]) => {
+    const found = j.steps.filter((s) => s.name === name);
+    if (found.length !== 1 || found[0].status !== 'completed' || found[0].conclusion !== conclusion
+      || found[0].number <= previousNumber) return false;
+    previousNumber = found[0].number;
+    return true;
+  }) && j.steps.filter((s) => !['success', 'skipped'].includes(s.conclusion))
+    .every((s) => conclusion === 'failure' && s.name === 'Finalize OpenCode review budget' && s.conclusion === 'failure');
+}
+function validateReceipt(facts) {
+  try {
+    const {receipt: r, check, driverRun, driverJobs, originalRun, originalJobs, canonicalCheck, comment, ledgerComment} = facts;
+    if (!receiptShape(r) || canonicalJson(envelope(check?.output?.text, 'automation-opencode-recovery')) !== canonicalJson(r)) return false;
+    const o = r.original, d = r.recovery;
+    if (!successfulCheck(check, CHECK, d.workflow_head)
+      || check.external_id !== `automation-opencode-recovery:${r.repository}:pr:${r.pr}:original:${o.run_id}:${o.run_attempt}:recovery:${d.run_id}:${d.run_attempt}`
+      || !runMatches(driverRun, d, r.repository, 'workflow_dispatch')
+      || driverRun.status !== 'completed' || driverRun.conclusion !== 'success'
+      || !jobMatches(driverJobs, 'opencode-recover-finalization', d, 'success')
+      || !runMatches(originalRun, o, r.repository, 'pull_request')
+      || originalRun.status !== 'completed' || originalRun.conclusion !== 'failure'
+      || !Array.isArray(originalRun.pull_requests) || originalRun.pull_requests.length !== 1) return false;
+    const pr = originalRun.pull_requests[0];
+    if (pr.number !== r.pr || pr.head?.sha !== o.head_sha || pr.base?.sha !== o.base_sha) return false;
+    if (!jobMatches(originalJobs, 'opencode-prepare', o, 'success', {
+      'Claim OpenCode review budget': 'success', 'Build sealed canonicalization handoff': 'success',
+      'Upload sealed canonicalization handoff': 'success'})
+      || !jobMatches(originalJobs, 'opencode-review', o, 'success', {
+        'Run OpenCode PR review': 'success', 'Materialize sealed OpenCode candidate': 'success',
+        'Upload untrusted OpenCode candidate': 'success'})
+      || !jobMatches(originalJobs, 'opencode-canonicalize', o, 'failure', {
+        'Canonicalize OpenCode review': 'success', 'Resolve OpenCode budget outcome': 'success',
+        'Finalize OpenCode review budget': 'failure'})) return false;
+    if (comment?.id !== o.comment_id || comment.user?.type !== 'Bot' || comment.user.login !== 'github-actions[bot]' || typeof comment.body !== 'string'
+      || sha(comment.body) !== o.body_sha256) return false;
+    const lines = comment.body.split('\n');
+    if (lines[0] !== '## OpenCode Review (latest)' || lines[1] !== '<!-- automation:opencode-auto-review:v2 -->'
+      || lines.filter((l) => /^- Attestation: /.test(l)).length !== 1
+      || !lines.includes(`- Attestation: ${o.attestation_id}`)
+      || !lines.includes(`- Run: https://github.com/${r.repository}/actions/runs/${o.run_id}`)) return false;
+    const state = envelope(lines[2], 'automation-state');
+    const stateText = lines[2].slice('<!-- automation-state:'.length, -4);
+    if (!exact(state, STATE_KEYS) || state.schema !== 2 || state.reviewer !== 'opencode' || state.pr !== r.pr
+      || state.run_id !== o.run_id || state.run_attempt !== o.run_attempt || state.attempt_head !== o.head_sha
+      || state.successful_head !== o.head_sha || state.attempt_status !== 'success'
+      || !['full', 'delta'].includes(state.diff_mode) || state.full_diff_sha256 !== o.full_diff_sha256
+      || sha(stateText) !== o.state_sha256) return false;
+    const a = envelope(canonicalCheck?.output?.text, 'automation-attestation');
+    if (!successfulCheck(canonicalCheck, 'automation/opencode-canonical-review', o.workflow_head)
+      || canonicalCheck.id !== o.attestation_id
+      || canonicalCheck.external_id !== `automation-opencode-canonical:${r.repository}:pr:${r.pr}:run:${o.run_id}:${o.run_attempt}:comment:${o.comment_id}`
+      || !exact(a, ATTESTATION_KEYS) || a.schema !== 1 || a.repository !== r.repository || a.pr !== r.pr
+      || a.workflow !== WORKFLOW || a.caller_event !== 'pull_request'
+      || a.attempt_head !== o.head_sha || a.successful_head !== o.head_sha
+      || !positive(a.prepared_run_attempt) || a.prepared_run_attempt !== o.run_attempt
+      || ['caller_workflow_path', 'referenced_workflow_path', 'referenced_workflow_sha', 'workflow_head',
+        'run_id', 'run_attempt', 'comment_id', 'body_sha256', 'state_sha256'].some((key) => a[key] !== o[key])) return false;
+    if (!positive(ledgerComment?.id) || ledgerComment.user?.type !== 'Bot' || ledgerComment.user.login !== 'github-actions[bot]') return false;
+    const ledgerLines = (ledgerComment.body || '').split('\n');
+    if (ledgerLines[0] !== LEDGER) return false;
+    const ledger = envelope(ledgerLines[1], 'automation-budget-state');
+    if (ledger.schema !== 1 || ledger.repository !== r.repository || ledger.pr !== r.pr || ledger.reviewer !== 'opencode'
+      || !Array.isArray(ledger.invocations) || ledger.invocations.length > 100
+      || ledgerLines[1] !== `<!-- automation-budget-state:${canonicalJson(ledger)} -->`) return false;
+    const entries = ledger.invocations.filter((e) => e.run_id === o.run_id && e.run_attempt === o.run_attempt);
+    if (entries.length !== 1) return false;
+    const entry = entries[0];
+    return exact(entry, INVOCATION_KEYS) && entry.status === 'finalized' && ['success', 'quality_filtered'].includes(entry.outcome)
+      && entry.caller_event === 'pull_request'
+      && ['head_sha', 'full_diff_sha256', 'caller_workflow_path', 'referenced_workflow_path', 'referenced_workflow_sha']
+        .every((key) => entry[key] === o[key])
+      && originalRun.referenced_workflows.some((ref) => ref.path === o.referenced_workflow_path
+        && ref.sha === o.referenced_workflow_sha
+        && entry.referenced_workflow_ref === ('ref' in ref ? ref.ref : ref.sha))
+      && sha(canonicalJson(entry)) === o.finalized_invocation_sha256;
+  } catch { return false; }
+}
+
+function boundedPage(data, key) {
+  if (!Array.isArray(data?.[key]) || !Number.isSafeInteger(data.total_count)
+    || data.total_count < 0 || data.total_count > 100 || data[key].length !== data.total_count) {
+    throw new Error(`unbounded or incomplete recovery ${key} page`);
+  }
+  return data[key];
+}
+async function authenticateRecovery({github, repository, pr, comments}) {
+  if (typeof repository !== 'string' || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)
+    || !positive(pr) || !Array.isArray(comments)) throw new Error('invalid recovery lookup scope');
+  const [owner, repo] = repository.split('/');
+  const scope = {owner, repo};
+  const {data: recent} = await github.rest.actions.listWorkflowRunsForRepo({
+    ...scope, event: 'workflow_dispatch', per_page: 100, page: 1,
+  });
+  if (!Array.isArray(recent?.workflow_runs) || recent.workflow_runs.length > 100) {
+    throw new Error('invalid recent recovery run page');
+  }
+  const runs = recent.workflow_runs.filter((run) => positive(run?.id) && positive(run.run_attempt)
+    && head(run.head_sha) && run.event === 'workflow_dispatch'
+    && Array.isArray(run.referenced_workflows)
+    && run.referenced_workflows.filter((r) => typeof r.path === 'string' && head(r.sha)
+      && r.path === RECOVERY + r.sha).length === 1).slice(0, 20);
+  const candidates = [], seen = new Set();
+  for (const run of runs) {
+    const {data} = await github.rest.checks.listForRef({...scope, ref: run.head_sha,
+      check_name: CHECK, status: 'completed', filter: 'all', per_page: 100, page: 1});
+    for (const check of boundedPage(data, 'check_runs')) {
+      if (seen.has(check.id) || !successfulCheck(check, CHECK, run.head_sha)) continue;
+      let r;
+      try { r = envelope(check.output?.text, 'automation-opencode-recovery'); } catch { continue; }
+      if (!receiptShape(r) || r.repository !== repository || r.pr !== pr) continue;
+      const d = r.recovery, o = r.original;
+      if (d.run_id !== run.id || d.run_attempt > run.run_attempt || d.workflow_head !== run.head_sha
+        || d.caller_workflow_path !== run.path || run.repository?.full_name !== repository
+        || !run.referenced_workflows.some((ref) => ref.path === d.referenced_workflow_path && ref.sha === d.referenced_workflow_sha)
+        || check.external_id !== `automation-opencode-recovery:${repository}:pr:${pr}:original:${o.run_id}:${o.run_attempt}:recovery:${d.run_id}:${d.run_attempt}`) continue;
+      const comment = comments.find((c) => c.id === o.comment_id && c.user?.type === 'Bot'
+        && typeof c.body === 'string' && sha(c.body) === o.body_sha256);
+      if (!comment) continue;
+      seen.add(check.id);
+      candidates.push({receipt: r, check, comment});
+      if (candidates.length > 40) throw new Error('recovery receipt candidate limit exceeded');
+    }
+  }
+  const records = [];
+  for (const facts of candidates) {
+    const r = facts.receipt, d = r.recovery, o = r.original;
+    const {data: driverRun} = await github.rest.actions.getWorkflowRunAttempt({
+      ...scope, run_id: d.run_id, attempt_number: d.run_attempt});
+    if (!runMatches(driverRun, d, repository, 'workflow_dispatch') || driverRun.status !== 'completed'
+      || !terminalConclusion(driverRun.conclusion)) {
+      throw new Error('unresolved exact recovery driver attempt');
+    }
+    if (driverRun.conclusion !== 'success') continue;
+    const {data: driverPage} = await github.rest.actions.listJobsForWorkflowRunAttempt({
+      ...scope, run_id: d.run_id, attempt_number: d.run_attempt, per_page: 100, page: 1});
+    const driverJobs = boundedPage(driverPage, 'jobs');
+    const matchedJobs = driverJobs.filter((j) => /(?:^|\s\/\s)opencode-recover-finalization$/.test(j?.name || ''));
+    if (matchedJobs.length !== 1 || matchedJobs[0].status !== 'completed'
+      || !terminalConclusion(matchedJobs[0].conclusion)
+      || matchedJobs[0].run_id !== d.run_id || !positive(matchedJobs[0].id)
+      || ('run_attempt' in matchedJobs[0] && matchedJobs[0].run_attempt !== d.run_attempt)) {
+      throw new Error('unresolved exact recovery driver job');
+    }
+    if (matchedJobs[0].conclusion !== 'success') continue;
+    const {data: originalRun} = await github.rest.actions.getWorkflowRunAttempt({
+      ...scope, run_id: o.run_id, attempt_number: o.run_attempt});
+    if (!runMatches(originalRun, o, repository, 'pull_request') || originalRun.status !== 'completed'
+      || !terminalConclusion(originalRun.conclusion)) {
+      throw new Error('unresolved exact recovery original attempt');
+    }
+    const {data: originalPage} = await github.rest.actions.listJobsForWorkflowRunAttempt({
+      ...scope, run_id: o.run_id, attempt_number: o.run_attempt, per_page: 100, page: 1});
+    const originalJobs = boundedPage(originalPage, 'jobs');
+    const requiredOriginalSteps = {
+      'opencode-prepare': ['Claim OpenCode review budget', 'Build sealed canonicalization handoff',
+        'Upload sealed canonicalization handoff'],
+      'opencode-review': ['Run OpenCode PR review', 'Materialize sealed OpenCode candidate',
+        'Upload untrusted OpenCode candidate'],
+      'opencode-canonicalize': ['Canonicalize OpenCode review', 'Resolve OpenCode budget outcome',
+        'Finalize OpenCode review budget'],
+    };
+    for (const [suffix, steps] of Object.entries(requiredOriginalSteps)) {
+      const matched = originalJobs.filter((j) => new RegExp(`(?:^|\\s/\\s)${suffix}$`).test(j?.name || ''));
+      if (matched.length !== 1 || !positive(matched[0].id) || matched[0].run_id !== o.run_id
+        || matched[0].status !== 'completed' || !terminalConclusion(matched[0].conclusion)
+        || !Array.isArray(matched[0].steps)
+        || ('run_attempt' in matched[0] && matched[0].run_attempt !== o.run_attempt)) {
+        throw new Error('unresolved exact recovery original job');
+      }
+      if (matched[0].steps.some((step, index) => !positive(step.number)
+        || (index > 0 && step.number <= matched[0].steps[index - 1].number))) {
+        throw new Error('unresolved exact recovery original job order');
+      }
+      let previousNumber = 0;
+      for (const name of steps) {
+        const found = matched[0].steps.filter((s) => s.name === name);
+        if (found.length !== 1 || found[0].status !== 'completed' || !terminalConclusion(found[0].conclusion)) {
+          throw new Error('unresolved exact recovery original job step');
+        }
+        if (found[0].number <= previousNumber) throw new Error('unresolved exact recovery original job order');
+        previousNumber = found[0].number;
+      }
+    }
+    const {data: checksPage} = await github.rest.checks.listForRef({...scope, ref: originalRun.head_sha,
+      check_name: 'automation/opencode-canonical-review', status: 'completed', filter: 'all', per_page: 100, page: 1});
+    const canonicalChecks = boundedPage(checksPage, 'check_runs').filter((c) => c.id === o.attestation_id);
+    const ledgers = comments.filter((c) => c.user?.type === 'Bot' && c.body?.startsWith(LEDGER + '\n'));
+    if (ledgers.length !== 1) throw new Error('unresolved or ambiguous recovery ledger');
+    if (canonicalChecks.length !== 1) throw new Error('unresolved original canonical Check');
+    Object.assign(facts, {driverRun, driverJobs, originalRun, originalJobs,
+      canonicalCheck: canonicalChecks[0], ledgerComment: ledgers[0]});
+    if (validateReceipt(facts)) records.push({comment: facts.comment,
+      state: envelope(facts.comment.body.split('\n')[2], 'automation-state'), attestationId: o.attestation_id});
+  }
+  return records.sort((a, b) => a.state.run_id - b.state.run_id || a.state.run_attempt - b.state.run_attempt);
+}
+module.exports = {validateReceipt, authenticateRecovery, canonicalJson};
+if (require.main === module) {
+  let valid = false;
+  try { valid = validateReceipt(strictJson(require('fs').readFileSync(0, 'utf8'))); } catch { /* invalid facts */ }
+  process.stdout.write(JSON.stringify({valid}));
+}

--- a/.github/actions/recover-opencode-review/replay.js
+++ b/.github/actions/recover-opencode-review/replay.js
@@ -1,0 +1,130 @@
+'use strict';
+// Read-only replay of a digest-approved original canonicalizer, stopped before its
+// first mutation. No credentials, network transport, model CLI or write API exists.
+const fs = require('node:fs');
+const crypto = require('node:crypto');
+const childProcess = require('node:child_process');
+const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+const approved = new Set(['b8804d0c387e4f7e554443a1d0edd5862d9c4b1c1435de4140c621c241a25df5',
+  '3915f9bc32985745996d2246017cff9122460d25a071ca72568ac73c75339371']);
+if (!approved.has(crypto.createHash('sha256').update(input.source).digest('hex'))) {
+  throw new Error('original_replay_unsupported');
+}
+const outputs = {};
+const target = input.target;
+const [owner, repo] = target.repository.split('/');
+const history = input.history;
+const validateArgs = (args) => {
+  if (args.owner !== owner || args.repo !== repo) throw new Error('replay_repository_mismatch');
+};
+const getAttempt = (args) => {
+  const value = history.attempts[`${args.run_id}:${args.attempt_number}`];
+  if (!value) throw new Error('replay_attempt_unavailable');
+  return value;
+};
+const rest = {
+  actions: {
+    getArtifact: async (args) => {
+      validateArgs(args);
+      const data = input.artifacts.find((item) => item.id === args.artifact_id);
+      if (!data) throw new Error('replay_artifact_unavailable');
+      return { data };
+    },
+    getWorkflowRunAttempt: async (args) => {
+      validateArgs(args);
+      return { data: getAttempt(args).run };
+    },
+    listWorkflowRunsForRepo: async (args) => {
+      validateArgs(args);
+      const runs = history.runs.filter((item) => item.event === args.event);
+      if (runs.length > 100 || args.page !== 1 || args.per_page !== 100) {
+        throw new Error('replay_runs_unbounded');
+      }
+      return { data: { total_count: runs.length, workflow_runs: runs } };
+    },
+    listJobsForWorkflowRunAttempt: async (args) => {
+      validateArgs(args);
+      const jobs = getAttempt(args).jobs;
+      if (jobs.length > 100 || args.page !== 1 || args.per_page !== 100) {
+        throw new Error('replay_jobs_unbounded');
+      }
+      return { data: { total_count: jobs.length, jobs } };
+    },
+  },
+  checks: {
+    listForRef: async (args) => {
+      validateArgs(args);
+      const checks = history.checks.filter((item) => item.head_sha === args.ref
+        && (!args.check_name || item.name === args.check_name));
+      if (checks.length > 100) throw new Error('replay_checks_unbounded');
+      return { data: { total_count: checks.length, check_runs: checks } };
+    },
+  },
+  issues: { listComments: Symbol('read-comments') },
+  pulls: {
+    get: async (args) => {
+      validateArgs(args);
+      if (args.pull_number !== target.pr) throw new Error('replay_pr_mismatch');
+      return { data: input.pr };
+    },
+  },
+};
+const github = {
+  rest,
+  paginate: async (method, args) => {
+    validateArgs(args);
+    if (method !== rest.issues.listComments || args.issue_number !== target.pr
+        || history.comments.length > 300) throw new Error('replay_comments_unavailable');
+    return history.comments;
+  },
+};
+const readonlyRequire = (name) => {
+  // This is the recovery checkout's sealed verifier, never an artifact/PR path.
+  if (name === require('node:path').join(__dirname, 'receipt.js')) return require('./receipt.js');
+  if (name === 'fs') return {
+    readFileSync: fs.readFileSync, realpathSync: fs.realpathSync,
+    readdirSync: fs.readdirSync, lstatSync: fs.lstatSync,
+  };
+  if (name === 'crypto') return crypto;
+  if (name === 'path') return require('node:path');
+  if (name === 'child_process') return {
+    spawnSync: (command, args, options) => {
+      if (command !== '/usr/bin/git' || options.cwd !== input.env.TRUSTED_WORKSPACE) {
+        throw new Error('replay_command_refused');
+      }
+      return childProcess.spawnSync(command, args, { ...options, timeout: 30000, maxBuffer: 8000000 });
+    },
+  };
+  throw new Error('replay_module_refused');
+};
+for (const key of Object.keys(process.env)) delete process.env[key];
+Object.assign(process.env, input.env, { PATH: '/usr/bin:/bin', LANG: 'C.UTF-8', LC_ALL: 'C.UTF-8' });
+const suffix = `
+const remainingFindingIds = [];
+let activeFindingSection = false;
+for (const line of displayBody.split('\\n')) {
+  if (line === '### New findings' || line === '### Still open') activeFindingSection = true;
+  else if (/^### /.test(line)) activeFindingSection = false;
+  else if (activeFindingSection) {
+    const match = line.match(/^#### (RVW-[0-9a-f]{12}) \\[(?:CRITICAL|HIGH|MEDIUM)\\] .+$/);
+    if (match && !remainingFindingIds.includes(match[1]) && remainingFindingIds.length < 8)
+      remainingFindingIds.push(match[1]);
+  }
+}
+return {body:bodyFor(recoveryCheckId), state, succeeded, quality_filtered:qualityFiltered,
+  remaining_finding_ids:remainingFindingIds};
+`;
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+if (!Number.isSafeInteger(input.check_id) || input.check_id < 1) throw new Error('replay_check_invalid');
+new AsyncFunction('require', 'github', 'context', 'core', 'recoveryCheckId', input.source + suffix)(
+  readonlyRequire, github, { repo: { owner, repo } }, {
+    notice: () => {}, warning: () => {},
+    setOutput: (key, value) => { outputs[key] = value; },
+  }, input.check_id,
+).then((result) => {
+  if (!result || outputs.budget_metrics_valid !== 'true') throw new Error('canonical_replay_refused');
+  process.stdout.write(JSON.stringify(result));
+}).catch((error) => {
+  process.stderr.write('canonical_replay_refused\n');
+  process.exitCode = 1;
+});

--- a/.github/actions/recover-opencode-review/transport.py
+++ b/.github/actions/recover-opencode-review/transport.py
@@ -1,0 +1,564 @@
+"""Serialized, bounded GitHub transport for original OpenCode finalization recovery.
+
+The caller holds the ordinary OpenCode per-PR concurrency group. A comparison
+before PATCH detects drift; GitHub issue comments do not provide atomic CAS.
+No retry of a mutation is implicit, even when its response is lost.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+from dataclasses import replace
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from urllib.parse import quote
+
+from evidence import (RecoveryError, RecoveryTarget, _budget_module, git_environment,
+                      integer, require, sha256, strict_json, validate_canonical,
+                      validate_evidence, validate_original_run, validate_pr)
+
+budget = _budget_module()
+CENTRAL = "jhw7500/automation"
+NORMAL = ".github/workflows/opencode-auto-review.yml"
+RECOVERY = ".github/workflows/opencode-recover-finalization.yml"
+CHECK = "automation/opencode-finalization-recovery"
+CANONICAL_CHECK = "automation/opencode-canonical-review"
+RECEIPT_PREFIX = "<!-- automation-opencode-recovery:"
+
+
+def positive_input(value: str) -> int:
+    require(isinstance(value, str) and re.fullmatch(r"[1-9][0-9]*", value) is not None
+            and len(value) <= 16, "recovery_input_invalid")
+    number = int(value)
+    require(integer(number), "recovery_input_invalid")
+    return number
+
+
+def canonical_json(value) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+class GitHub:
+    """One request per call, fixed host, isolated CLI config and bounded output."""
+
+    def __init__(self, token: str):
+        require(isinstance(token, str) and bool(token), "recovery_token_unavailable")
+        executable = shutil.which("gh")
+        require(executable is not None, "recovery_gh_unavailable")
+        self.executable = str(Path(executable).resolve())
+        self.token = token
+
+    def _call(self, method, path, payload=None):
+        require(method in {"GET", "PATCH", "POST"} and path.startswith("repos/")
+                and "\n" not in path and "\r" not in path, "recovery_api_path_invalid")
+        with tempfile.TemporaryDirectory(prefix="recovery-gh-") as directory:
+            env = git_environment() | {"GH_TOKEN": self.token, "GH_HOST": "github.com",
+                "GH_PROMPT_DISABLED": "1", "GH_CONFIG_DIR": directory}
+            command = [self.executable, "api", "--hostname", "github.com", "--method", method,
+                       "-H", "Accept: application/vnd.github+json",
+                       "-H", "X-GitHub-Api-Version: 2022-11-28", path]
+            if payload is not None:
+                command += ["--input", "-"]
+            try:
+                result = subprocess.run(command, input=None if payload is None else
+                    canonical_json(payload).encode(), env=env, capture_output=True,
+                    check=True, timeout=45)
+            except (OSError, subprocess.SubprocessError) as exc:
+                raise RecoveryError("recovery_api_uncertain") from exc
+            require(len(result.stdout) <= 8_000_000, "recovery_api_output_limit")
+            return result.stdout
+
+    def request(self, method, path, payload=None):
+        return strict_json(self._call(method, path, payload))
+
+    def download(self, path):
+        return self._call("GET", path)
+
+
+def get(api, path):
+    try:
+        return api.request("GET", path)
+    except (RecoveryError, OSError, TimeoutError) as exc:
+        raise RecoveryError("recovery_api_uncertain") from exc
+
+
+def page(api, path, key, *, horizon=False):
+    value = get(api, path + ("&" if "?" in path else "?") + "per_page=100&page=1")
+    require(isinstance(value, dict) and isinstance(value.get(key), list)
+            and integer(value.get("total_count"), minimum=0)
+            and len(value[key]) <= 100
+            and value["total_count"] >= len(value[key]), "recovery_api_page_invalid")
+    if not horizon:
+        require(value["total_count"] == len(value[key]), "recovery_api_page_limit")
+    require(all(isinstance(item, dict) for item in value[key]), "recovery_api_page_invalid")
+    return value[key]
+
+
+def all_items(api, path):
+    result = []
+    for number in range(1, 5):
+        value = get(api, path + f"?per_page=100&page={number}")
+        require(isinstance(value, list) and len(value) <= 100
+                and all(isinstance(item, dict) for item in value), "recovery_api_page_invalid")
+        result.extend(value)
+        require(len(result) <= 300, "recovery_api_page_limit")
+        if len(value) < 100:
+            return result
+    raise RecoveryError("recovery_api_page_limit")
+
+
+def central_reference(run, workflow, *, pinned=False):
+    references = run.get("referenced_workflows")
+    require(isinstance(references, list) and len(references) <= 100, "workflow_reference_invalid")
+    prefix = f"{CENTRAL}/{workflow}@"
+    matches = [r for r in references if isinstance(r, dict)
+               and isinstance(r.get("path"), str) and r["path"].startswith(prefix)]
+    require(len(matches) == 1, "workflow_reference_invalid")
+    ref = matches[0]
+    require(re.fullmatch(r"[0-9a-f]{40}", str(ref.get("sha"))) is not None
+            and bool(ref["path"][len(prefix):]), "workflow_reference_invalid")
+    if pinned:
+        require(ref["path"] == prefix + ref["sha"], "recovery_workflow_not_pinned")
+    return ref
+
+
+def driver_identity(target, run, run_id, attempt, central_sha):
+    require(isinstance(run, dict) and integer(run.get("id")) and run["id"] == run_id
+            and integer(run.get("run_attempt")) and run["run_attempt"] == attempt
+            and run.get("event") == "workflow_dispatch"
+            and run.get("repository", {}).get("full_name") == target.repository
+            and re.fullmatch(r"[0-9a-f]{40}", str(run.get("head_sha"))) is not None
+            and re.fullmatch(r"\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml", str(run.get("path")))
+            and ".." not in run["path"], "recovery_driver_invalid")
+    ref = central_reference(run, RECOVERY, pinned=True)
+    require(ref["sha"] == central_sha, "recovery_driver_invalid")
+    return {"run_id": run_id, "run_attempt": attempt, "workflow_head": run["head_sha"],
+        "caller_workflow_path": run["path"], "referenced_workflow_path": ref["path"],
+        "referenced_workflow_sha": ref["sha"], "provider_calls": 0}
+
+
+def comment_identity(comment):
+    require(isinstance(comment, dict) and integer(comment.get("id"))
+            and comment.get("user", {}).get("login") == "github-actions[bot]"
+            and comment["user"].get("type") == "Bot"
+            and isinstance(comment.get("body"), str), "recovery_comment_invalid")
+    return {key: comment[key] for key in ("id", "body", "user")}
+
+
+def ledger_comment(target, comments):
+    marker = budget.MARKERS["opencode"]
+    matches = [c for c in comments if isinstance(c.get("body"), str)
+               and (c["body"] == marker or c["body"].startswith(marker + "\n"))]
+    require(len(matches) == 1, "recovery_ledger_ambiguous")
+    comment = matches[0]
+    comment_identity(comment)
+    try:
+        state = budget.parse_ledger(comment["body"], repository=target.repository,
+                                    pr=target.pr, reviewer="opencode")
+        require(state is not None, "recovery_ledger_invalid")
+    except budget.BudgetStateError as exc:
+        raise RecoveryError("recovery_ledger_invalid") from exc
+    return comment, state
+
+
+def named_checks(api, repository, head, name):
+    require(re.fullmatch(r"[0-9a-f]{40}", str(head)) is not None, "recovery_check_head_invalid")
+    return page(api, f"repos/{repository}/commits/{head}/check-runs?"
+                f"check_name={quote(name, safe='')}&filter=all", "check_runs")
+
+
+def original_publication(target, run, comments, checks):
+    matches = []
+    for check in checks:
+        for comment in comments:
+            try:
+                validate_canonical(target, comment, check, run["head_sha"])
+            except (RecoveryError, KeyError, TypeError, AttributeError):
+                continue
+            matches.append((comment, check))
+    require(len(matches) == 1, "original_canonical_ambiguous")
+    return matches[0]
+
+
+def parse_receipt(check):
+    raw = check.get("output", {}).get("text")
+    require(isinstance(raw, str) and len(raw) <= 32768 and raw.startswith(RECEIPT_PREFIX)
+            and raw.endswith(" -->") and "\n" not in raw, "recovery_receipt_invalid")
+    value = strict_json(raw[len(RECEIPT_PREFIX):-4])
+    require(isinstance(value, dict), "recovery_receipt_invalid")
+    return value
+
+
+def receipt_valid(facts):
+    node = shutil.which("node")
+    require(node is not None, "recovery_node_unavailable")
+    try:
+        output = subprocess.run([str(Path(node).resolve()), str(Path(__file__).with_name("receipt.js"))],
+            input=canonical_json(facts).encode(), env=git_environment(), capture_output=True,
+            check=True, timeout=30).stdout
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RecoveryError("recovery_receipt_verifier_failed") from exc
+    require(len(output) <= 1024, "recovery_receipt_verifier_failed")
+    return strict_json(output) == {"valid": True}
+
+
+def completed_receipt(target, api, comments):
+    """Server heads seed discovery; embedded IDs are used only after intersection."""
+    repository = target.repository
+    runs = page(api, f"repos/{repository}/actions/runs?event=workflow_dispatch",
+                "workflow_runs", horizon=True)
+    matches = []
+    for run in runs:
+        try:
+            central_reference(run, RECOVERY, pinned=True)
+        except RecoveryError:
+            continue
+        matches.append(run)
+    require(len(matches) <= 20, "recovery_driver_horizon_limit")
+    checked = set()
+    for run in matches:
+        require(integer(run.get("id")) and integer(run.get("run_attempt")), "recovery_driver_invalid")
+        for check in named_checks(api, repository, run.get("head_sha"), CHECK):
+            try:
+                receipt = parse_receipt(check)
+                original = receipt["original"]
+                driver = receipt["recovery"]
+                selected = (receipt.get("repository") == repository and receipt.get("pr") == target.pr
+                    and original["run_id"] == target.run_id and original["run_attempt"] == target.run_attempt
+                    and original["head_sha"] == target.head_sha and original["base_sha"] == target.base_sha
+                    and driver["run_id"] == run["id"] and driver["workflow_head"] == run["head_sha"]
+                    and integer(driver["run_attempt"]) and driver["run_attempt"] <= run["run_attempt"])
+            except (RecoveryError, KeyError, TypeError):
+                continue
+            if not selected or check.get("id") in checked:
+                continue
+            checked.add(check.get("id"))
+            require(len(checked) <= 40, "recovery_receipt_candidate_limit")
+            driver_run = get(api, f"repos/{repository}/actions/runs/{run['id']}/attempts/{driver['run_attempt']}")
+            if driver_run.get("status") != "completed":
+                # The active driver has not published a completed recovery yet.
+                continue
+            if driver_run.get("conclusion") != "success":
+                continue
+            original_run = get(api, f"repos/{repository}/actions/runs/{target.run_id}/attempts/{target.run_attempt}")
+            original_jobs = page(api, f"repos/{repository}/actions/runs/{target.run_id}/attempts/"
+                                 f"{target.run_attempt}/jobs", "jobs")
+            checks = named_checks(api, repository, original_run.get("head_sha"), CANONICAL_CHECK)
+            comment, canonical = original_publication(target, original_run, comments, checks)
+            ledger, _ = ledger_comment(target, comments)
+            facts = {"receipt": receipt, "check": check, "driverRun": driver_run,
+                "driverJobs": page(api, f"repos/{repository}/actions/runs/{run['id']}/attempts/"
+                                   f"{driver['run_attempt']}/jobs", "jobs"),
+                "originalRun": original_run, "originalJobs": original_jobs,
+                "canonicalCheck": canonical, "comment": comment, "ledgerComment": ledger}
+            if receipt_valid(facts):
+                return check["id"]
+    return None
+
+
+def workflow_source(api, run):
+    ref = central_reference(run, NORMAL)
+    path = NORMAL
+    value = get(api, f"repos/{CENTRAL}/contents/{path}?ref={ref['sha']}")
+    require(isinstance(value, dict) and value.get("type") == "file" and value.get("path") == path
+            and value.get("encoding") == "base64" and integer(value.get("size"))
+            and value["size"] <= 2_000_000 and isinstance(value.get("content"), str),
+            "original_workflow_invalid")
+    try:
+        data = base64.b64decode("".join(value["content"].split()), validate=True)
+        require(len(data) == value["size"], "original_workflow_invalid")
+        return data.decode("utf-8")
+    except (ValueError, UnicodeError) as exc:
+        raise RecoveryError("original_workflow_invalid") from exc
+
+
+def history_evidence(target, api, comments, original_run, original_jobs, original_check):
+    repository = target.repository
+    runs = page(api, f"repos/{repository}/actions/runs?event=pull_request",
+                "workflow_runs", horizon=True)
+    selected = []
+    for run in runs:
+        try:
+            central_reference(run, NORMAL)
+        except RecoveryError:
+            continue
+        if integer(run.get("id")) and integer(run.get("run_attempt")):
+            selected.append(run)
+    selected = selected[:20]
+    checks = {original_check["id"]: original_check}
+    attempts = {f"{target.run_id}:{target.run_attempt}": {"run": original_run, "jobs": original_jobs}}
+    for run in selected:
+        for check in named_checks(api, repository, run.get("head_sha"), CANONICAL_CHECK):
+            checks[check["id"]] = check
+            raw = check.get("output", {}).get("text", "")
+            match = re.fullmatch(r"<!-- automation-attestation:(\{.*\}) -->", raw)
+            if match is None:
+                continue
+            a = strict_json(match[1])
+            if not isinstance(a, dict) or not integer(a.get("run_attempt")):
+                continue
+            if (a.get("run_id") != run["id"] or a.get("workflow_head") != run["head_sha"]
+                    or not any(c.get("id") == a.get("comment_id")
+                        and sha256(c.get("body", "").encode()) == a.get("body_sha256") for c in comments)):
+                continue
+            key = f"{run['id']}:{a['run_attempt']}"
+            if key in attempts:
+                continue
+            require(len(attempts) < 40, "recovery_attempt_limit")
+            exact = get(api, f"repos/{repository}/actions/runs/{run['id']}/attempts/{a['run_attempt']}")
+            jobs = page(api, f"repos/{repository}/actions/runs/{run['id']}/attempts/"
+                        f"{a['run_attempt']}/jobs", "jobs")
+            attempts[key] = {"run": exact, "jobs": jobs}
+    # New canonicalizers can authenticate prior recoveries. Seed these only from
+    # server-selected dispatch runs and their named Checks, with the same limits
+    # and exact-attempt API facts exposed to the tokenless verifier.
+    dispatch = page(api, f"repos/{repository}/actions/runs?event=workflow_dispatch",
+                    "workflow_runs", horizon=True)
+    selected_dispatch = []
+    for run in dispatch:
+        try:
+            central_reference(run, RECOVERY, pinned=True)
+        except RecoveryError:
+            continue
+        if integer(run.get("id")) and integer(run.get("run_attempt")):
+            selected_dispatch.append(run)
+    candidates = set()
+    for run in selected_dispatch[:20]:
+        for check in named_checks(api, repository, run.get("head_sha"), CHECK):
+            checks[check["id"]] = check
+            try:
+                receipt = parse_receipt(check)
+                driver, original = receipt["recovery"], receipt["original"]
+                selected = (receipt.get("repository") == repository and receipt.get("pr") == target.pr
+                    and driver["run_id"] == run["id"] and driver["workflow_head"] == run["head_sha"]
+                    and integer(driver["run_attempt"]) and driver["run_attempt"] <= run["run_attempt"]
+                    and integer(original["run_id"]) and integer(original["run_attempt"])
+                    and check.get("app", {}).get("id") == 15368
+                    and check.get("app", {}).get("slug") == "github-actions"
+                    and check.get("external_id") == check_payload(receipt)["external_id"]
+                    and any(c.get("id") == original["comment_id"]
+                        and sha256(c.get("body", "").encode()) == original["body_sha256"] for c in comments))
+            except (RecoveryError, KeyError, TypeError):
+                continue
+            if not selected:
+                continue
+            candidates.add(check["id"])
+            require(len(candidates) <= 40, "recovery_receipt_candidate_limit")
+            for binding in (driver, original):
+                key = f"{binding['run_id']}:{binding['run_attempt']}"
+                if key not in attempts:
+                    require(len(attempts) < 80, "recovery_attempt_limit")
+                    exact = get(api, f"repos/{repository}/actions/runs/{binding['run_id']}/attempts/{binding['run_attempt']}")
+                    jobs = page(api, f"repos/{repository}/actions/runs/{binding['run_id']}/attempts/"
+                                f"{binding['run_attempt']}/jobs", "jobs")
+                    attempts[key] = {"run": exact, "jobs": jobs}
+            original_exact = attempts[f"{original['run_id']}:{original['run_attempt']}"]["run"]
+            for canonical in named_checks(api, repository, original_exact.get("head_sha"), CANONICAL_CHECK):
+                checks[canonical["id"]] = canonical
+    return {"runs": runs + dispatch, "checks": list(checks.values()), "attempts": attempts, "comments": comments}
+
+
+def collect_evidence(target, api, workspace, pr, comments):
+    repository = target.repository
+    run = get(api, f"repos/{repository}/actions/runs/{target.run_id}/attempts/{target.run_attempt}")
+    jobs = page(api, f"repos/{repository}/actions/runs/{target.run_id}/attempts/{target.run_attempt}/jobs", "jobs")
+    validate_original_run(target, run, jobs)
+    comment, check = original_publication(target, run, comments,
+        named_checks(api, repository, run["head_sha"], CANONICAL_CHECK))
+    ledger, _ = ledger_comment(target, comments)
+    artifacts = page(api, f"repos/{repository}/actions/runs/{target.run_id}/artifacts", "artifacts")
+    collected = {}
+    for role, prefix in (("handoff", "opencode-handoff"), ("claim", "opencode-review-budget-claim"),
+                         ("candidate", "opencode-candidate")):
+        name = f"{prefix}-{target.run_id}-{target.run_attempt}"
+        matches = [a for a in artifacts if a.get("name") == name]
+        require(len(matches) == 1 and integer(matches[0].get("id")), "artifact_identity_invalid")
+        metadata = get(api, f"repos/{repository}/actions/artifacts/{matches[0]['id']}")
+        require(metadata.get("id") == matches[0]["id"] and metadata.get("name") == name
+                and metadata.get("expired") is False, "artifact_expired_or_unavailable")
+        require(integer(metadata.get("size_in_bytes")) and metadata["size_in_bytes"] <= 8_000_000,
+                "artifact_size_invalid")
+        try:
+            payload = api.download(f"repos/{repository}/actions/artifacts/{metadata['id']}/zip")
+        except (RecoveryError, OSError, TimeoutError) as exc:
+            raise RecoveryError("artifact_expired_or_unavailable") from exc
+        collected[role] = {"metadata": metadata, "payload": payload}
+    return {"pr": pr, "original_run": run, "original_jobs": jobs,
+        "artifacts": collected, "canonical_comment": comment, "original_check": check,
+        "ledger_comment": ledger, "workflow_source": workflow_source(api, run),
+        "history": history_evidence(target, api, comments, run, jobs, check)}
+
+
+def dismissals(target, api):
+    events = all_items(api, f"repos/{target.repository}/issues/{target.pr}/timeline")
+    result, permissions = [], {}
+    for event in events:
+        if event.get("event") != "commented":
+            continue
+        finding = budget.parse_dismiss_command(event.get("body"))
+        if finding is None:
+            continue
+        actor = event.get("actor", {}).get("login")
+        require(isinstance(actor, str) and 1 <= len(actor) <= 100 and integer(event.get("id")),
+                "recovery_dismissal_invalid")
+        if actor not in permissions:
+            require(len(permissions) < budget.MAX_PERMISSION_ACTORS, "recovery_permission_limit")
+            value = get(api, f"repos/{target.repository}/collaborators/{quote(actor, safe='')}/permission")
+            require(value.get("user", {}).get("login") == actor and value.get("permission") in
+                {"admin", "maintain", "write", "triage", "read", "none"}, "recovery_permission_invalid")
+            permissions[actor] = value["permission"]
+        result.append(budget.DismissEvent(event["id"], finding, permissions[actor]))
+    return tuple(result)
+
+
+def provenances(target, api, state):
+    result = {}
+    for item in state.invocations:
+        run = get(api, f"repos/{target.repository}/actions/runs/{item.run_id}/attempts/{item.run_attempt}")
+        ref = central_reference(run, NORMAL)
+        head = item.head_sha
+        if item.caller_event == "pull_request":
+            pulls = run.get("pull_requests")
+            require(isinstance(pulls, list) and len(pulls) <= 100
+                    and len([p for p in pulls if p.get("number") == target.pr
+                             and p.get("head", {}).get("sha") == head]) == 1,
+                    "recovery_provenance_invalid")
+        result[(item.run_id, item.run_attempt)] = budget.RunProvenance(
+            run.get("repository", {}).get("full_name"), target.pr, head, run.get("path"),
+            run.get("event"), ref["path"], ref.get("ref", ref["sha"]), ref["sha"],
+            run.get("id"), run.get("run_attempt"), run.get("status"), run.get("conclusion"))
+    return result
+
+
+def receipt_for(target, validated, driver, bundle, invocation):
+    attestation = validated.attestation
+    original = {key: attestation[key] for key in ("workflow_head", "caller_workflow_path",
+        "referenced_workflow_path", "referenced_workflow_sha", "comment_id", "body_sha256", "state_sha256")}
+    original.update(run_id=target.run_id, run_attempt=target.run_attempt,
+        head_sha=target.head_sha, base_sha=target.base_sha,
+        full_diff_sha256=validated.state["full_diff_sha256"], attestation_id=bundle["original_check"]["id"],
+        claim_checkpoint_sha256=validated.evidence_digests["claim_checkpoint_sha256"],
+        finalized_invocation_sha256=sha256(canonical_json(invocation.to_dict()).encode()),
+        artifacts={role: validated.evidence_digests[role] for role in ("handoff", "claim", "candidate")})
+    return {"schema": 1, "repository": target.repository, "pr": target.pr, "original": original, "recovery": driver}
+
+
+def check_payload(receipt):
+    original, driver = receipt["original"], receipt["recovery"]
+    return {"name": CHECK, "head_sha": driver["workflow_head"], "status": "completed",
+        "conclusion": "success",
+        "external_id": f"automation-opencode-recovery:{receipt['repository']}:pr:{receipt['pr']}:"
+            f"original:{original['run_id']}:{original['run_attempt']}:"
+            f"recovery:{driver['run_id']}:{driver['run_attempt']}",
+        "output": {"title": "Original OpenCode finalization recovered",
+            "summary": "Original invocation finalized with zero additional provider calls.",
+            "text": RECEIPT_PREFIX + canonical_json(receipt) + " -->"}}
+
+
+def expected_check(check, payload):
+    return (isinstance(check, dict) and integer(check.get("id"))
+        and check.get("app", {}).get("slug") == "github-actions" and check["app"].get("id") == 15368
+        and all(check.get(key) == value for key, value in payload.items() if key != "output")
+        and isinstance(check.get("output"), dict)
+        and all(check["output"].get(key) == value for key, value in payload["output"].items()))
+
+
+def recover(target, api, workspace, *, driver_run_id, driver_run_attempt, central_sha):
+    require(integer(driver_run_id) and integer(driver_run_attempt), "recovery_driver_invalid")
+    repository = target.repository
+    pr = get(api, f"repos/{repository}/pulls/{target.pr}")
+    validate_pr(target, pr)
+    driver_run = get(api, f"repos/{repository}/actions/runs/{driver_run_id}/attempts/{driver_run_attempt}")
+    driver = driver_identity(target, driver_run, driver_run_id, driver_run_attempt, central_sha)
+    comments = all_items(api, f"repos/{repository}/issues/{target.pr}/comments")
+    existing = completed_receipt(target, api, comments)
+    if existing is not None:
+        return {"decision": "already_recovered", "provider_calls": 0, "receipt_id": existing}
+    require(driver_run.get("status") == "in_progress", "recovery_driver_not_running")
+    bundle = collect_evidence(target, api, workspace, pr, comments)
+    validated = validate_evidence(target, bundle, Path(workspace))
+    ledger, state = ledger_comment(target, comments)
+    events = dismissals(target, api)
+    request = replace(validated.request, dismiss_events=events)
+    transition = budget.recover_finalize(state, validated.original_claim, request, provenances(target, api, state))
+    require(transition.decision == "finalized", "recovery_finalization_conflict")
+    expected = budget.render_comment(transition.state, server_url="https://github.com")
+
+    # Fresh comparison immediately before the only ledger mutation.
+    validate_pr(target, get(api, f"repos/{repository}/pulls/{target.pr}"))
+    fresh_comments = all_items(api, f"repos/{repository}/issues/{target.pr}/comments")
+    fresh_ledger, _ = ledger_comment(target, fresh_comments)
+    require(comment_identity(fresh_ledger) == comment_identity(ledger), "recovery_ledger_changed")
+    fresh_comment, fresh_check = original_publication(target, bundle["original_run"], fresh_comments,
+        named_checks(api, repository, bundle["original_run"]["head_sha"], CANONICAL_CHECK))
+    require(comment_identity(fresh_comment) == comment_identity(bundle["canonical_comment"])
+            and fresh_check == bundle["original_check"], "recovery_canonical_changed")
+    require(dismissals(target, api) == events, "recovery_dismissals_changed")
+    if transition.mutate_comment:
+        try:
+            api.request("PATCH", f"repos/{repository}/issues/comments/{ledger['id']}", {"body": expected})
+        except (RecoveryError, OSError, TimeoutError):
+            pass  # One readback resolves uncertainty; never repeat this PATCH.
+    else:
+        require(ledger["body"] == expected, "recovery_finalization_conflict")
+    readback = get(api, f"repos/{repository}/issues/comments/{ledger['id']}")
+    require(comment_identity(readback) == comment_identity(dict(ledger, body=expected)),
+            "recovery_ledger_readback_mismatch")
+    receipt = receipt_for(target, validated, driver, bundle, transition.state.invocations[-1])
+    payload = check_payload(receipt)
+    # A prior ambiguous receipt publication from this exact driver is never duplicated.
+    prior = named_checks(api, repository, driver["workflow_head"], CHECK)
+    same = [c for c in prior if c.get("external_id") == payload["external_id"]]
+    require(len(same) <= 1 and (not same or expected_check(same[0], payload)), "recovery_receipt_conflict")
+    if not same:
+        try:
+            api.request("POST", f"repos/{repository}/check-runs", payload)
+        except (RecoveryError, OSError, TimeoutError):
+            pass
+        prior = named_checks(api, repository, driver["workflow_head"], CHECK)
+        same = [c for c in prior if c.get("external_id") == payload["external_id"]]
+    require(len(same) == 1 and expected_check(same[0], payload), "recovery_receipt_readback_mismatch")
+    verified = get(api, f"repos/{repository}/check-runs/{same[0]['id']}")
+    require(expected_check(verified, payload), "recovery_receipt_readback_mismatch")
+    return {"decision": "finalized", "provider_calls": 0, "receipt_id": verified["id"],
+        "original_run_id": target.run_id, "original_run_attempt": target.run_attempt,
+        "original_call_count": request.call_count, "original_elapsed_seconds": request.elapsed_seconds}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", required=True)
+    parser.add_argument("--checkpoint", required=True)
+    args = parser.parse_args()
+    result = {"decision": "refused", "provider_calls": 0}
+    status = 1
+    try:
+        require(os.environ.get("GITHUB_SERVER_URL") == "https://github.com"
+                and os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch", "recovery_driver_invalid")
+        target = RecoveryTarget(os.environ.get("GITHUB_REPOSITORY"),
+            positive_input(os.environ.get("RECOVERY_PR")), positive_input(os.environ.get("ORIGINAL_RUN_ID")),
+            positive_input(os.environ.get("ORIGINAL_RUN_ATTEMPT")), os.environ.get("EXPECTED_HEAD_SHA"),
+            os.environ.get("EXPECTED_BASE_SHA"))
+        result = recover(target, GitHub(os.environ.get("GH_TOKEN")), Path(args.workspace),
+            driver_run_id=positive_input(os.environ.get("GITHUB_RUN_ID")),
+            driver_run_attempt=positive_input(os.environ.get("GITHUB_RUN_ATTEMPT")),
+            central_sha=os.environ.get("RECOVERY_CENTRAL_SHA"))
+        status = 0
+    except (RecoveryError, ValueError, KeyError, TypeError, AttributeError, OSError) as exc:
+        # Only bounded local reason codes are emitted, never API/source content.
+        reason = str(exc) if isinstance(exc, RecoveryError) else "recovery_evidence_invalid"
+        result["reason"] = reason if re.fullmatch(r"[a-z_]+", reason) else "recovery_refused"
+    finally:
+        budget.write_private(Path(args.checkpoint), canonical_json(result).encode() + b"\n")
+        print(canonical_json(result))
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -1331,6 +1331,119 @@ def finalize(
     )
 
 
+def _expected_recovered_invocation(
+        state: LedgerState, original_claim: Invocation,
+        request: FinalizeRequest) -> Invocation:
+    outcome = request.outcome
+    stop_reason = request.stop_reason
+    if request.call_count > state.budgets.max_calls_per_round:
+        outcome, stop_reason = "checkpoint_failure", "call_budget_exhausted"
+    elif request.elapsed_seconds > state.budgets.max_wall_seconds_per_round:
+        outcome, stop_reason = "wall_time_exhausted", "wall_time_exhausted"
+    # Recovery accepts only a successful authenticated publication. Findings come
+    # from that original request, never from the entry/handoff being verified.
+    remaining = _without_dismissed(state, request.remaining_finding_ids)
+    return replace(
+        original_claim,
+        status="finalized",
+        outcome=outcome,
+        stop_reason=stop_reason,
+        call_count=request.call_count,
+        elapsed_seconds=request.elapsed_seconds,
+        model_route=request.model_route,
+        effort=request.effort,
+        remaining_finding_ids=remaining,
+    )
+
+
+def recover_finalize(
+        state: LedgerState, original_claim: Invocation, request: FinalizeRequest,
+        provenances: Mapping[tuple[int, int], RunProvenance]) -> Transition:
+    """Finalize one authenticated original OpenCode claim, idempotently.
+
+    Recovery callers authenticate the evidence before reaching this pure transition.
+    This function additionally proves that the supplied original claim still selects
+    the latest live ledger generation and that live run provenance remains valid.
+    """
+
+    try:
+        _validate_finalize_request(request)
+        _validate_state_shape(state)
+        if not isinstance(original_claim, Invocation):
+            raise BudgetStateError("original_claim_invalid")
+        Invocation.from_dict(original_claim.to_dict())
+        if original_claim.status != "claimed" or original_claim.remaining_finding_ids:
+            raise BudgetStateError("original_claim_invalid")
+    except (AttributeError, BudgetStateError) as exc:
+        return _invalid_transition(state, request, str(exc))
+
+    if state.reviewer != "opencode" or request.reviewer != "opencode":
+        return _invalid_transition(state, request, "recovery_reviewer_invalid")
+    if (state.repository, state.pr, state.reviewer) != (
+            request.repository, request.pr, request.reviewer):
+        return _invalid_transition(state, request, "identity_mismatch")
+    if (request.run_id, request.run_attempt, request.head_sha, request.full_diff_sha256) != (
+            original_claim.run_id, original_claim.run_attempt,
+            original_claim.head_sha, original_claim.full_diff_sha256):
+        return _invalid_transition(state, request, "recovery_request_mismatch")
+    if (request.outcome not in {"success", "quality_filtered"}
+            or not request.authenticated_review.success
+            or request.authenticated_review.head_sha != request.head_sha
+            or request.authenticated_review.full_diff_sha256 != request.full_diff_sha256):
+        return _invalid_transition(state, request, "recovery_finalization_conflict")
+
+    matching = [
+        (index, item)
+        for index, item in enumerate(state.invocations)
+        if (item.run_id, item.run_attempt) == (
+            original_claim.run_id, original_claim.run_attempt,
+        )
+    ]
+    if len(matching) != 1:
+        return _invalid_transition(state, request, "original_claim_mismatch")
+    index, current = matching[0]
+    if index != len(state.invocations) - 1:
+        return _invalid_transition(state, request, "newer_invocation_exists")
+
+    immutable_fields = (
+        "run_id", "run_attempt", "head_sha", "full_diff_sha256",
+        "caller_workflow_path", "caller_event", "referenced_workflow_path",
+        "referenced_workflow_ref", "referenced_workflow_sha", "round_number",
+        "override_event_id", "call_unit", "estimated_input_tokens",
+    )
+    if current.status == "claimed":
+        original_matches = current == original_claim
+    else:
+        original_matches = all(
+            getattr(current, field_name) == getattr(original_claim, field_name)
+            for field_name in immutable_fields
+        )
+    if not original_matches:
+        return _invalid_transition(state, request, "original_claim_mismatch")
+
+    try:
+        _validate_stored_provenance_identity(original_claim, "opencode")
+        _validate_provenance(state, request, provenances)
+    except BudgetStateError as exc:
+        return _invalid_transition(state, request, str(exc))
+
+    if request.model_route[0] != original_claim.model_route[0]:
+        return _invalid_transition(state, request, "model_route_unknown")
+
+    if current.status == "claimed":
+        return finalize(state, request, provenances)
+
+    if choose_dismissals(state, request.dismiss_events) != state.dismissed_findings:
+        return _invalid_transition(state, request, "recovery_finalization_conflict")
+    expected = _expected_recovered_invocation(state, original_claim, request)
+    if current != expected:
+        return _invalid_transition(state, request, "recovery_finalization_conflict")
+    return Transition(
+        state, False, "finalized", current.stop_reason, current.round_number,
+        f"{current.run_id}:{current.run_attempt}", False,
+    )
+
+
 _REVIEWER_TITLES = {"claude": "Claude", "gemini": "Gemini", "opencode": "OpenCode"}
 
 

--- a/.github/workflows/opencode-recover-finalization.yml
+++ b/.github/workflows/opencode-recover-finalization.yml
@@ -1,0 +1,119 @@
+name: Recover OpenCode finalization
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        type: string
+        required: true
+      original_run_id:
+        type: string
+        required: true
+      original_run_attempt:
+        type: string
+        required: true
+      expected_head_sha:
+        type: string
+        required: true
+      expected_base_sha:
+        type: string
+        required: true
+
+concurrency:
+  group: automation-opencode-auto-review-${{ github.repository }}-${{ inputs.pr_number }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  opencode-recover-finalization:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Validate recovery driver and immutable central revision
+        id: driver
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # ratchet:actions/github-script@v7
+        env:
+          RECOVERY_PR: ${{ inputs.pr_number }}
+          ORIGINAL_RUN_ID: ${{ inputs.original_run_id }}
+          ORIGINAL_RUN_ATTEMPT: ${{ inputs.original_run_attempt }}
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+          EXPECTED_BASE_SHA: ${{ inputs.expected_base_sha }}
+        with:
+          script: |
+            const positive = (value) => typeof value === 'string'
+              && /^[1-9][0-9]*$/.test(value) && Number.isSafeInteger(Number(value));
+            if (context.eventName !== 'workflow_dispatch'
+              || process.env.GITHUB_SERVER_URL !== 'https://github.com'
+              || ![process.env.RECOVERY_PR, process.env.ORIGINAL_RUN_ID,
+                process.env.ORIGINAL_RUN_ATTEMPT, process.env.GITHUB_RUN_ID,
+                process.env.GITHUB_RUN_ATTEMPT].every(positive)
+              || ![process.env.EXPECTED_HEAD_SHA, process.env.EXPECTED_BASE_SHA]
+                .every((v) => /^[0-9a-f]{40}$/.test(v || ''))) {
+              throw new Error('recovery_input_invalid');
+            }
+            const {data: run} = await github.rest.actions.getWorkflowRunAttempt({
+              ...context.repo, run_id: Number(process.env.GITHUB_RUN_ID),
+              attempt_number: Number(process.env.GITHUB_RUN_ATTEMPT),
+            });
+            const prefix = 'jhw7500/automation/.github/workflows/opencode-recover-finalization.yml@';
+            const refs = (run.referenced_workflows || []).filter((r) => r.path?.startsWith(prefix));
+            if (run.id !== Number(process.env.GITHUB_RUN_ID)
+              || run.run_attempt !== Number(process.env.GITHUB_RUN_ATTEMPT)
+              || run.event !== 'workflow_dispatch' || run.status !== 'in_progress'
+              || run.repository?.full_name !== process.env.GITHUB_REPOSITORY
+              || !/^[0-9a-f]{40}$/.test(run.head_sha || '')
+              || !/^\.github\/workflows\/[A-Za-z0-9_.-]+\.ya?ml$/.test(run.path || '')
+              || run.path.includes('..') || refs.length !== 1
+              || !/^[0-9a-f]{40}$/.test(refs[0].sha || '')
+              || refs[0].path !== prefix + refs[0].sha) {
+              throw new Error('recovery_driver_invalid');
+            }
+            core.setOutput('central_sha', refs[0].sha);
+      - name: Checkout trusted recovery implementation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: jhw7500/automation
+          ref: ${{ steps.driver.outputs.central_sha }}
+          path: automation-recovery
+          persist-credentials: false
+      - name: Checkout exact reviewed Git objects
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ inputs.expected_head_sha }}
+          path: review-target
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Recover original finalization with zero provider calls
+        working-directory: automation-recovery
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RECOVERY_PR: ${{ inputs.pr_number }}
+          ORIGINAL_RUN_ID: ${{ inputs.original_run_id }}
+          ORIGINAL_RUN_ATTEMPT: ${{ inputs.original_run_attempt }}
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+          EXPECTED_BASE_SHA: ${{ inputs.expected_base_sha }}
+          RECOVERY_CENTRAL_SHA: ${{ steps.driver.outputs.central_sha }}
+          TARGET_WORKSPACE: ${{ github.workspace }}/review-target
+          RECOVERY_CHECKPOINT: ${{ runner.temp }}/opencode-recovery-checkpoint.json
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -e 'if (Number(process.versions.node.split(".")[0]) < 20) process.exit(1)'
+          python3 .github/actions/recover-opencode-review/transport.py \
+            --workspace "$TARGET_WORKSPACE" --checkpoint "$RECOVERY_CHECKPOINT"
+      - name: Upload recovery checkpoint
+        if: ${{ always() && steps.driver.outcome == 'success' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: opencode-recovery-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/opencode-recovery-checkpoint.json
+          if-no-files-found: ignore
+          retention-days: 7

--- a/docs/superpowers/plans/2026-09-10-opencode-finalization-recovery.md
+++ b/docs/superpowers/plans/2026-09-10-opencode-finalization-recovery.md
@@ -1,0 +1,136 @@
+# OpenCode Finalization Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Authenticate a failed original OpenCode finalizer, complete its existing invocation idempotently with zero provider calls, and make the original review reusable through a distinct completed recovery receipt.
+
+**Architecture:** Keep normal claim/finalize strict. Add a separate pure budget transition, a bounded evidence collector and serialized recovery publisher, and a distinct receipt verifier in both normal OpenCode collectors. Recompute original canonical output with the original approved canonicalizer in a read-only replay.
+
+**Tech Stack:** Python standard library, Node standard library, GitHub Actions/REST, existing pytest and workflow harnesses.
+
+**Spec:** ../specs/2026-09-10-opencode-finalization-recovery-design.md
+
+## Global Constraints
+
+- Worktree: existing task/2fb06be868a0-jhw7500-automation-179 at 6dc5934ecd6bd1c298e8b7fb869b412b0828ff7c; no new Claim or Registry operation.
+- Every shell command starts with rtk. Edit source with apply_patch.
+- No commit, push, PR, release, live recovery, override, provider execution or consumer mutation in this implementation pass.
+- Preserve original run/attempt, caller and central SHA, head/diff, round and estimated usage. No additional provider calls or rounds.
+- Same OpenCode per-PR concurrency group; cancel-in-progress false for recovery; bounded prewrite comparison, not an atomic external-writer guarantee.
+- Original artifact expiry fails closed unless a completed recovery receipt already authenticates an identical no-op.
+- Preserve normal failed-run distrust and v1.74/v1.75 release verification.
+- No new dependencies. No consumer executable code or artifact executable payloads run.
+- Tests first; meaningful behavioral and mutation checks. Existing Task start approval and approved design persist.
+
+### Task 1: Idempotent original invocation transition
+
+**Files:**
+- Modify: .github/actions/review-invocation-budget/review_invocation_budget.py
+- Test: tests/test_review_invocation_budget_recovery.py
+
+**Interfaces:**
+- Consumes existing LedgerState, Invocation, FinalizeRequest, RunProvenance and Transition.
+- Produces recover_finalize(state: LedgerState, original_claim: Invocation, request: FinalizeRequest, provenances: Mapping[tuple[int,int], RunProvenance]) -> Transition.
+- Caller is the authenticated recovery validator, never the ordinary claim/finalize CLI.
+
+- [x] Write tests against real claimed_state("opencode") fixtures: original call_count 1 / elapsed_seconds 45 are finalized on the same invocation with no appended round.
+- [x] Run the new test file and observe missing recover_finalize failure.
+- [x] Validate full original claimed entry and live state/provenance; require selected invocation to be the latest relevant entry. Use existing finalize only after checks. For already-finalized state derive the expected entry from the original claim and authenticated request; exact equality permits an unchanged Transition with decision finalized, mutate_comment false, allow_invocation false.
+- [x] Reject foreign reviewer, request run/attempt/head/diff drift, changed original immutable fields, newer generation, altered metrics/outcome on repeat and malformed state. Ordinary finalize repeat stays refused.
+- [x] Run new tests and existing budget suite. Report tests, exact edited files, and verifier implications without committing.
+
+Example required assertions:
+```python
+assert result.state.invocations[0].run_attempt == 1
+assert result.state.invocations[0].call_count == 1
+assert result.state.invocations[0].elapsed_seconds == 45
+assert len(result.state.invocations) == 1
+assert result.allow_invocation is False
+assert repeat.state == result.state
+assert repeat.mutate_comment is False
+```
+
+### Task 2: Authenticated evidence and read-only canonical replay
+
+**Files:**
+- Create: .github/actions/recover-opencode-review/evidence.py
+- Create: .github/actions/recover-opencode-review/replay.js
+- Test: tests/test_opencode_recovery_evidence.py
+- Test fixtures: tests/fixtures/opencode-recovery/
+
+**Interfaces:**
+- RecoveryTarget(repository, pr, run_id, run_attempt, head_sha, base_sha).
+- validate_evidence(target, bundle, workspace) returns validated original claim, FinalizeRequest, canonical binding and evidence digests.
+- read_artifact(metadata, payload, expected_name, run_id) returns an exact bounded filename-to-bytes mapping.
+- replay.js consumes a JSON fixture bundle on stdin and produces JSON with canonical body, state, outcome and finding IDs. All API methods are read-only evidence lookups; every unsupported call throws. No model executable is available.
+
+- [x] Write a sanitized synthetic real-git fixture plus malformed artifact/job/check cases. Check missing implementation fails.
+- [x] Reject malformed/duplicate JSON, unsafe ZIP entries/size, expired/missing artifacts and wrong API ID/name/digest/run.
+- [x] Validate exact original failed run/PR bindings, sealed handoff/claim/candidate and successful publication/outcome steps followed by failed finalize.
+- [x] Verify original attestation and canonical bytes, original scope and hermetic recomputed full diff.
+- [x] Replay the approved original workflow canonicalizer up to its first mutation boundary in a tokenless Node subprocess; match canonical body byte-for-byte. Pin accepted replay source digest; unsupported source refuses.
+- [x] Derive original metrics and findings only from successful validated original evidence, and test zero calls.
+- [x] Run focused evidence tests and existing canonicalization behavior cases.
+
+### Task 3: Recovery receipt and ordinary collector integration
+
+**Files:**
+- Create: .github/actions/recover-opencode-review/receipt.js
+- Modify: .github/workflows/opencode-auto-review.yml
+- Test: tests/test_opencode_recovery_receipts.py
+- Extend if necessary: tests/test_review_workflow_logic.py
+
+**Interfaces:**
+- Receipt schema 1 carries repository/pr; original run/attempt/head/base/full_diff and immutable provenance; canonical comment/check IDs and body/state digests; original artifact/claim digests; finalized invocation digest; recovery driver run/attempt/head/caller/central workflow SHA.
+- Named Check: automation/opencode-finalization-recovery.
+- Named reusable recovery workflow: jhw7500/automation/.github/workflows/opencode-recover-finalization.yml.
+- Named recovery job: opencode-recover-finalization.
+- Normal verifier returns trusted original canonical IDs only for exact completed successful driver run/job and matching original provenance/comment/ledger entry; generation ordering remains original run/attempt.
+
+- [x] Define exact receipt keys once and test fabricated, failed, cancelled and mismatched driver/original/comment bindings.
+- [x] Implement bounded server-first recovery run/Check discovery, exact attempts/jobs, and immutable ledger invocation digest validation.
+- [x] Integrate verification into prepare and live canonicalization, retaining the old path's checks and unresolved-evidence fail-closed behavior.
+- [x] Verify normal failed run is still rejected without a valid receipt and valid recovered review supports zero-call reuse.
+- [x] Verify later unrelated ledger handoff changes do not break a receipt; changed original invocation does.
+- [x] Run receipt and affected OpenCode behavioral suites.
+
+### Task 4: Serialized recovery transport and workflow entrypoint
+
+**Files:**
+- Create: .github/actions/recover-opencode-review/transport.py
+- Create: .github/workflows/opencode-recover-finalization.yml
+- Modify: examples/baseline-workflows/.github/workflows/opencode-auto-review.yml
+- Test: tests/test_opencode_recovery_transport.py
+
+**Interfaces:**
+- Transport CLI reads validated driver env plus PR/original run/attempt/expected HEAD/base inputs; only supported GitHub REST reads and bounded ledger/Check writes.
+- Uses validate_evidence then budget.recover_finalize.
+- Outcomes: finalized, already_recovered, or bounded refusal with zero provider calls.
+
+- [x] Write HTTP-fake tests for PATCH-before-timeout, committed-PATCH-response-loss, unchanged/conflicting/unknown readback and receipt response loss.
+- [x] Collect bounded fresh evidence and dismissal permissions; pin trusted helper checkout to the actual referenced central SHA; never execute PR source.
+- [x] Recheck live PR/canonical/ledger immediately before mutation. PATCH at most once; on uncertainty reread once. Exact already-finalized target performs no PATCH.
+- [x] Publish exact recovery receipt only after ledger readback; verify readback; completed run/job required for later trust. Verify an existing completed matching receipt before requiring expired artifacts on no-op.
+- [x] Add mutually exclusive caller dispatch route with strict recovery inputs and no model job/credentials.
+- [x] Use existing per-PR concurrency group and cancel-in-progress false. Add private checkpoint artifact and bounded failure output.
+- [x] Run transport/workflow gate tests and actionlint/Bash syntax.
+
+### Task 5: Release contract, documentation and whole-change validation
+
+**Files:**
+- Modify: scripts/workflow_release_inventory.py
+- Modify: scripts/verify_workflow_release.py
+- Modify: tests/test_verify_workflow_release.py
+- Modify relevant release inventory/bundle/catalog tests as necessary
+- Modify: docs/workflows/contracts.md
+
+**Interfaces:**
+- v1.76 enables and seals recovery artifacts/workflows/caller interface; v1.74/v1.75 immutable acceptance stays unchanged.
+- All new executable files are owned by the closed release inventory.
+
+- [x] Add v1.76 positive acceptance and mutation tests for recovery gates, helper bytes, new permissions, normal receipt trust and caller mutual exclusion.
+- [x] Update inventory/verifier without accepting recovery content as old-release content.
+- [x] Document original vs driver provenance, zero calls, idempotency, CAS limits, expiry and caller adoption.
+- [x] Run related suites, full pytest, YAML/actionlint, Bash syntax and git diff --check.
+- [x] Independent review of spec compliance and code quality; address blocking findings and rerun affected tests.
+- [x] Report review readiness with exact test evidence and remaining live-release/canary boundary. Do not commit or publish.

--- a/docs/superpowers/specs/2026-09-10-opencode-finalization-recovery-design.md
+++ b/docs/superpowers/specs/2026-09-10-opencode-finalization-recovery-design.md
@@ -1,0 +1,279 @@
+# #179 OpenCode original-attempt finalization recovery — design for review
+
+Status: implementation design approved by the user's go on 2026-09-10.
+Date: 2026-09-10. Source tree: 6dc5934ecd6bd1c298e8b7fb869b412b0828ff7c.
+Issue: https://github.com/jhw7500/automation/issues/179
+
+This is an advisory work record. Task ownership comes only from the supported lifecycle.
+The approved #169 finish and #179 start both succeeded; see the private .review/issue-179/task-switch.json in the main checkout.
+
+## Result to deliver
+
+Recover a review whose provider, candidate validation, canonical publication and outcome
+resolution succeeded, but whose budget finalization failed. Authenticate the original
+execution, finalize its existing invocation once, and publish a separately authenticated
+recovery receipt. Recovery consumes zero provider calls and zero new review rounds.
+
+The original invocation keeps its run ID, attempt, caller/central-workflow provenance,
+HEAD/diff identity, estimated input usage and round number. Actual usage comes from its
+authenticated candidate. The recovery driver has its own run/attempt and never appears
+as a provider invocation. The original failed Actions run remains failed.
+
+## Evidence and reproduced cause
+
+The archived 21-file evidence manifest passed size/SHA-256 verification. The three
+OpenCode ZIP digests also match their API metadata; the canonical comment bytes match
+the original attestation. A fresh read at 2026-09-10T07:52:45Z confirmed the original
+attempt remains failed, the PR remains open/unmerged at its original HEAD/base, and
+the artifacts are not expired.
+
+| Field | Value |
+| --- | --- |
+| Consumer | jhw7500/wlan-package PR 326 |
+| Original run / attempt | 34421303503 / 1 |
+| Original workflow SHA | eb460b7e547a85f831820f8f25d30f134b2c6254 |
+| PR HEAD | 8afe40e1194dd8c748abd7b6f6e504f7f633bde8 |
+| PR base / sealed merge base | 9abf6b5650e020ee56d1bf2e9d073893ffa9cd83 |
+| Full diff SHA-256 | 7cf2f1ba122d6c7cc00c0209f2924cfb3bf7aabef1c8c06b0dccc8551bbe8092 |
+| Budget comment | 5610734298 |
+| Canonical comment | 5610756061 |
+| Original attestation Check | 102697694955 |
+| Original provider usage | 1 call / 45 seconds |
+| Handoff artifact | 10130993045 |
+| Claim artifact | 10130993536 |
+| Candidate artifact | 10131032389 |
+
+The original job evidence reports success for canonical publication and outcome
+resolution, then failure for Finalize OpenCode review budget. Its log records an
+API GET timeout. The ledger remains claimed.
+
+Pure-function reproduction on the new #179 worktree, without API/provider calls:
+
+| Operation | Observed result |
+| --- | --- |
+| Finalize original claim as attempt 2 | state_invalid / invocation_not_claimed |
+| Whole rerun without an authenticated receipt | duplicate_head |
+| Finalize original attempt 1 with original metrics | finalized |
+| Repeat that identical finalization after the write | state_invalid / invocation_not_claimed |
+
+These are diagnosis assertions, not tests of an implemented recovery feature.
+
+Relevant current boundaries:
+- Budget helper finalize() matches the exact invocation tuple and rejects an already
+  finalized entry. Its provenance validation does not itself require run success.
+- action.yml constructs identity from the current GITHUB_RUN_ID/GITHUB_RUN_ATTEMPT.
+- OpenCode's normal receipt collectors additionally require successful original
+  run/canonicalizer-job completion; a successful Check alone cannot bypass that.
+- The existing ledger CAS is a prewrite read-and-compare followed by an ordinary
+  PATCH. It is not an atomic GitHub conditional-write primitive.
+
+## Approaches considered
+
+| Approach | Decision | Reason |
+| --- | --- | --- |
+| Separate recovery workflow and receipt | Recommended | Explicit original/driver identities; no provider credentials |
+| Relax failed-run reuse / substitute current attempt | Reject | Loses authenticated execution identity |
+| Local operator ledger-edit command | Reject | Bypasses Actions serialization and canonical receipt trust |
+
+## Proposed architecture
+
+A central reusable opencode-recover-finalization.yml runs only from an explicitly
+selected workflow_dispatch recovery path in the existing consumer caller. It receives
+PR number, original run ID/attempt, expected HEAD and expected base. Recovery inputs
+and force_review are mutually exclusive; malformed recovery inputs fail before any
+normal provider job is eligible. The recovery job has actions:read, contents:read,
+issues:write, pull-requests:read and checks:write, with no model secret or model CLI.
+
+The recovery workflow uses the existing exact per-repository/per-PR OpenCode
+concurrency group and cancel-in-progress:false. It adds no Project Control Claim,
+Registry lock, or operator lock. Participating normal review and recovery workflows
+therefore serialize. A synchronize event can still cancel a run through the existing
+normal workflow policy; every incomplete recovery remains safe to inspect and retry.
+
+Executable helpers come from the exact API-verified referenced central workflow
+commit in a separate trusted checkout. The target PR checkout and downloaded
+artifacts are data only; no PR hook, action, or script is executed. Run provenance,
+input shape, caller identity and central SHA are checked before privileged writes.
+
+Split responsibilities:
+1. Bounded API/artifact collector: fresh GitHub facts and exact downloaded bytes.
+2. Pure recovery validator/transition: evidence validation and deterministic mutation.
+3. Serialized publisher: recheck, write, readback and recovery attestation.
+4. Normal receipt collectors: authenticate the distinct recovery receipt when present.
+
+The shared budget helper gains a separate recovery transition. Its normal claim and
+finalize request identity rules remain intact. Recovery does not synthesize a claim
+or append an invocation.
+
+## Required evidence before any write
+
+- Exact original run and attempt from GitHub, completed with failure; original
+  repository, PR association, caller path/event, server workflow head and referenced
+  central workflow SHA must agree with the sealed handoff.
+- Exact bounded job/step evidence: successful prepare, model, canonical publication
+  and outcome resolution; finalization is the failed functional step. No cancelled,
+  in-progress, missing or ambiguously duplicated producer/canonicalizer job.
+- Exact original run PR bindings must include the expected PR, repository, HEAD
+  and base; missing or conflicting server bindings refuse recovery. Live open PR
+  HEAD and base must also equal those explicitly expected values. Recompute
+  the merge base and full diff under the existing hermetic diff contract; match the
+  sealed merge base, review scope and full-diff bytes/hash. The base guard is checked
+  against the server run binding; it is not falsely described as a field sealed in
+  the original handoff, which contains only the merge base.
+- Unique non-expired original artifacts, exact names/IDs/run binding and API digest.
+  ZIP bytes must match those digests. Reject duplicate entries, paths, symlinks,
+  extra files and excessive compressed/uncompressed sizes before reading payloads.
+- Exact handoff schema and file hashes, claim checkpoint, allowed original claim,
+  candidate nonce/contract validation, candidate claim-checkpoint digest, identity,
+  review digest, successful outcome and bounded original metrics.
+- Server-discovered original canonical Check and exact canonical comment bytes:
+  bot author, check app/name/external ID, comment/state digests, original attempt,
+  original central SHA, successful HEAD and full-diff hash all match.
+- Recompute the candidate-to-canonical validation using the existing canonicalization
+  contract and sealed scope/context. Neither candidate-reported success nor job
+  success alone authenticates a final review.
+- Fresh budget comment parses under the existing schema. The selected invocation
+  must match the original claim's immutable fields and be the current relevant
+  generation. Conflicting/newer work, changed canonical bytes or unresolved newer
+  provenance stops recovery. Refresh dismissal provenance using the existing rules.
+
+## Write, response loss and repeat behavior
+
+```text
+original claim + authenticated original review
+                     |
+                     v
+       validate original evidence + live state
+                     |
+                     v
+       recheck PR / canonical / ledger bytes
+                     |
+                     v
+       finalize original invocation once
+                     |
+                     v
+           read back exact result
+                     |
+                     v
+     separate recovery Check + driver completion
+                     |
+                     v
+          eligible authenticated reuse
+```
+
+For claimed state, use the original candidate metrics and original invocation tuple
+to construct the expected finalized entry. Preserve all unrelated ledger records.
+An identical already-finalized target is a successful no-op only after the same
+original evidence checks and original immutable/finalized fields match. Any other
+finalized value is a conflict.
+
+Immediately before mutation, reread PR HEAD/base, canonical comment/Check and budget
+comment identity/body. Any drift refuses without writing. Use Actions serialization
+plus this existing comparison discipline; do not claim protection against arbitrary
+uncoordinated external writers.
+
+If PATCH times out, reread once to distinguish the exact committed result from
+unchanged/conflicting/unknown state. Do not blindly issue another PATCH. A later
+explicit recovery run can validate and continue idempotently. If the ledger write
+succeeded but receipt publication failed, the next recovery performs no ledger write
+and completes the missing receipt stage after validation.
+
+The separate recovery receipt binds the original invocation and evidence digests,
+canonical comment/Check and unchanged original review identity, plus the actual
+recovery driver run/attempt/caller/central SHA. A receipt is reusable only when its
+exact recovery run and recovery job have completed successfully. Receipt publication
+response loss uses bounded server discovery and exact payload matching, with no
+duplicate ambiguous receipt accepted.
+
+Normal prepare and live canonicalization discover these receipts from bounded,
+server-authored recovery workflow runs. They verify both provenance chains. They
+continue to reject ordinary failed-run review receipts without a valid recovery
+receipt. Ordering uses the original provider generation, not the later recovery
+run ID. Later ledger handoff updates must not invalidate a receipt solely because
+the entire ledger body changed; bind the original finalized invocation instead.
+
+Checks retain the existing trust ceiling: they are not signatures against an
+unrelated workflow independently granted checks:write.
+
+## Expiration policy and this canary
+
+Initial recovery requires live, non-expired original artifacts and matching downloads.
+Archived ZIP/API responses alone are not authorization after expiry. If evidence
+has expired or disappeared, return a bounded artifact-expired/unavailable refusal,
+perform no writes, and retain the original consumed claim. There is no upload of an
+old ZIP as a substitute and no refund/override fallback.
+
+An already completed, authenticated recovery receipt can support later normal reuse
+after original artifact expiry, within the normal bounded discovery policy. That is
+a completed trust receipt, not a late attempt to create one from local archives.
+An explicit repeat with that same fully verified completed receipt returns an
+already-recovered no-op; it cannot authorize a different target or any new write.
+
+Current API expiry times:
+- Handoff: 2026-09-11 09:27:07 KST.
+- Candidate: 2026-09-11 09:28:38 KST.
+- Claim checkpoint: 2026-09-17 09:27:08 KST.
+
+The consumer default branch is master and already contains the caller path with
+workflow_dispatch. A reviewed operator branch at that same path can select the new
+immutable recovery workflow while keeping PR 326 HEAD and base untouched. GitHub
+documents selecting a branch/ref for a manual run; live deployment must still
+validate that exact caller, inputs and central pin before dispatch. Creating that
+branch, publishing the recovery release and dispatching are later concrete actions,
+not performed or implied by this diagnosis.
+
+## Implementation and verification scope
+
+- New central recovery workflow and a focused recovery helper/transport.
+- Separate recovery transition in review_invocation_budget.py and narrow action
+  integration if needed; no broad weakening of the ordinary transport.
+- Existing OpenCode caller template: explicit mutually exclusive recovery path.
+- Existing OpenCode prepare/live receipt collectors: recovery receipt support.
+- Workflow release inventory/verifier and mutation tests: seal the new contract in
+  the next release (proposed v1.76), preserve immutable v1.74/v1.75 verification.
+- docs/workflows/contracts.md: identity, retry, serialization, receipts, expiry and
+  operator entrypoint contract.
+
+Tests must exercise outcomes, with mocked API/provider transport and zero provider
+calls asserted:
+- Timeout before PATCH, after committed PATCH, and during receipt publication.
+- Identical repeat, failed-job rerun identity, concurrent queued recovery and changed
+  state between observation and write.
+- Wrong original attempt/claim, HEAD/base/diff drift and superseding generations.
+- Forged or missing jobs/attestation/comment/artifact, digest mismatch, malformed ZIP,
+  unverified success, expired artifacts and unavailable API.
+- Recovery driver failure/cancellation cannot authorize reuse; successful recovery
+  permits reuse without relabeling provider provenance or spending a round.
+- Receipt ordering/discovery limits and old successful/failed-run trust behavior.
+- Caller mode separation and zero model credentials/jobs in recovery mode.
+- Release acceptance plus security mutation tests; YAML/actionlint and Bash checks.
+- Relevant existing budget/action/OpenCode suites; full repository suite before
+  reporting the implementation ready for review.
+
+## Current stop boundary
+
+The user authorized Task transition and #179 work; that transition is complete.
+The implementation design adds a new authenticated workflow/receipt interface and
+received design approval in the following user go; implementation may proceed.
+No code, commit, PR, provider call, canary rerun, budget mutation or rollout has been
+performed in this diagnosis. Keep the active #179 Claim; do not recreate it.
+
+After this design is approved: turn it into the required implementation plan and
+implement/test in the existing #179 worktree. Do not ask again to start the Task.
+
+## Sources
+
+Local code: .github/actions/review-invocation-budget/{action.yml,review_invocation_budget.py},
+.github/workflows/opencode-auto-review.yml, tests/test_review_invocation_budget.py,
+examples/baseline-workflows/.github/workflows/opencode-auto-review.yml,
+docs/workflows/contracts.md and scripts/verify_workflow_release.py.
+
+GitHub concurrency:
+https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
+
+GitHub manual branch/ref dispatch:
+https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow
+
+GitHub exact attempt and artifact APIs:
+https://docs.github.com/en/rest/actions/workflow-runs
+https://docs.github.com/en/rest/actions/artifacts

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -42,6 +42,68 @@ The renderer may update only these two scalars in an existing
 An explicitly approved bootstrap creates the canonical disabled config. Never hand-edit a
 caller to use a moving tag or branch.
 
+## OpenCode original-attempt finalization recovery (v1.76)
+
+The separate `opencode-recover-finalization.yml` reusable workflow repairs only an
+authenticated original OpenCode attempt whose provider execution, candidate validation,
+canonical publication and outcome resolution succeeded, but budget finalization failed.
+It finalizes the existing invocation and adds zero provider calls and zero review rounds.
+Normal claim/finalize rules remain strict; an ordinary failed Actions run remains untrusted.
+
+| Identity | Preserved or recorded fields |
+| --- | --- |
+| Original provider invocation | Run ID/attempt, caller and central SHA, HEAD/full diff, round, estimated input usage, original actual calls and elapsed time |
+| Recovery driver | Its own run ID/attempt, caller/head and immutable central SHA; never a provider invocation |
+| Recovery receipt | Original invocation digest, canonical comment/Check and evidence digests, plus both provenance chains |
+
+```text
+original failed finalizer -> authenticate original evidence -> finalize original entry
+                                                          -> verify ledger readback
+                                                          -> recovery Check + successful driver job
+                                                          -> authenticated zero-call reuse
+```
+
+Both normal OpenCode collectors discover the distinct
+`automation/opencode-finalization-recovery` Check from bounded server run evidence.
+They require the exact recovery run and `opencode-recover-finalization` job to finish
+successfully and validate the original canonical bytes and finalized invocation.
+Generation ordering uses the original provider run/attempt. Later unrelated ledger
+handoff changes do not invalidate the original invocation digest. Checks have the
+existing trust ceiling: they are not signatures against unrelated workflows with
+`checks:write` authority.
+
+Recovery shares the normal `automation-opencode-auto-review-<repository>-<PR>`
+concurrency group with `cancel-in-progress: false`. The transport rereads PR HEAD/base,
+canonical comment/Check and ledger immediately before writing. This is a bounded
+prewrite comparison under Actions serialization, not atomic compare-and-swap protection
+against arbitrary external writers. It sends at most one ledger PATCH; a lost response
+permits one readback, never a blind second PATCH. Exact already-finalized state is a
+no-op; a later authenticated retry can finish missing receipt publication.
+
+Initial recovery requires the live, unexpired original handoff, claim checkpoint and
+candidate artifacts, with exact API identity/digests and bounded safe ZIP contents.
+Expired or unavailable evidence refuses without writes or a budget refund. Local
+archives cannot substitute for live artifacts. A completed, fully authenticated recovery
+receipt may support later reuse or an identical already-recovered no-op after expiry;
+it cannot authorize a new target or write.
+
+Adopting the caller is a separate immutable release adoption. Its ordinary and recovery
+`uses:` targets must carry the same verified 40-character automation commit. Manual
+recovery supplies `pr_number`, `recovery_original_run_id`,
+`recovery_original_run_attempt`, `recovery_expected_head_sha` and
+`recovery_expected_base_sha`; `recover_finalization` selects the recovery route.
+Any recovery input routes away from normal review, malformed inputs fail before writes,
+and `force_review` combined with any recovery input is rejected. The recovery job passes
+no model secrets and executes trusted helpers from the API-verified central SHA; the
+target checkout and downloaded artifacts are data only.
+
+The recovery job grants exactly `actions:read`, `contents:read`, `issues:write`,
+`pull-requests:read` and `checks:write`, with no workflow-level permission grant.
+Release v1.76 owns and seals all four recovery helpers, the recovery workflow and caller,
+the updated normal receipt collectors and budget helper. Immutable v1.74/v1.75
+acceptance remains unchanged. This implementation pass performs no release publication,
+consumer adoption, live recovery or provider execution; those remain separate actions.
+
 ## Same-name credential mappings
 
 Model credential names are fixed by authentication family, and every mapping uses the

--- a/examples/baseline-workflows/.github/workflows/opencode-auto-review.yml
+++ b/examples/baseline-workflows/.github/workflows/opencode-auto-review.yml
@@ -14,8 +14,59 @@ on:
         type: boolean
         required: false
         default: false
+      recover_finalization:
+        description: Finalize a successful original review with zero additional provider calls
+        type: boolean
+        required: false
+        default: false
+      recovery_original_run_id:
+        description: Original failed Actions run ID
+        type: string
+        required: false
+      recovery_original_run_attempt:
+        description: Exact original Actions attempt
+        type: string
+        required: false
+      recovery_expected_head_sha:
+        description: Exact reviewed PR HEAD (40 lowercase hex)
+        type: string
+        required: false
+      recovery_expected_base_sha:
+        description: Exact original PR base (40 lowercase hex)
+        type: string
+        required: false
 
 jobs:
+  reject-conflicting-dispatch:
+    if: >-
+      github.event_name == 'workflow_dispatch' && inputs.force_review &&
+      (inputs.recover_finalization || inputs.recovery_original_run_id ||
+      inputs.recovery_original_run_attempt || inputs.recovery_expected_head_sha ||
+      inputs.recovery_expected_base_sha)
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Reject conflicting recovery and force-review inputs
+        run: exit 1
+  opencode-recovery:
+    if: >-
+      github.event_name == 'workflow_dispatch' && !inputs.force_review &&
+      (inputs.recover_finalization || inputs.recovery_original_run_id ||
+      inputs.recovery_original_run_attempt || inputs.recovery_expected_head_sha ||
+      inputs.recovery_expected_base_sha)
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      issues: write
+      pull-requests: read
+    uses: jhw7500/automation/.github/workflows/opencode-recover-finalization.yml@__AUTOMATION_COMMIT__
+    with:
+      pr_number: ${{ format('{0}', inputs.pr_number) }}
+      original_run_id: ${{ inputs.recovery_original_run_id }}
+      original_run_attempt: ${{ inputs.recovery_original_run_attempt }}
+      expected_head_sha: ${{ inputs.recovery_expected_head_sha }}
+      expected_base_sha: ${{ inputs.recovery_expected_base_sha }}
   opencode-review:
     if: >-
       (github.event_name == 'pull_request' &&
@@ -23,7 +74,10 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false &&
       (github.event.action != 'labeled' || github.event.label.name == 'review:request')) ||
-      (github.event_name == 'workflow_dispatch' && inputs.force_review)
+      (github.event_name == 'workflow_dispatch' && inputs.force_review &&
+      !inputs.recover_finalization && !inputs.recovery_original_run_id &&
+      !inputs.recovery_original_run_attempt && !inputs.recovery_expected_head_sha &&
+      !inputs.recovery_expected_base_sha)
     permissions:
       actions: read
       checks: write

--- a/scripts/prepare_workflow_rollout.py
+++ b/scripts/prepare_workflow_rollout.py
@@ -179,8 +179,12 @@ def render_caller(
         text = template.decode("utf-8")
     except UnicodeDecodeError as exc:
         raise RolloutError(f"{entry.path}: canonical caller is not UTF-8") from exc
-    if text.count("@__AUTOMATION_COMMIT__") != 1:
-        raise RolloutError(f"{entry.path}: expected one commit placeholder")
+    expected_targets = _caller_targets(entry)
+    uses = tuple(CENTRAL_USE.finditer(text))
+    if (text.count("@__AUTOMATION_COMMIT__") != len(expected_targets)
+        or tuple(match.group("name") for match in uses) != expected_targets
+        or any(match.group("ref") != "__AUTOMATION_COMMIT__" for match in uses)):
+        raise RolloutError(f"{entry.path}: unexpected central target or commit placeholder")
     text = text.replace("@__AUTOMATION_COMMIT__", f"@{release_commit}")
     if entry.auth_family == "gemini" and profile.repo_write_auth == "github_token":
         text = replace_once(
@@ -411,6 +415,14 @@ def _canonical_bytes(canonical: Path, entry: CatalogEntry) -> bytes:
         raise RolloutError(f"{entry.path}: cannot read canonical file: {exc}") from exc
 
 
+def _caller_targets(entry: CatalogEntry) -> tuple[str | None, ...]:
+    if (entry.path.as_posix() == ".github/workflows/opencode-auto-review.yml"
+        and entry.central_workflow == "opencode-auto-review.yml"
+        and tuple(job.name for job in entry.caller_jobs) == ("opencode-recovery", "opencode-review")):
+        return ("opencode-recover-finalization.yml", "opencode-auto-review.yml")
+    return (entry.central_workflow,)
+
+
 def _validate_caller(
     rendered: bytes, entry: CatalogEntry, profile: RepoProfile
 ) -> None:
@@ -430,8 +442,9 @@ def _validate_caller(
         raise RolloutError(f"{entry.path}: rendered caller jobs violate the catalog")
     uses = tuple(CENTRAL_USE.finditer(rendered.decode("utf-8")))
     if (
-        len(uses) != 1
-        or uses[0].group("name") != entry.central_workflow
+        tuple(match.group("name") for match in uses) != _caller_targets(entry)
+        or len({match.group("ref") for match in uses}) != 1
+        or any(SHA40.fullmatch(match.group("ref")) is None for match in uses)
     ):
         raise RolloutError(f"{entry.path}: rendered central target violates the catalog")
 

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -60,6 +60,7 @@ from scripts.workflow_release_inventory import (
     release_supports_opencode_active_section_order,
     release_supports_expanded_review_budget,
     release_supports_claude_workflow_validation,
+    release_supports_opencode_recovery,
     release_retires_manual_pr_review,
     release_supports_same_head_cancel_guard,
     release_supports_review_policy,
@@ -839,6 +840,48 @@ EXPECTED_CLAUDE_VALIDATION_WORKFLOW_SHA256 = {
     **EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256,
     "claude": "63c672654918c95de9636062f68d33d43845d64c4a674ff54c03bf90ec3d48ce",
 }
+# v1.76 adds a separate zero-provider recovery path. These literal seals are
+# reviewed release inputs, never learned from the candidate tree at runtime.
+EXPECTED_OPENCODE_RECOVERY_WORKFLOW_SHA256 = {
+    **EXPECTED_CLAUDE_VALIDATION_WORKFLOW_SHA256,
+    "opencode": "9cc171e9c11de4c6719d73922fed0373c5db0281feae7488c55c7447025bf0ab",
+}
+EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V176 = "3e8decf2bf21d007d40c0dc011b173ed0af6b2e15ae8827ae51f6986e90b813f"
+EXPECTED_OPENCODE_RECOVERY_SHA256 = {
+    ".github/actions/recover-opencode-review/evidence.py": "3b43f256e77c89fbd123cc155dc8931cf02701d2a642bf280cbc795253ea81b8",
+    ".github/actions/recover-opencode-review/replay.js": "1756d715e529dbe66dbea0674b2ca157a80fee5069309ec902eec7de19556a3b",
+    ".github/actions/recover-opencode-review/receipt.js": "65566b1625775a6b9917207c6ddfd10fb4e60f72e7dce7bdf3405a3c4cc2eb35",
+    ".github/actions/recover-opencode-review/transport.py": "045c8b49c6ffe78eeabe878586d0206468dd904c12e0783ae1365dad81c5b676",
+    ".github/workflows/opencode-recover-finalization.yml": "fe20cac47531cb43d7b924686be0154b5c5aa988462c509800a9966c9dd64270",
+    "examples/baseline-workflows/.github/workflows/opencode-auto-review.yml": "8b0751992dacd8d70cb300f66983ecd08ae9e3af9c7bf92a9130a1c7ce661761",
+}
+RECOVERY_WORKFLOW = "opencode-recover-finalization.yml"
+RECOVERY_CALLER = "examples/baseline-workflows/.github/workflows/opencode-auto-review.yml"
+RECOVERY_PERMISSIONS = {
+    "actions": "read", "checks": "write", "contents": "read",
+    "issues": "write", "pull-requests": "read",
+}
+RECOVERY_INPUTS = (
+    "pr_number", "original_run_id", "original_run_attempt",
+    "expected_head_sha", "expected_base_sha",
+)
+RECOVERY_DISPATCH_INPUTS = {
+    "recover_finalization": {
+        "description": "Finalize a successful original review with zero additional provider calls",
+        "type": "boolean", "required": "false", "default": "false",
+    },
+    **{
+        key: {"description": description, "type": "string", "required": "false"}
+        for key, description in (
+            ("recovery_original_run_id", "Original failed Actions run ID"),
+            ("recovery_original_run_attempt", "Exact original Actions attempt"),
+            ("recovery_expected_head_sha", "Exact reviewed PR HEAD (40 lowercase hex)"),
+            ("recovery_expected_base_sha", "Exact original PR base (40 lowercase hex)"),
+        )
+    },
+}
+RECOVERY_NORMAL_GUARD = " && ".join("!inputs." + key for key in RECOVERY_DISPATCH_INPUTS)
+RECOVERY_REQUEST_GUARD = "(" + " || ".join("inputs." + key for key in RECOVERY_DISPATCH_INPUTS) + ")"
 EXPECTED_CLAUDE_CALLER_VALIDATION_SHA256 = (
     "c723636ffdf202b3888c7903704353edb6367630a46b50e77412389b43d566db"
 )
@@ -2546,6 +2589,7 @@ def verify_opencode_runtime(
         EXPECTED_OPENCODE_DISMISSAL_WORKFLOW_SHA256["opencode"],
         EXPECTED_OPENCODE_CONTEXT_BUDGET_WORKFLOW_SHA256["opencode"],
         EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256["opencode"],
+        EXPECTED_OPENCODE_RECOVERY_WORKFLOW_SHA256["opencode"],
     }
     initial_validation_argument = " initial" if current_diagnostics_contract else ""
     repair_validation_argument = " repair" if current_diagnostics_contract else ""
@@ -2585,6 +2629,7 @@ def verify_opencode_runtime(
             EXPECTED_OPENCODE_DISMISSAL_WORKFLOW_SHA256["opencode"],
             EXPECTED_OPENCODE_CONTEXT_BUDGET_WORKFLOW_SHA256["opencode"],
             EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256["opencode"],
+            EXPECTED_OPENCODE_RECOVERY_WORKFLOW_SHA256["opencode"],
         }
         and run_step.get("shell") == "bash"
         and run_env.get("CANDIDATE_NONCE")
@@ -3520,7 +3565,10 @@ def _verify_tag_catalog(
                 r"([^\s'\"]+)",
                 text,
             )
-            if uses != [(entry.central_workflow, "__AUTOMATION_COMMIT__")]:
+            expected_uses = [(entry.central_workflow, "__AUTOMATION_COMMIT__")]
+            if release_supports_opencode_recovery(ref) and name == RECOVERY_CALLER:
+                expected_uses.insert(0, (RECOVERY_WORKFLOW, "__AUTOMATION_COMMIT__"))
+            if uses != expected_uses:
                 raise ReleaseVerificationError(
                     f"{name} central target or release placeholder violates the catalog"
                 )
@@ -6154,7 +6202,9 @@ def _verify_review_invocation_budget(
         ),
         REVIEW_INVOCATION_BUDGET_HELPER_ROOT.path.as_posix(): (
             helper_payload,
-            EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V174
+            EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V176
+            if release_supports_opencode_recovery(ref)
+            else EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V174
             if release_supports_expanded_review_budget(ref)
             else EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V171
             if release_supports_opencode_dismissals(ref)
@@ -6168,7 +6218,9 @@ def _verify_review_invocation_budget(
         ),
     }
     workflow_digests = (
-        EXPECTED_CLAUDE_VALIDATION_WORKFLOW_SHA256
+        EXPECTED_OPENCODE_RECOVERY_WORKFLOW_SHA256
+        if release_supports_opencode_recovery(ref)
+        else EXPECTED_CLAUDE_VALIDATION_WORKFLOW_SHA256
         if release_supports_claude_workflow_validation(ref)
         else EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256
         if release_supports_opencode_active_section_order(ref)
@@ -6424,10 +6476,15 @@ def _verify_review_policy_callers(tree: VerifiedCommitTree, ref: str) -> None:
                 tree.read_file(path),
                 reject_duplicate_keys=True,
             )
-            if not isinstance(document, dict) or document.get("on") != trigger:
+            expected_trigger = deepcopy(trigger)
+            expected_if = caller_if
+            if release_supports_opencode_recovery(ref) and workflow == "opencode-auto-review.yml":
+                expected_trigger["workflow_dispatch"]["inputs"].update(RECOVERY_DISPATCH_INPUTS)
+                expected_if = caller_if[:-1] + " && " + RECOVERY_NORMAL_GUARD + ")"
+            if not isinstance(document, dict) or document.get("on") != expected_trigger:
                 raise ValueError("caller trigger differs")
             job = document["jobs"][job_name]
-            if _normalize_expression(job.get("if")) != caller_if:
+            if _normalize_expression(job.get("if")) != expected_if:
                 raise ValueError("caller draft/manual guard differs")
             values = job["with"]
             if (
@@ -7332,6 +7389,96 @@ def _verify_gemini_workflow(name: str, document: dict, ref: str) -> None:
         raise ReleaseVerificationError(f"{name} has no setup-gemini-auth resolver")
 
 
+def _verify_opencode_recovery(tree: VerifiedCommitTree, ref: str) -> None:
+    """Authenticate the separate recovery execution surface and admission gates."""
+    path = ".github/workflows/" + RECOVERY_WORKFLOW
+    if not release_supports_opencode_recovery(ref):
+        if any(blob.path.as_posix() == path for blob in tree.files(".github/workflows")):
+            raise ReleaseVerificationError("OpenCode recovery requires v1.76")
+        return
+    helper_paths = {
+        blob.path.as_posix() for blob in tree.files(".github/actions/recover-opencode-review")
+    }
+    if helper_paths != {
+        ".github/actions/recover-opencode-review/" + name
+        for name in ("evidence.py", "replay.js", "receipt.js", "transport.py")
+    }:
+        raise ReleaseVerificationError("OpenCode recovery inventory is not closed")
+    try:
+        document = _load_release_yaml(tree.read_file(path), reject_duplicate_keys=True)
+        job = document["jobs"]["opencode-recover-finalization"]
+        steps = job["steps"]
+        driver, trusted, target, recover, checkpoint = steps
+        caller = _load_release_yaml(tree.read_file(RECOVERY_CALLER), reject_duplicate_keys=True)
+        recovery_job = caller["jobs"]["opencode-recovery"]
+        reject = caller["jobs"]["reject-conflicting-dispatch"]
+        if (
+            document.get("on") != {"workflow_call": {"inputs": {
+                name: {"type": "string", "required": "true"} for name in RECOVERY_INPUTS
+            }}}
+            or document.get("permissions") != {}
+            or document.get("concurrency") != {
+                "group": "automation-opencode-auto-review-${{ github.repository }}-${{ inputs.pr_number }}",
+                "cancel-in-progress": "false",
+            }
+            or set(document["jobs"]) != {"opencode-recover-finalization"}
+            or job.get("permissions") != RECOVERY_PERMISSIONS
+            or job.get("runs-on") != "ubuntu-latest" or job.get("timeout-minutes") != "20"
+            or set(job) != {"runs-on", "timeout-minutes", "permissions", "steps"}
+            or trusted.get("uses") != CHECKOUT_ACTION
+            or trusted.get("with") != {
+                "repository": "jhw7500/automation", "ref": "${{ steps.driver.outputs.central_sha }}",
+                "path": "automation-recovery", "persist-credentials": "false",
+            }
+            or target.get("uses") != CHECKOUT_ACTION
+            or target.get("with") != {
+                "repository": "${{ github.repository }}", "ref": "${{ inputs.expected_head_sha }}",
+                "path": "review-target", "fetch-depth": "0", "persist-credentials": "false",
+            }
+            or driver.get("id") != "driver"
+            or driver.get("uses") != "actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea"
+            or any(key in driver for key in ("if", "continue-on-error"))
+            or recover.get("working-directory") != "automation-recovery"
+            or recover.get("shell") != "bash"
+            or checkpoint.get("uses") != UPLOAD_ARTIFACT_ACTION
+            or checkpoint.get("with", {}).get("retention-days") != "7"
+            or recovery_job.get("permissions") != RECOVERY_PERMISSIONS
+            or set(recovery_job) != {"if", "permissions", "uses", "with"}
+            or recovery_job.get("uses") != "jhw7500/automation/.github/workflows/" + RECOVERY_WORKFLOW + "@__AUTOMATION_COMMIT__"
+            or recovery_job.get("with") != {
+                "pr_number": "${{ format('{0}', inputs.pr_number) }}",
+                **{name: "${{ inputs.recovery_" + name + " }}" for name in RECOVERY_INPUTS[1:]},
+            }
+            or _normalize_expression(recovery_job.get("if")) != (
+                "github.event_name == 'workflow_dispatch' && !inputs.force_review && " + RECOVERY_REQUEST_GUARD
+            )
+            or _normalize_expression(reject.get("if")) != (
+                "github.event_name == 'workflow_dispatch' && inputs.force_review && " + RECOVERY_REQUEST_GUARD
+            )
+            or reject.get("permissions") != {}
+            or reject.get("steps") != [{"name": "Reject conflicting recovery and force-review inputs", "run": "exit 1"}]
+            or set(caller["jobs"]) != {"reject-conflicting-dispatch", "opencode-recovery", "opencode-review"}
+        ):
+            raise ValueError("recovery execution or caller gate differs")
+        script = driver["with"]["script"]
+        for guard in (
+            "context.eventName !== 'workflow_dispatch'", "Number.isSafeInteger(Number(value))",
+            "/^[1-9][0-9]*$/", "/^[0-9a-f]{40}$/", "getWorkflowRunAttempt",
+            "run.run_attempt !== Number(process.env.GITHUB_RUN_ATTEMPT)",
+            "run.repository?.full_name !== process.env.GITHUB_REPOSITORY",
+            "refs.length !== 1", "refs[0].path !== prefix + refs[0].sha",
+        ):
+            if guard not in script:
+                raise ValueError("recovery input/provenance guard differs")
+        if any(secret in tree.read_text(path) for secret in ("ZHIPU_API_KEY", "secrets:", "opencode run", "pip install", "npm install")):
+            raise ValueError("provider execution is forbidden in recovery")
+        for relative, expected in EXPECTED_OPENCODE_RECOVERY_SHA256.items():
+            if hashlib.sha256(tree.read_file(relative)).hexdigest() != expected:
+                raise ReleaseVerificationError("OpenCode recovery authenticated source digest differs: " + relative)
+    except (AttributeError, KeyError, TypeError, ValueError, yaml.YAMLError):
+        raise ReleaseVerificationError("OpenCode recovery execution/caller contract is invalid") from None
+
+
 def _verify_commit_content(
     repo: Path, ref: str, revision: str
 ) -> VerifiedCommitTree:
@@ -7339,6 +7486,7 @@ def _verify_commit_content(
     if _release_version(ref) >= (1, 40):
         _release_inventory(tree, ref)
         _verify_setup_gemini_auth(tree, ref)
+    _verify_opencode_recovery(tree, ref)
     if release_supports_prepare_review_diff(ref):
         _verify_prepare_review_diff_action(tree, ref)
     if release_supports_canonicalize_review(ref):
@@ -7439,6 +7587,9 @@ def _verify_commit_content(
                 or not set(job.secrets) <= set(declared_secrets)
                 or not required_secrets <= set(job.secrets)
                 for job in entry.caller_jobs
+                if not (release_supports_opencode_recovery(ref)
+                        and entry.path.as_posix() == ".github/workflows/opencode-auto-review.yml"
+                        and job.name == "opencode-recovery")
             ):
                 raise ReleaseVerificationError(
                     f"{entry.path} is incompatible with {entry.central_workflow}"
@@ -7858,8 +8009,8 @@ def _verify_commit_content(
         self_job = self_document.get("jobs", {}).get("opencode-review", {})
         if (
             opencode_entry is None
-            or len(opencode_entry.caller_jobs) != 1
-            or dict(opencode_entry.caller_jobs[0].permissions) != expected_caller_permissions
+            or len(opencode_entry.caller_jobs) != (2 if release_supports_opencode_recovery(ref) else 1)
+            or dict(opencode_entry.caller_jobs[-1].permissions) != expected_caller_permissions
             or self_job.get("permissions") != expected_caller_permissions
             or self_job.get("uses") != "./.github/workflows/opencode-auto-review.yml"
         ):

--- a/scripts/workflow-catalog.json
+++ b/scripts/workflow-catalog.json
@@ -548,11 +548,55 @@
               "type": "boolean",
               "required": "false",
               "default": "false"
+            },
+            "recover_finalization": {
+              "description": "Finalize a successful original review with zero additional provider calls",
+              "type": "boolean",
+              "required": "false",
+              "default": "false"
+            },
+            "recovery_original_run_id": {
+              "description": "Original failed Actions run ID",
+              "type": "string",
+              "required": "false"
+            },
+            "recovery_original_run_attempt": {
+              "description": "Exact original Actions attempt",
+              "type": "string",
+              "required": "false"
+            },
+            "recovery_expected_head_sha": {
+              "description": "Exact reviewed PR HEAD (40 lowercase hex)",
+              "type": "string",
+              "required": "false"
+            },
+            "recovery_expected_base_sha": {
+              "description": "Exact original PR base (40 lowercase hex)",
+              "type": "string",
+              "required": "false"
             }
           }
         }
       },
       "caller_jobs": [
+        {
+          "name": "opencode-recovery",
+          "permissions": {
+            "actions": "read",
+            "checks": "write",
+            "contents": "read",
+            "issues": "write",
+            "pull-requests": "read"
+          },
+          "with": [
+            "expected_base_sha",
+            "expected_head_sha",
+            "original_run_attempt",
+            "original_run_id",
+            "pr_number"
+          ],
+          "secrets": []
+        },
         {
           "name": "opencode-review",
           "permissions": {

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -129,12 +129,17 @@ REVIEW_POLICY_ROOTS = (
     REVIEW_POLICY_ACTION_ROOT,
     REVIEW_POLICY_HELPER_ROOT,
 )
+OPENCODE_RECOVERY_ROOTS = tuple(
+    ReleaseRoot(PurePosixPath(f".github/actions/recover-opencode-review/{name}"), "file", "100644")
+    for name in ("evidence.py", "replay.js", "receipt.js", "transport.py")
+)
 RELEASE_ROOTS = (
     HISTORICAL_RELEASE_ROOTS
     + PREPARE_REVIEW_DIFF_ROOTS
     + CANONICALIZE_REVIEW_ROOTS
     + REVIEW_INVOCATION_BUDGET_ROOTS
     + REVIEW_POLICY_ROOTS
+    + OPENCODE_RECOVERY_ROOTS
 )
 RELEASE_PATHS = tuple(root.path.as_posix() for root in RELEASE_ROOTS)
 EXACT_RELEASE_ROOTS = tuple(root for root in RELEASE_ROOTS if root.kind == "file")
@@ -163,6 +168,7 @@ OPENCODE_CONTEXT_BUDGET_RELEASE = (1, 72)
 OPENCODE_ACTIVE_SECTION_ORDER_RELEASE = (1, 73)
 EXPANDED_REVIEW_BUDGET_RELEASE = (1, 74)
 CLAUDE_WORKFLOW_VALIDATION_RELEASE = (1, 75)
+OPENCODE_RECOVERY_RELEASE = (1, 76)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -285,6 +291,11 @@ def release_supports_claude_workflow_validation(ref: str) -> bool:
     return _release_version(ref) >= CLAUDE_WORKFLOW_VALIDATION_RELEASE
 
 
+def release_supports_opencode_recovery(ref: str) -> bool:
+    """Return whether the release owns original-attempt finalization recovery."""
+    return _release_version(ref) >= OPENCODE_RECOVERY_RELEASE
+
+
 def release_retires_manual_pr_review(ref: str) -> bool:
     """Return whether ``ref`` has withdrawn the workflow_dispatch pull-request review."""
 
@@ -302,6 +313,8 @@ def release_roots_for(ref: str) -> tuple[ReleaseRoot, ...]:
         roots += REVIEW_INVOCATION_BUDGET_ROOTS
     if release_supports_review_policy(ref):
         roots += REVIEW_POLICY_ROOTS
+    if release_supports_opencode_recovery(ref):
+        roots += OPENCODE_RECOVERY_ROOTS
     return roots
 
 

--- a/tests/fixtures/opencode-recovery/original-workflow.yml
+++ b/tests/fixtures/opencode-recovery/original-workflow.yml
@@ -109,47 +109,12 @@ jobs:
           # job is isolated from the model and its read-only token never crosses jobs.
           persist-credentials: true
 
-      - name: Load trusted recovery receipt verifier
-        id: load-recovery-helper
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # ratchet:actions/github-script@v7
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const attempt = Number(process.env.GITHUB_RUN_ATTEMPT);
-            if (!Number.isSafeInteger(context.runId) || context.runId < 1
-              || !Number.isSafeInteger(attempt) || attempt < 1) throw new Error('invalid current run identity');
-            const {data: run} = await github.rest.actions.getWorkflowRunAttempt({
-              ...context.repo, run_id: context.runId, attempt_number: attempt,
-            });
-            const prefix = 'jhw7500/automation/.github/workflows/opencode-auto-review.yml@';
-            const refs = (run.referenced_workflows || []).filter((r) =>
-              typeof r.path === 'string' && r.path.startsWith(prefix) && r.path.length > prefix.length);
-            if (run.id !== context.runId || run.run_attempt !== attempt || refs.length !== 1
-              || !/^[0-9a-f]{40}$/.test(refs[0].sha || '')) throw new Error('unresolved central workflow SHA');
-            const helperPath = '.github/actions/recover-opencode-review/receipt.js';
-            const {data: file} = await github.rest.repos.getContent({
-              owner: 'jhw7500', repo: 'automation', path: helperPath, ref: refs[0].sha,
-            });
-            if (file?.type !== 'file' || file.path !== helperPath || file.encoding !== 'base64'
-              || !Number.isSafeInteger(file.size) || file.size < 1 || file.size > 1000000
-              || typeof file.content !== 'string' || file.content.length > 1400000
-              || file.symlink || file.submodule_git_url) throw new Error('invalid trusted recovery helper file');
-            const encoded = file.content.replace(/\n/g, '');
-            const bytes = Buffer.from(encoded, 'base64');
-            if (bytes.length !== file.size || bytes.toString('base64') !== encoded) throw new Error('invalid recovery helper encoding');
-            const target = path.join(process.env.RUNNER_TEMP, 'opencode-recovery-receipt.js');
-            const fd = fs.openSync(target, 'wx', 0o600);
-            try { fs.fchmodSync(fd, 0o600); fs.writeFileSync(fd, bytes); } finally { fs.closeSync(fd); }
-
       # Context and the review input are prepared before the CLI starts. Only an exact v2
       # envelope is state; the legacy marker exists solely for OpenCode's sticky-comment
       # compatibility and for identifying this run's raw output after the CLI returns.
       - name: Collect previous review context
         id: ctx
         env:
-          OPENCODE_RECOVERY_HELPER: ${{ runner.temp }}/opencode-recovery-receipt.js
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
           HEADER: '## OpenCode Review (latest)'
@@ -377,45 +342,7 @@ jobs:
             });
             if (valid) ids.push(comment.id);
           }
-          (async () => {
-            const claimed = comments.filter((comment) => {
-              if (ids.includes(comment.id) || comment.user?.type !== 'Bot') return false;
-              const lines = (comment.body || '').split('\n');
-              if (lines[0] !== '## OpenCode Review (latest)' || lines[1] !== '<!-- automation:opencode-auto-review:v2 -->') return false;
-              const match = (lines[2] || '').match(/^<!-- automation-state:(\{.*\}) -->$/);
-              if (!match || lines.filter((l) => /^- Attestation: [1-9][0-9]*$/.test(l)).length !== 1) return false;
-              let state;
-              try { state = JSON.parse(match[1]); } catch { return false; }
-              return state?.schema === 2 && state.reviewer === 'opencode' && state.pr === Number(prRaw)
-                && JSON.stringify(Object.keys(state).sort()) === JSON.stringify(['attempt_head','attempt_status','diff_mode','full_diff_sha256','pr','reviewer','run_attempt','run_id','schema','successful_head'])
-                && Number.isSafeInteger(state.run_id) && state.run_id > 0
-                && Number.isSafeInteger(state.run_attempt) && state.run_attempt > 0
-                && /^[0-9a-f]{40}$/.test(state.attempt_head || '')
-                && state.attempt_status === 'success' && state.successful_head === state.attempt_head
-                && /^[0-9a-f]{64}$/.test(state.full_diff_sha256 || '')
-                && ['full','delta','unchanged'].includes(state.diff_mode)
-                && lines.includes(`- Run: ${process.env.SERVER_URL}/${repository}/actions/runs/${state.run_id}`);
-            });
-            if (claimed.length) {
-              const {execFileSync} = require('child_process');
-              const get = (route, params = {}) => {
-                const args = ['api', `repos/${repository}/${route}`, '--method', 'GET'];
-                for (const [key, value] of Object.entries(params)) args.push('-f', `${key}=${value}`);
-                return {data: JSON.parse(execFileSync('gh', args, {encoding: 'utf8', maxBuffer: 16000000}))};
-              };
-              const github = {rest: {
-                actions: {
-                  listWorkflowRunsForRepo: ({event, per_page, page}) => get('actions/runs', {event, per_page, page}),
-                  getWorkflowRunAttempt: ({run_id, attempt_number}) => get(`actions/runs/${run_id}/attempts/${attempt_number}`),
-                  listJobsForWorkflowRunAttempt: ({run_id, attempt_number, per_page, page}) => get(`actions/runs/${run_id}/attempts/${attempt_number}/jobs`, {per_page, page}),
-                },
-                checks: {listForRef: ({ref, check_name, status, filter, per_page, page}) => get(`commits/${ref}/check-runs`, {check_name, status, filter, per_page, page})},
-              }};
-              const recovered = await require(process.env.OPENCODE_RECOVERY_HELPER).authenticateRecovery({github, repository, pr: Number(prRaw), comments});
-              for (const record of recovered) if (!ids.includes(record.comment.id)) ids.push(record.comment.id);
-            }
-            fs.writeFileSync(outputPath, JSON.stringify(ids));
-          })().catch((error) => { console.error(error); process.exitCode = 1; });
+          fs.writeFileSync(outputPath, JSON.stringify(ids));
           NODE
           PREV_RECORD="$(jq -c \
             --arg header "$HEADER" \
@@ -3421,47 +3348,11 @@ jobs:
           path: ${{ runner.temp }}/opencode-candidate
           merge-multiple: true
 
-      - name: Load trusted recovery receipt verifier
-        id: load-recovery-helper
-        if: ${{ always() }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # ratchet:actions/github-script@v7
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const attempt = Number(process.env.GITHUB_RUN_ATTEMPT);
-            if (!Number.isSafeInteger(context.runId) || context.runId < 1
-              || !Number.isSafeInteger(attempt) || attempt < 1) throw new Error('invalid current run identity');
-            const {data: run} = await github.rest.actions.getWorkflowRunAttempt({
-              ...context.repo, run_id: context.runId, attempt_number: attempt,
-            });
-            const prefix = 'jhw7500/automation/.github/workflows/opencode-auto-review.yml@';
-            const refs = (run.referenced_workflows || []).filter((r) =>
-              typeof r.path === 'string' && r.path.startsWith(prefix) && r.path.length > prefix.length);
-            if (run.id !== context.runId || run.run_attempt !== attempt || refs.length !== 1
-              || !/^[0-9a-f]{40}$/.test(refs[0].sha || '')) throw new Error('unresolved central workflow SHA');
-            const helperPath = '.github/actions/recover-opencode-review/receipt.js';
-            const {data: file} = await github.rest.repos.getContent({
-              owner: 'jhw7500', repo: 'automation', path: helperPath, ref: refs[0].sha,
-            });
-            if (file?.type !== 'file' || file.path !== helperPath || file.encoding !== 'base64'
-              || !Number.isSafeInteger(file.size) || file.size < 1 || file.size > 1000000
-              || typeof file.content !== 'string' || file.content.length > 1400000
-              || file.symlink || file.submodule_git_url) throw new Error('invalid trusted recovery helper file');
-            const encoded = file.content.replace(/\n/g, '');
-            const bytes = Buffer.from(encoded, 'base64');
-            if (bytes.length !== file.size || bytes.toString('base64') !== encoded) throw new Error('invalid recovery helper encoding');
-            const target = path.join(process.env.RUNNER_TEMP, 'opencode-recovery-receipt.js');
-            const fd = fs.openSync(target, 'wx', 0o600);
-            try { fs.fchmodSync(fd, 0o600); fs.writeFileSync(fd, bytes); } finally { fs.closeSync(fd); }
-
       - name: Canonicalize OpenCode review
         id: canonicalize-opencode-review
-        if: ${{ always() && steps.load-recovery-helper.outcome == 'success' && (needs.opencode-prepare.outputs.allow_invocation == 'true' || needs.opencode-prepare.outputs.budget_decision == 'authenticated_reuse') }}
+        if: ${{ always() && (needs.opencode-prepare.outputs.allow_invocation == 'true' || needs.opencode-prepare.outputs.budget_decision == 'authenticated_reuse') }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # ratchet:actions/github-script@v7
         env:
-          OPENCODE_RECOVERY_HELPER: ${{ runner.temp }}/opencode-recovery-receipt.js
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RUN_ID: ${{ github.run_id }}
@@ -4083,16 +3974,6 @@ jobs:
                   authenticatedLiveIds.add(record.comment.id);
                   authenticatedLiveRecords.set(record.comment.id, record);
                   records.push(record);
-                }
-              }
-              if (claimed.some((record) => !records.some((trusted) => trusted.comment.id === record.comment.id))) {
-                const recovered = await require(process.env.OPENCODE_RECOVERY_HELPER).authenticateRecovery({
-                  github, repository, pr: issueNumber, comments,
-                });
-                for (const record of recovered) {
-                  authenticatedLiveIds.add(record.comment.id);
-                  authenticatedLiveRecords.set(record.comment.id, record);
-                  if (!records.some((trusted) => trusted.comment.id === record.comment.id)) records.push(record);
                 }
               }
               return records.sort((a, b) => a.state.run_id - b.state.run_id

--- a/tests/opencode_recovery_fixtures.py
+++ b/tests/opencode_recovery_fixtures.py
@@ -1,0 +1,163 @@
+"""Synthetic original-attempt evidence, with real Git objects and a literal clean review."""
+import copy
+import hashlib
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location(
+    "recovery_fixture_budget", ROOT / ".github/actions/review-invocation-budget/review_invocation_budget.py")
+budget = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = budget
+spec.loader.exec_module(budget)
+REPOSITORY = "example/repo"
+PR = 52
+RUN = 700
+ATTEMPT = 1
+CENTRAL = "d" * 40
+WORKFLOW = "jhw7500/automation/.github/workflows/opencode-auto-review.yml@" + CENTRAL
+
+
+def encode(value):
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=True).encode()
+
+
+def digest(value):
+    return hashlib.sha256(value).hexdigest()
+
+
+def artifact(identifier, name, files):
+    out = io.BytesIO()
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as z:
+        for filename, data in files.items():
+            z.writestr(filename, data)
+    data = out.getvalue()
+    return {"metadata": {"id": identifier, "name": name, "expired": False,
+            "digest": "sha256:" + digest(data), "size_in_bytes": len(data),
+            "workflow_run": {"id": RUN}}, "payload": data}
+
+
+def git(root, *args):
+    return subprocess.run(["/usr/bin/git", *args], cwd=root, check=True,
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE).stdout
+
+
+def original_bundle(tmp_path):
+    repo = tmp_path / "target"
+    repo.mkdir()
+    git(repo, "init", "-q")
+    git(repo, "config", "user.name", "Recovery Test")
+    git(repo, "config", "user.email", "test@example.com")
+    (repo / "app.py").write_text("ready = False\n")
+    git(repo, "add", "app.py")
+    git(repo, "commit", "-qm", "base")
+    base = git(repo, "rev-parse", "HEAD").decode().strip()
+    (repo / "app.py").write_text("ready = True\n")
+    git(repo, "add", "app.py")
+    git(repo, "commit", "-qm", "head")
+    head = git(repo, "rev-parse", "HEAD").decode().strip()
+    diff = git(repo, "--no-replace-objects", "--literal-pathspecs", "-c", "diff.external=",
+               "diff", "--no-ext-diff", "--no-textconv", "--find-renames=50%",
+               "--ignore-submodules=none", "-U3", base + ".." + head)
+    full_hash = digest(diff)
+    provenance = budget.RunProvenance(
+        REPOSITORY, PR, head, ".github/workflows/opencode-auto-review.yml", "pull_request",
+        WORKFLOW, CENTRAL, CENTRAL, RUN, ATTEMPT, "in_progress", None)
+    request = budget.ClaimRequest(
+        REPOSITORY, PR, "opencode", RUN, ATTEMPT, head, full_hash, 1200, "changed",
+        budget.AuthenticatedReview(False, None, None), (), ("zai-coding-plan/glm-4.7",),
+        "final-review/default", "opencode run session")
+    claim_state = budget.claim(None, request, {(RUN, ATTEMPT): provenance}).state
+    checkpoint = budget.render_checkpoint(claim_state)
+    scope = {"schema": 1, "repository": REPOSITORY, "pr_number": PR,
+             "merge_base_sha": base, "head_sha": head,
+             "files": [{"filename": "app.py", "status": "modified"}]}
+    handoff_files = {"opencode-comments-before.json": b"[]",
+        "opencode-attestations-before.json": encode({"check_runs": [], "workflow_runs": []}),
+        "review-budget-claim.json": checkpoint, "review-full.diff": diff,
+        "review-scope.json": encode(scope)}
+    handoff = {"schema": 1, "repository": REPOSITORY, "pr": PR, "server_url": "https://github.com",
+        "workflow": ".github/workflows/opencode-auto-review.yml",
+        "caller_workflow_path": ".github/workflows/opencode-auto-review.yml", "caller_event": "pull_request",
+        "candidate_nonce": "ab" * 32, "workflow_head": head,
+        "referenced_workflow_path": WORKFLOW, "referenced_workflow_sha": CENTRAL,
+        "run_id": RUN, "run_attempt": ATTEMPT, "attempt_head": head, "merge_base_sha": base,
+        "diff_ready": True, "diff_mode": "full", "unchanged_since_previous": False,
+        "full_diff_sha256": full_hash, "allow_invocation": True, "budget_decision": "claimed",
+        "budget_checkpoint_sha256": digest(checkpoint),
+        "files": {name: digest(data) for name, data in handoff_files.items()}}
+    handoff_files["handoff.json"] = encode(handoff)
+    review = ("<!-- automation:opencode-auto-review -->\n<!-- automation-candidate:"
+              + "ab" * 32 + " -->\n### New findings\nNone").encode()
+    candidate = {"schema": 2, "repository": REPOSITORY, "pr": PR,
+        "run_id": RUN, "run_attempt": ATTEMPT, "head_sha": head, "full_diff_sha256": full_hash,
+        "diff_mode": "full", "claim_checkpoint_sha256": digest(checkpoint), "call_count": 1,
+        "elapsed_seconds": 45, "model_route": ["zai-coding-plan/glm-4.7"], "outcome": "success",
+        "failure_reason": "none", "review_sha256": digest(review),
+        "candidate_validations": [{"attempt": "initial", "sha256": digest(review), "valid": True,
+                                  "rule": None, "line": None, "column": None}]}
+    state = {"schema": 2, "reviewer": "opencode", "pr": PR, "run_id": RUN, "run_attempt": ATTEMPT,
+        "attempt_head": head, "successful_head": head, "attempt_status": "success",
+        "diff_mode": "full", "full_diff_sha256": full_hash}
+    state_text = encode(state).decode()
+    body = ("## OpenCode Review (latest)\n<!-- automation:opencode-auto-review:v2 -->\n"
+        + "<!-- automation-state:" + state_text + " -->\n<!-- automation:opencode-auto-review -->\n\n"
+        + "- Status: success\n- Run: https://github.com/example/repo/actions/runs/700\n"
+        + "- Attestation: 903\n- Reviewed: " + head + "\n\n### New findings\nNone")
+    comment = {"id": 902, "body": body, "user": {"type": "Bot", "login": "github-actions[bot]"}}
+    attestation = {"schema": 1, "repository": REPOSITORY, "workflow": handoff["workflow"], "pr": PR,
+        "caller_workflow_path": handoff["caller_workflow_path"], "caller_event": "pull_request",
+        "referenced_workflow_path": WORKFLOW, "referenced_workflow_sha": CENTRAL,
+        "attempt_head": head, "workflow_head": head, "successful_head": head, "run_id": RUN,
+        "run_attempt": ATTEMPT, "comment_id": 902, "prepared_run_attempt": ATTEMPT,
+        "body_sha256": digest(body.encode()), "state_sha256": digest(state_text.encode())}
+    check = {"id": 903, "name": "automation/opencode-canonical-review", "status": "completed",
+        "conclusion": "success", "head_sha": head, "app": {"id": 15368, "slug": "github-actions"},
+        "external_id": "automation-opencode-canonical:example/repo:pr:52:run:700:1:comment:902",
+        "output": {"text": "<!-- automation-attestation:" + encode(attestation).decode() + " -->"}}
+    pr = {"number": PR, "state": "open", "merged": False,
+        "head": {"sha": head, "repo": {"full_name": REPOSITORY, "fork": False}},
+        "base": {"sha": base, "repo": {"full_name": REPOSITORY}}}
+    run = {"id": RUN, "run_attempt": ATTEMPT, "head_sha": head, "status": "completed",
+        "conclusion": "failure", "event": "pull_request", "path": handoff["caller_workflow_path"],
+        "repository": {"full_name": REPOSITORY}, "referenced_workflows": [{"path": WORKFLOW, "sha": CENTRAL}],
+        "pull_requests": [{"number": PR, "head": {"sha": head, "repo": {"name": "repo"}},
+                          "base": {"sha": base, "repo": {"name": "repo"}}}]}
+    def job(suffix, conclusion, steps):
+        return {"id": {"opencode-prepare": 1101, "opencode-review": 1102, "opencode-canonicalize": 1103}[suffix],
+            "name": "opencode-review / " + suffix, "status": "completed", "conclusion": conclusion,
+            "run_id": RUN, "run_attempt": ATTEMPT,
+            "steps": [{"number": i + 1, "name": name, "status": "completed", "conclusion": outcome}
+                      for i, (name, outcome) in enumerate(steps)]}
+    jobs = [
+        job("opencode-prepare", "success", [("Claim OpenCode review budget", "success"),
+            ("Build sealed canonicalization handoff", "success"),
+            ("Upload sealed canonicalization handoff", "success")]),
+        job("opencode-review", "success", [("Run OpenCode PR review", "success"),
+            ("Materialize sealed OpenCode candidate", "success"), ("Upload untrusted OpenCode candidate", "success")]),
+        job("opencode-canonicalize", "failure", [("Canonicalize OpenCode review", "success"),
+            ("Resolve OpenCode budget outcome", "success"), ("Finalize OpenCode review budget", "failure")]),
+    ]
+    artifacts = {
+        "handoff": artifact(101, "opencode-handoff-700-1", handoff_files),
+        "claim": artifact(102, "opencode-review-budget-claim-700-1",
+                          {"opencode-review-budget-claim.json": checkpoint}),
+        "candidate": artifact(103, "opencode-candidate-700-1",
+                              {"candidate.json": encode(candidate), "review.md": review}),
+    }
+    return {"target": {"repository": REPOSITORY, "pr": PR, "run_id": RUN, "run_attempt": ATTEMPT,
+                       "head_sha": head, "base_sha": base},
+        "pr": pr, "original_run": run, "original_jobs": jobs,
+        "artifacts": artifacts, "canonical_comment": comment, "original_check": check,
+        "ledger_comment": {"id": 901, "user": {"type": "Bot", "login": "github-actions[bot]"},
+                           "body": budget.render_comment(claim_state, server_url="https://github.com")},
+        "workspace": repo, "claim_state": claim_state,
+        "history": {"runs": [run], "checks": [check], "attempts": {"700:1": {"run": run, "jobs": jobs}},
+                    "comments": [comment]},
+        "workflow_source": (ROOT / "tests/fixtures/opencode-recovery/original-workflow.yml").read_text(),
+    }

--- a/tests/release_fixture_helpers.py
+++ b/tests/release_fixture_helpers.py
@@ -9,6 +9,32 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import hashlib
+
+
+def restore_pre_v176_opencode_recovery(repo: Path) -> None:
+    """Restore authenticated pre-recovery bytes only when new recovery markers exist."""
+    from scripts.verify_workflow_release import VerifiedCommitTree
+
+    root = Path(__file__).resolve().parents[1]
+    tree = None
+    for relative, marker in (
+        (".github/workflows/opencode-auto-review.yml", b"recover-opencode-review"),
+        (".github/actions/review-invocation-budget/review_invocation_budget.py", b"def recover_finalize("),
+        ("examples/baseline-workflows/.github/workflows/opencode-auto-review.yml", b"recover_finalization:"),
+        ("scripts/workflow-catalog.json", b'"opencode-recovery"'),
+    ):
+        path = repo / relative
+        if path.is_file() and marker in path.read_bytes():
+            if tree is None:
+                tree = VerifiedCommitTree.open(root, "6dc5934ecd6bd1c298e8b7fb869b412b0828ff7c")
+            payload = tree.read_file(relative)
+            if relative == ".github/workflows/opencode-auto-review.yml":
+                assert hashlib.sha256(payload).hexdigest() == "f81db9665847aea815c8691caea7c6458011595cbed28c13809f051c381b5e91"
+            if relative.endswith("review_invocation_budget.py"):
+                assert hashlib.sha256(payload).hexdigest() == "9be3f16b8254a3268788ffecdf653cd821a3ed3452022dceebed67e1c90f1aad"
+            path.write_bytes(payload)
+    (repo / ".github/workflows/opencode-recover-finalization.yml").unlink(missing_ok=True)
 
 
 HISTORICAL_REVIEW_FIXTURE_ROOT = (
@@ -64,6 +90,7 @@ def restore_pre_v164_label_trigger(repo: Path) -> None:
     first) so the older restores still find the text they assert on.
     """
 
+    restore_pre_v176_opencode_recovery(repo)
     # Idempotent: a fixture that already restored (or never had) the v1.64 text is
     # left alone, so this can also run first inside the older restore chains.
     for workflow in ("claude-code-review.yml", "gemini-auto-review.yml", "opencode-auto-review.yml"):
@@ -578,6 +605,7 @@ def restore_historical_review_workflows(
     Keeping them in the test tree makes historical fixtures independent of Git history.
     """
 
+    restore_pre_v176_opencode_recovery(repo)
     for filename in filenames:
         relative = f".github/workflows/{filename}"
         (repo / relative).write_bytes(
@@ -753,6 +781,7 @@ PRE_V173_OPENCODE_ACTIVE_SECTION_ORDER_HUNKS = (
 def restore_pre_v173_opencode_active_section_order(repo: Path) -> None:
     """Restore the v1.72 positional renderer and append-only active section."""
 
+    restore_pre_v176_opencode_recovery(repo)
     path = repo / ".github/workflows/opencode-auto-review.yml"
     if not path.exists():
         return

--- a/tests/test_canonical_workflow_tree.py
+++ b/tests/test_canonical_workflow_tree.py
@@ -230,6 +230,30 @@ EXPECTED_TRIGGERS: dict[str, object] = {
     },
 }
 
+EXPECTED_TRIGGERS["opencode-auto-review.yml"]["workflow_dispatch"]["inputs"].update({
+    "recover_finalization": {
+        "description": "Finalize a successful original review with zero additional provider calls",
+        "type": "boolean", "required": "false", "default": "false",
+    },
+    "recovery_original_run_id": {
+        "description": "Original failed Actions run ID", "type": "string", "required": "false",
+    },
+    "recovery_original_run_attempt": {
+        "description": "Exact original Actions attempt", "type": "string", "required": "false",
+    },
+    "recovery_expected_head_sha": {
+        "description": "Exact reviewed PR HEAD (40 lowercase hex)", "type": "string", "required": "false",
+    },
+    "recovery_expected_base_sha": {
+        "description": "Exact original PR base (40 lowercase hex)", "type": "string", "required": "false",
+    },
+})
+
+OPENCODE_RECOVERY_PERMISSIONS = {
+    "actions": "read", "checks": "write", "contents": "read",
+    "issues": "write", "pull-requests": "read",
+}
+
 CLAUDE_COMMAND_PERMISSIONS = {
     "actions": "read",
     "contents": "read",
@@ -301,21 +325,32 @@ def caller_job_contracts(
 
 def central_accepts(entry: CatalogEntry, central_root: Path) -> bool:
     assert entry.central_workflow is not None
-    central = load_yaml(central_root / entry.central_workflow)
-    call = central["on"]["workflow_call"]
-    declared_inputs = set(call.get("inputs", {}))
-    declared_secrets = call.get("secrets", {})
-    required_secrets = {
-        name
-        for name, value in declared_secrets.items()
-        if value.get("required", "false") == "true"
-    }
-    return all(
-        set(job.with_keys) <= declared_inputs
-        and set(job.secrets) <= set(declared_secrets)
-        and required_secrets <= set(job.secrets)
-        for job in entry.caller_jobs
-    )
+    caller = load_yaml(CANONICAL / entry.path.relative_to(".github"))
+    for job in entry.caller_jobs:
+        target = entry.central_workflow
+        if (entry.path.as_posix() == ".github/workflows/opencode-auto-review.yml"
+            and job.name == "opencode-recovery"):
+            target = "opencode-recover-finalization.yml"
+        assert caller["jobs"][job.name]["uses"] == (
+            f"jhw7500/automation/.github/workflows/{target}@__AUTOMATION_COMMIT__"
+        )
+        call = load_yaml(central_root / target)["on"]["workflow_call"]
+        declared_inputs = call.get("inputs", {})
+        required_inputs = {
+            name for name, value in declared_inputs.items()
+            if value.get("required", "false") == "true"
+        }
+        declared_secrets = call.get("secrets", {})
+        required_secrets = {
+            name for name, value in declared_secrets.items()
+            if value.get("required", "false") == "true"
+        }
+        if not (set(job.with_keys) <= set(declared_inputs)
+                and required_inputs <= set(job.with_keys)
+                and set(job.secrets) <= set(declared_secrets)
+                and required_secrets <= set(job.secrets)):
+            return False
+    return True
 
 
 def test_canonical_tree_is_exactly_catalogued() -> None:
@@ -379,10 +414,12 @@ def test_triggers_and_permissions_match_the_approved_policy() -> None:
         assert workflow["on"] == expected_trigger, filename
 
         contracts = caller_job_contracts(workflow)
-        assert len(contracts) == 1, filename
         expected_name, expected_permissions = EXPECTED_CALLER_PERMISSIONS[filename]
-        assert contracts[0].name == expected_name, filename
-        assert dict(contracts[0].permissions) == expected_permissions, filename
+        expected = [(expected_name, expected_permissions)]
+        if filename == "opencode-auto-review.yml":
+            expected.insert(0, ("opencode-recovery", OPENCODE_RECOVERY_PERMISSIONS))
+            assert workflow["jobs"]["reject-conflicting-dispatch"]["permissions"] == {}
+        assert [(job.name, dict(job.permissions)) for job in contracts] == expected, filename
 
 
 def test_canonical_callers_match_catalog_and_central_contracts() -> None:
@@ -411,14 +448,22 @@ def test_canonical_callers_use_only_the_selected_auth_contract() -> None:
         assert reusable_ref.search(text) is None, path
 
         reusable_jobs = [
-            job
-            for job in workflow["jobs"].values()
+            (name, job)
+            for name, job in workflow["jobs"].items()
             if isinstance(job, dict)
             and "jhw7500/automation/.github/workflows/" in job.get("uses", "")
         ]
         assert reusable_jobs, path
-        for job in reusable_jobs:
-            if entry.auth_family == "gemini":
+        for name, job in reusable_jobs:
+            if (entry.path.as_posix() == ".github/workflows/opencode-auto-review.yml"
+                and name == "opencode-recovery"):
+                assert job["uses"] == (
+                    "jhw7500/automation/.github/workflows/"
+                    "opencode-recover-finalization.yml@__AUTOMATION_COMMIT__"
+                )
+                assert job["permissions"] == OPENCODE_RECOVERY_PERMISSIONS
+                assert "secrets" not in job
+            elif entry.auth_family == "gemini":
                 assert job["with"]["repo_write_auth"] == "github_app"
                 assert job["with"]["app_id"] == "${{ vars.APP_ID }}"
                 if entry.central_workflow == "gemini-auto-review.yml":

--- a/tests/test_opencode_recovery_evidence.py
+++ b/tests/test_opencode_recovery_evidence.py
@@ -1,0 +1,347 @@
+"""Recovery refuses untrusted artifacts before any file extraction or mutation."""
+import hashlib
+import importlib.util
+import io
+import json
+import stat
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE = ROOT / ".github/actions/recover-opencode-review/evidence.py"
+
+
+def evidence_module():
+    if not MODULE.is_file():
+        pytest.fail("Recovery evidence validator is not implemented")
+    spec = importlib.util.spec_from_file_location("opencode_recovery_evidence", MODULE)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_current_workflow_replays_the_same_original_success(tmp_path):
+    module = evidence_module()
+    bundle = original_bundle(tmp_path)
+    bundle["workflow_source"] = (ROOT / ".github/workflows/opencode-auto-review.yml").read_text()
+    result = module.validate_evidence(module.RecoveryTarget(**bundle["target"]), bundle, bundle["workspace"])
+    assert result.request.call_count == 1
+    assert result.request.elapsed_seconds == 45
+    assert result.canonical_body == bundle["canonical_comment"]["body"]
+
+
+def archive(entries=None):
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as stream:
+        for name, data in entries or [("candidate.json", b'{"schema":2}'), ("review.md", b"review")]:
+            stream.writestr(name, data)
+    payload = output.getvalue()
+    metadata = {
+        "id": 101, "name": "opencode-candidate-42-1", "expired": False,
+        "digest": "sha256:" + hashlib.sha256(payload).hexdigest(),
+        "size_in_bytes": len(payload), "workflow_run": {"id": 42},
+    }
+    return metadata, payload
+
+
+def test_original_artifact_bytes_are_returned_without_extracting(tmp_path):
+    module = evidence_module()
+    metadata, payload = archive()
+    assert module.read_artifact(metadata, payload, "opencode-candidate-42-1", 42) == {
+        "candidate.json": b'{"schema":2}', "review.md": b"review",
+    }
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize("change", [
+    {"id": True}, {"id": 0}, {"name": "opencode-candidate-42-2"},
+    {"expired": True}, {"expired": None}, {"workflow_run": {"id": 43}},
+    {"digest": "sha256:" + "0" * 64}, {"digest": None},
+    {"size_in_bytes": 1},
+])
+def test_artifact_identity_or_expiry_refuses(change):
+    module = evidence_module()
+    metadata, payload = archive()
+    metadata.update(change)
+    with pytest.raises(module.RecoveryError):
+        module.read_artifact(metadata, payload, "opencode-candidate-42-1", 42)
+
+
+@pytest.mark.parametrize("name", ["../review.md", "/review.md", "a/review.md", "a\\review.md", ".hidden", ""])
+def test_unsafe_artifact_paths_refuse(name):
+    module = evidence_module()
+    # ZIP itself cannot encode an empty filename; empty inventory is checked separately.
+    if not name:
+        output = io.BytesIO()
+        with zipfile.ZipFile(output, "w"):
+            pass
+        metadata, _ = archive()
+        payload = output.getvalue()
+        metadata.update(size_in_bytes=len(payload), digest="sha256:" + hashlib.sha256(payload).hexdigest())
+    else:
+        metadata, payload = archive([(name, b"bad")])
+    with pytest.raises(module.RecoveryError):
+        module.read_artifact(metadata, payload, "opencode-candidate-42-1", 42)
+
+
+def test_duplicate_zip_entry_refuses():
+    module = evidence_module()
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        metadata, payload = archive([("review.md", b"first"), ("review.md", b"second")])
+    with pytest.raises(module.RecoveryError):
+        module.read_artifact(metadata, payload, "opencode-candidate-42-1", 42)
+
+
+def test_zip_symlink_refuses():
+    module = evidence_module()
+    entry = zipfile.ZipInfo("review.md")
+    entry.create_system = 3
+    entry.external_attr = (stat.S_IFLNK | 0o777) << 16
+    metadata, payload = archive([(entry, b"/etc/passwd")])
+    with pytest.raises(module.RecoveryError):
+        module.read_artifact(metadata, payload, "opencode-candidate-42-1", 42)
+
+
+def test_expanding_zip_refuses_before_reading_entries(monkeypatch):
+    module = evidence_module()
+    metadata, payload = archive([("review.md", b"x" * 4_000_001)])
+    def unexpected_read(*args, **kwargs):
+        pytest.fail("oversized ZIP entry was read")
+    monkeypatch.setattr(zipfile.ZipFile, "read", unexpected_read)
+    with pytest.raises(module.RecoveryError):
+        module.read_artifact(metadata, payload, "opencode-candidate-42-1", 42)
+
+
+@pytest.mark.parametrize("raw", [b'{"schema":1,"schema":2}', b'{"n":NaN}', b'{"n":Infinity}', b"\xff"])
+def test_json_evidence_rejects_ambiguous_or_nonstandard_values(raw):
+    module = evidence_module()
+    with pytest.raises(module.RecoveryError):
+        module.strict_json(raw)
+
+from opencode_recovery_fixtures import original_bundle
+
+
+def test_verified_original_success_returns_original_metrics(tmp_path):
+    module = evidence_module()
+    bundle = original_bundle(tmp_path)
+    assert hasattr(module, "validate_evidence"), "Original evidence validation is not implemented"
+    target = module.RecoveryTarget(**bundle["target"])
+    validated = module.validate_evidence(target, bundle, bundle["workspace"])
+    assert validated.request.run_id == 700
+    assert validated.request.run_attempt == 1
+    assert validated.request.call_count == 1
+    assert validated.request.elapsed_seconds == 45
+    assert validated.request.authenticated_review.success is True
+    assert validated.request.remaining_finding_ids == ()
+    assert validated.canonical_body == bundle["canonical_comment"]["body"]
+
+def test_original_workflow_head_can_differ_from_reviewed_head(tmp_path):
+    module = evidence_module()
+    bundle = original_bundle(tmp_path)
+    workflow_head = "e" * 40
+    bundle["original_run"]["head_sha"] = workflow_head
+    bundle["original_check"]["head_sha"] = workflow_head
+    raw = bundle["original_check"]["output"]["text"]
+    attestation = json.loads(raw[len("<!-- automation-attestation:"):-len(" -->")])
+    attestation["workflow_head"] = workflow_head
+    bundle["original_check"]["output"]["text"] = "<!-- automation-attestation:" + json.dumps(attestation) + " -->"
+    _rewrite_payload(bundle, "handoff", "handoff.json", lambda h: h.update(workflow_head=workflow_head))
+    validated = module.validate_evidence(module.RecoveryTarget(**bundle["target"]), bundle, bundle["workspace"])
+    assert validated.request.head_sha == bundle["target"]["head_sha"]
+    assert validated.attestation["workflow_head"] == workflow_head
+
+
+@pytest.mark.parametrize("field", ["schema", "run_attempt", "prepared_run_attempt"])
+def test_attestation_boolean_is_not_an_integer_identity(tmp_path, field):
+    module = evidence_module()
+    bundle = original_bundle(tmp_path)
+    check = bundle["original_check"]
+    raw = check["output"]["text"]
+    attestation = json.loads(raw[len("<!-- automation-attestation:"):-len(" -->")])
+    attestation[field] = True
+    check["output"]["text"] = "<!-- automation-attestation:" + json.dumps(attestation) + " -->"
+    with pytest.raises(module.RecoveryError):
+        module.validate_evidence(module.RecoveryTarget(**bundle["target"]), bundle, bundle["workspace"])
+
+def _rewrite_payload(bundle, role, filename, mutate):
+    from opencode_recovery_fixtures import artifact, encode
+    item = bundle["artifacts"][role]
+    with zipfile.ZipFile(io.BytesIO(item["payload"])) as stream:
+        files = {name: stream.read(name) for name in stream.namelist()}
+    content = json.loads(files[filename])
+    mutate(content)
+    files[filename] = encode(content)
+    bundle["artifacts"][role] = artifact(item["metadata"]["id"], item["metadata"]["name"], files)
+
+
+@pytest.mark.parametrize('changes', [
+    {'caller_workflow_path': '.github/workflows/other.yml'},
+    {'caller_event': 'workflow_dispatch'},
+    {'referenced_workflow_ref': 'refs/tags/other'},
+    {'referenced_workflow_sha': 'e' * 40,
+     'referenced_workflow_path': 'jhw7500/automation/.github/workflows/opencode-auto-review.yml@' + 'e' * 40},
+])
+def test_claim_provenance_must_match_original_publication_even_with_sealed_hashes(tmp_path, changes):
+    from dataclasses import replace
+    from opencode_recovery_fixtures import artifact, budget, digest, encode
+    module = evidence_module()
+    bundle = original_bundle(tmp_path)
+    original = bundle['claim_state']
+    changed = replace(original, invocations=(replace(original.invocations[0], **changes),))
+    checkpoint = budget.render_checkpoint(changed)
+    with zipfile.ZipFile(io.BytesIO(bundle['artifacts']['handoff']['payload'])) as stream:
+        files = {name: stream.read(name) for name in stream.namelist()}
+    handoff = json.loads(files['handoff.json'])
+    files['review-budget-claim.json'] = checkpoint
+    handoff['files']['review-budget-claim.json'] = digest(checkpoint)
+    handoff['budget_checkpoint_sha256'] = digest(checkpoint)
+    files['handoff.json'] = encode(handoff)
+    bundle['artifacts']['handoff'] = artifact(101, 'opencode-handoff-700-1', files)
+    bundle['artifacts']['claim'] = artifact(102, 'opencode-review-budget-claim-700-1',
+        {'opencode-review-budget-claim.json': checkpoint})
+    _rewrite_payload(bundle, 'candidate', 'candidate.json',
+        lambda c: c.update(claim_checkpoint_sha256=digest(checkpoint)))
+    with pytest.raises(module.RecoveryError, match='original_claim_provenance_invalid'):
+        module.validate_evidence(module.RecoveryTarget(**bundle['target']), bundle, bundle['workspace'])
+
+
+@pytest.mark.parametrize('job_index', [0, 1, 2])
+@pytest.mark.parametrize('change', ['reverse', 'numbers', 'duplicate', 'boolean'])
+def test_original_step_order_is_part_of_finalizer_failure_proof(tmp_path, job_index, change):
+    module = evidence_module()
+    bundle = original_bundle(tmp_path)
+    steps = bundle['original_jobs'][job_index]['steps']
+    if change == 'reverse':
+        steps.reverse()
+    elif change == 'numbers':
+        for index, step in enumerate(steps):
+            step['number'] = len(steps) - index
+    elif change == 'duplicate':
+        steps[1]['number'] = steps[0]['number']
+    else:
+        steps[0]['number'] = True
+    with pytest.raises(module.RecoveryError, match='original_step_order_invalid'):
+        module.validate_evidence(module.RecoveryTarget(**bundle['target']), bundle, bundle['workspace'])
+
+
+@pytest.mark.parametrize("field,value", [
+    ("call_count", 3), ("call_count", True), ("elapsed_seconds", 601),
+    ("run_attempt", 2), ("head_sha", "f" * 40), ("full_diff_sha256", "f" * 64),
+    ("claim_checkpoint_sha256", "e" * 64), ("outcome", "failure"),
+    ("model_route", ["unapproved-model"]), ("failure_reason", "provider_failed"),
+    ("review_sha256", "e" * 64), ("candidate_validations", []),
+])
+def test_candidate_claim_or_usage_drift_refuses_even_with_valid_zip_digest(tmp_path, field, value):
+    module = evidence_module()
+    bundle = original_bundle(tmp_path)
+    _rewrite_payload(bundle, "candidate", "candidate.json", lambda c: c.update({field: value}))
+    with pytest.raises(module.RecoveryError):
+        module.validate_evidence(module.RecoveryTarget(**bundle["target"]), bundle, bundle["workspace"])
+
+
+def test_unsupported_original_code_is_not_executed(tmp_path, monkeypatch):
+    module = evidence_module()
+    bundle = original_bundle(tmp_path)
+    bundle["workflow_source"] = bundle["workflow_source"].replace(
+        "const fs = require('fs');", "throw new Error('unapproved');")
+    subprocess_run = module.subprocess.run
+    def refuse_node(argv, *args, **kwargs):
+        assert not str(argv[0]).endswith("/node"), "unapproved code reached replay"
+        return subprocess_run(argv, *args, **kwargs)
+    monkeypatch.setattr(module.subprocess, "run", refuse_node)
+    with pytest.raises(module.RecoveryError, match="original_replay_unsupported"):
+        module.validate_evidence(module.RecoveryTarget(**bundle["target"]), bundle, bundle["workspace"])
+
+
+def test_forged_canonical_success_refuses_when_candidate_replays_differently(tmp_path):
+    module = evidence_module()
+    bundle = original_bundle(tmp_path)
+    comment = bundle["canonical_comment"]
+    comment["body"] = comment["body"].replace("### New findings\nNone", "### New findings\nForged clean result")
+    check = bundle["original_check"]
+    raw = check["output"]["text"]
+    attestation = json.loads(raw[len("<!-- automation-attestation:"):-len(" -->")])
+    attestation["body_sha256"] = hashlib.sha256(comment["body"].encode()).hexdigest()
+    check["output"]["text"] = "<!-- automation-attestation:" + json.dumps(attestation) + " -->"
+    with pytest.raises(module.RecoveryError, match="canonical_replay_mismatch"):
+        module.validate_evidence(module.RecoveryTarget(**bundle["target"]), bundle, bundle["workspace"])
+
+
+def test_changed_local_full_diff_refuses(tmp_path):
+    module = evidence_module()
+    bundle = original_bundle(tmp_path)
+    from opencode_recovery_fixtures import git
+    (bundle["workspace"] / "app.py").write_text("ready = 'different'\n")
+    git(bundle["workspace"], "add", "app.py")
+    git(bundle["workspace"], "commit", "-qm", "unreviewed")
+    with pytest.raises(module.RecoveryError, match="workspace_head_invalid"):
+        module.validate_evidence(module.RecoveryTarget(**bundle["target"]), bundle, bundle["workspace"])
+
+
+def test_noncanonical_claim_json_is_a_bounded_refusal(tmp_path):
+    module = evidence_module()
+    bundle = original_bundle(tmp_path)
+    from opencode_recovery_fixtures import artifact, encode, digest
+    with zipfile.ZipFile(io.BytesIO(bundle["artifacts"]["handoff"]["payload"])) as stream:
+        files = {name: stream.read(name) for name in stream.namelist()}
+    invalid = files["review-budget-claim.json"] + b" "
+    files["review-budget-claim.json"] = invalid
+    handoff = json.loads(files["handoff.json"])
+    handoff["files"]["review-budget-claim.json"] = digest(invalid)
+    handoff["budget_checkpoint_sha256"] = digest(invalid)
+    files["handoff.json"] = encode(handoff)
+    bundle["artifacts"]["handoff"] = artifact(101, "opencode-handoff-700-1", files)
+    bundle["artifacts"]["claim"] = artifact(102, "opencode-review-budget-claim-700-1",
+                                           {"opencode-review-budget-claim.json": invalid})
+    with pytest.raises(module.RecoveryError):
+        module.validate_evidence(module.RecoveryTarget(**bundle["target"]), bundle, bundle["workspace"])
+
+
+
+@pytest.mark.parametrize("field,value", [
+    ("run_attempt", 2), ("head_sha", "f" * 40), ("base_sha", "e" * 40),
+    ("repository", "foreign/repo"), ("pr", True),
+])
+def test_wrong_original_target_refuses(tmp_path, field, value):
+    module = evidence_module()
+    bundle = original_bundle(tmp_path)
+    assert hasattr(module, "validate_evidence"), "Original evidence validation is not implemented"
+    bundle["target"][field] = value
+    with pytest.raises(module.RecoveryError):
+        target = module.RecoveryTarget(**bundle["target"])
+        module.validate_evidence(target, bundle, bundle["workspace"])
+
+
+@pytest.mark.parametrize("case", ["run_cancelled", "job_cancelled", "publication_failed",
+    "outcome_failed", "finalizer_succeeded", "duplicate_job", "foreign_check",
+    "changed_comment", "wrong_base_binding", "missing_candidate"])
+def test_unverified_success_refuses(tmp_path, case):
+    module = evidence_module()
+    bundle = original_bundle(tmp_path)
+    assert hasattr(module, "validate_evidence"), "Original evidence validation is not implemented"
+    if case == "run_cancelled":
+        bundle["original_run"]["conclusion"] = "cancelled"
+    elif case == "job_cancelled":
+        bundle["original_jobs"][1]["conclusion"] = "cancelled"
+    elif case == "publication_failed":
+        bundle["original_jobs"][2]["steps"][0]["conclusion"] = "failure"
+    elif case == "outcome_failed":
+        bundle["original_jobs"][2]["steps"][1]["conclusion"] = "failure"
+    elif case == "finalizer_succeeded":
+        bundle["original_jobs"][2]["steps"][2]["conclusion"] = "success"
+    elif case == "duplicate_job":
+        bundle["original_jobs"].append(bundle["original_jobs"][2])
+    elif case == "foreign_check":
+        bundle["original_check"]["app"]["slug"] = "unrelated-app"
+    elif case == "changed_comment":
+        bundle["canonical_comment"]["body"] += "\nchanged"
+    elif case == "wrong_base_binding":
+        bundle["original_run"]["pull_requests"][0]["base"]["sha"] = "e" * 40
+    else:
+        del bundle["artifacts"]["candidate"]
+    with pytest.raises(module.RecoveryError):
+        module.validate_evidence(module.RecoveryTarget(**bundle["target"]), bundle, bundle["workspace"])

--- a/tests/test_opencode_recovery_receipts.py
+++ b/tests/test_opencode_recovery_receipts.py
@@ -1,0 +1,533 @@
+"""Executable authentication tests for the recovery receipt trust boundary."""
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / ".github/actions/recover-opencode-review/receipt.js"
+
+
+def compact(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def digest(value):
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def facts_fixture(pr=7, full_hash="12" * 32, pinned_original=True):
+    head, base, central, driver_head = "ab" * 20, "bc" * 20, "75" * 20, "ef" * 20
+    workflow = ".github/workflows/opencode-auto-review.yml"
+    original_ref = "jhw7500/automation/" + workflow + "@" + (central if pinned_original else "refs/tags/v1.75")
+    recovery_ref = "jhw7500/automation/.github/workflows/opencode-recover-finalization.yml@" + central
+    state = dict(schema=2, reviewer="opencode", pr=pr, run_id=700, run_attempt=1,
+                 attempt_head=head, successful_head=head, attempt_status="success",
+                 diff_mode="full", full_diff_sha256=full_hash)
+    state_text = compact(state)
+    comment = dict(id=902, user=dict(type="Bot", login="github-actions[bot]"), body=(
+        "## OpenCode Review (latest)\n<!-- automation:opencode-auto-review:v2 -->\n"
+        f"<!-- automation-state:{state_text} -->\n\n- Attestation: 903\n"
+        "- Run: https://github.com/example/repo/actions/runs/700\n\n### New findings\nNone"))
+    attestation = dict(schema=1, repository="example/repo", workflow=workflow,
+        caller_workflow_path=workflow, caller_event="pull_request",
+        referenced_workflow_path=original_ref, referenced_workflow_sha=central,
+        pr=pr, attempt_head=head, successful_head=head, workflow_head=head,
+        run_id=700, run_attempt=1, prepared_run_attempt=1, comment_id=902,
+        body_sha256=digest(comment["body"]), state_sha256=digest(state_text))
+    canonical = dict(id=903, name="automation/opencode-canonical-review", head_sha=head,
+        status="completed", conclusion="success", app=dict(id=15368, slug="github-actions"),
+        external_id=f"automation-opencode-canonical:example/repo:pr:{pr}:run:700:1:comment:902",
+        output=dict(text="<!-- automation-attestation:" + compact(attestation) + " -->"))
+    entry = dict(run_id=700, run_attempt=1, head_sha=head, full_diff_sha256=full_hash,
+        caller_workflow_path=workflow, caller_event="pull_request", referenced_workflow_path=original_ref,
+        referenced_workflow_ref="refs/tags/v1.75", referenced_workflow_sha=central,
+        round_number=1, override_event_id=None, model_route=["zai-coding-plan/glm-4.7"], effort="default",
+        call_unit="provider", call_count=1, estimated_input_tokens=120, elapsed_seconds=10,
+        status="finalized", outcome="success", stop_reason="", remaining_finding_ids=[])
+    ledger = dict(schema=1, repository="example/repo", pr=pr, reviewer="opencode", budgets={},
+        invocations=[entry], consumed_override_event_ids=[], last_decision={}, handoff={})
+    ledger_comment = dict(id=904, user=dict(type="Bot", login="github-actions[bot]"), body=(
+        "<!-- automation:review-invocation-budget:opencode:v1 -->\n"
+        "<!-- automation-budget-state:" + compact(ledger) + " -->\n"))
+    original = dict(run_id=700, run_attempt=1, head_sha=head, base_sha=base, workflow_head=head,
+        full_diff_sha256=full_hash, caller_workflow_path=workflow, referenced_workflow_path=original_ref,
+        referenced_workflow_sha=central, comment_id=902, attestation_id=903,
+        body_sha256=digest(comment["body"]), state_sha256=digest(state_text),
+        claim_checkpoint_sha256="34" * 32, finalized_invocation_sha256=digest(compact(entry)),
+        artifacts={role: dict(id=101 + i, sha256=str(i + 1) * 64)
+                   for i, role in enumerate(("handoff", "claim", "candidate"))})
+    recovery = dict(run_id=800, run_attempt=1, workflow_head=driver_head, caller_workflow_path=workflow,
+        referenced_workflow_path=recovery_ref, referenced_workflow_sha=central, provider_calls=0)
+    receipt = dict(schema=1, repository="example/repo", pr=pr, original=original, recovery=recovery)
+    check = dict(id=905, name="automation/opencode-finalization-recovery", head_sha=driver_head,
+        status="completed", conclusion="success", app=dict(id=15368, slug="github-actions"),
+        external_id=f"automation-opencode-recovery:example/repo:pr:{pr}:original:700:1:recovery:800:1",
+        output=dict(text="<!-- automation-opencode-recovery:" + compact(receipt) + " -->"))
+    def run(run_id, workflow_head, event, conclusion, ref):
+        return dict(id=run_id, run_attempt=1, head_sha=workflow_head, event=event, status="completed",
+            conclusion=conclusion, path=workflow, repository=dict(full_name="example/repo"),
+            referenced_workflows=[dict(path=ref, sha=central)])
+    original_run = run(700, head, "pull_request", "failure", original_ref)
+    original_run["referenced_workflows"][0]["ref"] = "refs/tags/v1.75"
+    original_run["pull_requests"] = [dict(number=pr, head=dict(sha=head), base=dict(sha=base))]
+    def job(name, conclusion, steps):
+        return dict(id=1001, run_id=700, run_attempt=1, name=name, status="completed", conclusion=conclusion,
+                    steps=[dict(number=i + 1, name=n, status="completed", conclusion=c)
+                           for i, (n,c) in enumerate(steps)])
+    original_jobs = [
+        job("opencode-prepare", "success", [(n, "success") for n in (
+            "Claim OpenCode review budget", "Build sealed canonicalization handoff", "Upload sealed canonicalization handoff")]),
+        job("opencode-review", "success", [(n, "success") for n in (
+            "Run OpenCode PR review", "Materialize sealed OpenCode candidate", "Upload untrusted OpenCode candidate")]),
+        job("opencode-canonicalize", "failure", [("Canonicalize OpenCode review", "success"),
+            ("Resolve OpenCode budget outcome", "success"), ("Finalize OpenCode review budget", "failure")])]
+    driver_jobs = [dict(id=1002, run_id=800, run_attempt=1, name="opencode-recover-finalization",
+                        status="completed", conclusion="success")]
+    return dict(receipt=receipt, check=check, driverRun=run(800, driver_head, "workflow_dispatch", "success", recovery_ref),
+        driverJobs=driver_jobs, originalRun=original_run, originalJobs=original_jobs,
+        canonicalCheck=canonical, comment=comment, ledgerComment=ledger_comment)
+
+
+def node_validate(facts):
+    result = subprocess.run(["node", str(HELPER)], input=json.dumps(facts), capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)["valid"]
+
+
+def test_receipt_accepts_complete_exact_provenance():
+    assert node_validate(facts_fixture())
+
+
+@pytest.mark.parametrize("field,value", [
+    ("driverRun.conclusion", "failure"), ("driverRun.conclusion", "cancelled"),
+    ("driverRun.status", "in_progress"), ("driverRun.event", "pull_request"),
+    ("driverRun.id", 801), ("driverRun.run_attempt", 2), ("driverRun.head_sha", "aa"*20),
+    ("driverRun.repository.full_name", "evil/repo"), ("driverJobs.0.conclusion", "failure"),
+    ("driverJobs.0.run_id", 801), ("driverJobs.0.run_attempt", 2),
+    ("originalRun.conclusion", "success"), ("originalRun.event", "workflow_dispatch"),
+    ("originalRun.run_attempt", 2), ("originalRun.pull_requests.0.base.sha", "aa"*20),
+    ("originalJobs.2.steps.2.conclusion", "success"), ("originalJobs.1.conclusion", "failure"),
+    ("check.app.id", 123), ("check.app.slug", "impostor"), ("check.conclusion", "failure"),
+    ("check.external_id", "forged"), ("canonicalCheck.app.id", 1),
+    ("canonicalCheck.id", 99), ("comment.id", 99), ("comment.user.type", "User"),
+    ("comment.body", "forged"), ("ledgerComment.user.type", "User"),
+    ("receipt.original.artifacts.claim.id", 0), ("receipt.recovery.provider_calls", 1),
+    ("receipt.extra", True), ("receipt.original.head_sha", "AA"*20),
+])
+def test_receipt_rejects_broken_binding(field, value):
+    facts = facts_fixture()
+    cursor = facts
+    parts = field.split(".")
+    for part in parts[:-1]:
+        cursor = cursor[int(part)] if isinstance(cursor, list) else cursor[part]
+    cursor[parts[-1]] = value
+    assert not node_validate(facts)
+
+
+def test_receipt_binds_only_finalized_entry_and_allows_later_handoff():
+    facts = facts_fixture()
+    line = facts["ledgerComment"]["body"].splitlines()[1]
+    ledger = json.loads(line[len("<!-- automation-budget-state:"):-4])
+    ledger["handoff"] = {"reason": "later handoff 한글😀", "run_id": 999}
+    prefix = facts["ledgerComment"]["body"].splitlines()[0] + "\n<!-- automation-budget-state:"
+    facts["ledgerComment"]["body"] = prefix + compact(ledger) + " -->"
+    assert node_validate(facts)
+    ledger["invocations"][0]["elapsed_seconds"] += 1
+    facts["ledgerComment"]["body"] = prefix + compact(ledger) + " -->"
+    assert not node_validate(facts)
+
+
+def test_duplicate_json_receipt_keys_are_rejected():
+    facts = facts_fixture()
+    facts["check"]["output"]["text"] = facts["check"]["output"]["text"].replace('"schema":1', '"schema":1,"schema":1')
+    assert not node_validate(facts)
+
+
+def test_python_canonical_json_matches_unicode_and_numeric_keys():
+    value = {"z": "한글😀\u007f", "20": 1, "3": 2, "nested": {"b": 2, "a": 1}}
+    result = subprocess.run(["node", "-e", "process.stdout.write(require(process.argv[1]).canonicalJson(JSON.parse(process.argv[2])))",
+        str(HELPER), json.dumps(value)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == compact(value)
+
+
+def test_quality_filtered_finalized_entry_is_valid_when_exactly_bound():
+    facts = facts_fixture()
+    prefix = '<!-- automation-budget-state:'
+    ledger = json.loads(facts['ledgerComment']['body'].splitlines()[1][len(prefix):-4])
+    ledger['invocations'][0]['outcome'] = 'quality_filtered'
+    facts['ledgerComment']['body'] = '<!-- automation:review-invocation-budget:opencode:v1 -->\n' + prefix + compact(ledger) + ' -->'
+    facts['receipt']['original']['finalized_invocation_sha256'] = digest(compact(ledger['invocations'][0]))
+    facts['check']['output']['text'] = '<!-- automation-opencode-recovery:' + compact(facts['receipt']) + ' -->'
+    assert node_validate(facts)
+
+
+DISCOVER_SCRIPT = r'''
+const fs = require('fs');
+const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+const f = input.facts, calls = [];
+const reply = (name, params, data) => {
+  calls.push([name, params]);
+  if (input.fail === name) throw new Error('unavailable');
+  return {data};
+};
+const github = {rest: {
+  actions: {
+    listWorkflowRunsForRepo: async (p) => reply('runs', p, {workflow_runs: input.runs || [f.driverRun]}),
+    getWorkflowRunAttempt: async (p) => reply('attempt', p,
+      p.run_id === 800 ? (input.driverAttempt || f.driverRun) : f.originalRun),
+    listJobsForWorkflowRunAttempt: async (p) => {
+      const jobs = p.run_id === 800 ? f.driverJobs : f.originalJobs;
+      return reply('jobs', p, {total_count: input.jobsCount ?? jobs.length, jobs});
+    },
+  },
+  checks: {listForRef: async (p) => {
+    const checks = p.check_name === 'automation/opencode-finalization-recovery'
+      ? (input.checks || [f.check]) : [f.canonicalCheck];
+    return reply('checks', p, {total_count: input.checkCount ?? checks.length, check_runs: checks});
+  }},
+}};
+(async () => {
+  try {
+    const records = await require(process.argv[1]).authenticateRecovery({github, repository:'example/repo', pr:7,
+      comments: input.comments || [f.comment, f.ledgerComment]});
+    process.stdout.write(JSON.stringify({records, calls}));
+  } catch (error) { process.stdout.write(JSON.stringify({error: error.message, calls})); }
+})();
+'''
+
+
+def discover(facts=None, **options):
+    result = subprocess.run(['node', '-e', DISCOVER_SCRIPT, str(HELPER)],
+        input=json.dumps(dict(facts=facts or facts_fixture(), **options)), capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_server_discovery_authenticates_original_generation():
+    result = discover()
+    assert 'error' not in result, result
+    assert len(result['records']) == 1
+    record = result['records'][0]
+    assert record['comment']['id'] == 902 and record['attestationId'] == 903
+    assert record['state']['run_id'] == 700 and record['state']['run_attempt'] == 1
+    assert result['calls'][0] == ['runs', dict(owner='example', repo='repo', event='workflow_dispatch', per_page=100, page=1)]
+    assert [c[1]['run_id'] for c in result['calls'] if c[0] == 'attempt'] == [800, 700]
+
+
+@pytest.mark.parametrize('kind', ['runs', 'checks', 'attempt', 'jobs'])
+def test_server_api_uncertainty_fails_closed(kind):
+    result = discover(fail=kind)
+    assert 'error' in result and 'unavailable' in result['error']
+
+
+def test_comments_never_seed_recovery_run_discovery():
+    result = discover(runs=[])
+    assert result.get('records') == [] and len(result['calls']) == 1
+
+
+@pytest.mark.parametrize('conclusion', ['failure', 'cancelled'])
+def test_completed_unsuccessful_exact_driver_is_untrusted(conclusion):
+    run = facts_fixture()['driverRun']
+    run['conclusion'] = conclusion
+    assert discover(driverAttempt=run).get('records') == []
+
+
+def test_pending_exact_driver_fails_closed():
+    run = facts_fixture()['driverRun']
+    run['status'] = 'in_progress'
+    assert 'error' in discover(driverAttempt=run)
+
+
+@pytest.mark.parametrize('option', ['jobsCount', 'checkCount'])
+def test_server_pages_are_bounded(option):
+    assert 'error' in discover(**{option: 101})
+
+
+def test_server_discovery_rejects_ambiguous_ledgers():
+    f = facts_fixture()
+    other = dict(f['ledgerComment'], id=999)
+    result = discover(f, comments=[f['comment'], f['ledgerComment'], other])
+    assert 'error' in result
+
+
+def test_server_discovery_ignores_unbound_receipts_before_original_lookup():
+    f = facts_fixture()
+    f['check']['app']['id'] = 99
+    result = discover(f)
+    assert result.get('records') == []
+    assert not any(c[0] == 'attempt' for c in result['calls'])
+
+
+def test_prepare_reuses_authenticated_recovered_comment(tmp_path):
+    from test_review_workflow_logic import _run_opencode_ctx
+    f = facts_fixture()
+    output = _run_opencode_ctx(tmp_path, [f['comment'], f['ledgerComment']],
+        check_runs=[f['canonicalCheck'], f['check']], workflow_runs=[f['originalRun'], f['driverRun']],
+        run_jobs_by_attempt={'700:1': f['originalJobs'], '800:1': f['driverJobs']})
+    assert 'previous_sha=' + f['receipt']['original']['head_sha'] in output
+    assert 'previous_full_hash=' + f['receipt']['original']['full_diff_sha256'] in output
+
+
+def test_prepare_failed_original_without_receipt_remains_untrusted(tmp_path):
+    from test_review_workflow_logic import _run_opencode_ctx
+    f = facts_fixture()
+    output = _run_opencode_ctx(tmp_path, [f['comment'], f['ledgerComment']],
+        check_runs=[f['canonicalCheck']], workflow_runs=[f['originalRun']],
+        run_jobs_by_attempt={'700:1': f['originalJobs']})
+    assert 'previous_sha=' + f['receipt']['original']['head_sha'] not in output
+
+
+def test_live_canonicalizer_respects_recovered_original_generation(tmp_path):
+    from test_review_workflow_logic import _run_opencode_canonicalize
+    f = facts_fixture()
+    calls = _run_opencode_canonicalize(tmp_path, [], [f['comment'], f['ledgerComment']],
+        check_runs=[f['canonicalCheck'], f['check']], workflow_runs=[f['originalRun'], f['driverRun']],
+        run_jobs_by_attempt={'700:1': f['originalJobs'], '800:1': f['driverJobs']}, run_id='42')
+    assert not [c for c in calls if c[0] in {'create', 'update', 'delete', 'create-check', 'update-check'}]
+    assert any(c[0] == 'list-runs' and c[1].get('event') == 'workflow_dispatch' for c in calls)
+
+
+def loader_script():
+    import yaml
+    workflow = yaml.safe_load((ROOT / '.github/workflows/opencode-auto-review.yml').read_text())
+    steps = workflow['jobs']['opencode-prepare']['steps']
+    matches = [s for s in steps if s.get('id') == 'load-recovery-helper']
+    assert len(matches) == 1, 'trusted recovery helper loader must exist'
+    return matches[0]['with']['script']
+
+
+def run_loader(tmp_path, **overrides):
+    import base64
+    f = facts_fixture()
+    source = HELPER.read_bytes()
+    data = dict(type='file', path='.github/actions/recover-opencode-review/receipt.js',
+                encoding='base64', size=len(source), content=base64.b64encode(source).decode())
+    data.update(overrides)
+    script = r'''
+const fs = require('fs');
+const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+const calls = [];
+const context = {repo: {owner:'example', repo:'repo'}, runId:700};
+const github = {rest: {
+ actions: {getWorkflowRunAttempt: async p => { calls.push(['attempt',p]); return {data:input.run}; }},
+ repos: {getContent: async p => { calls.push(['content',p]); return {data:input.content}; }},
+}};
+(async () => {
+ try { await (new Function('github','context','require', 'return (async () => {' + input.script + '})();'))(github,context,require);
+ process.stdout.write(JSON.stringify({calls}));
+ } catch(e) { process.stdout.write(JSON.stringify({error:e.message,calls})); }
+})();
+'''
+    import os
+    result = subprocess.run(['node', '-e', script], input=json.dumps(dict(run=f['originalRun'], content=data, script=loader_script())),
+        capture_output=True, text=True, env=dict(os.environ, RUNNER_TEMP=str(tmp_path), GITHUB_RUN_ATTEMPT='1'))
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_loader_fetches_exact_server_central_sha_and_writes_private_regular_file(tmp_path):
+    result = run_loader(tmp_path)
+    assert 'error' not in result, result
+    target = tmp_path / 'opencode-recovery-receipt.js'
+    assert target.read_bytes() == HELPER.read_bytes()
+    assert target.stat().st_mode & 0o777 == 0o600
+    assert result['calls'][1][1]['ref'] == '75' * 20
+    assert result['calls'][1][1]['owner'] == 'jhw7500'
+
+
+@pytest.mark.parametrize('overrides', [dict(type='symlink'), dict(path='evil.js'), dict(encoding='utf8'),
+    dict(size=1000001), dict(content='!!!')])
+def test_loader_rejects_untrusted_content(tmp_path, overrides):
+    assert 'error' in run_loader(tmp_path, **overrides)
+    assert not (tmp_path / 'opencode-recovery-receipt.js').exists()
+
+
+def test_live_recovered_review_supports_zero_provider_call_reuse(tmp_path):
+    from test_review_workflow_logic import _run_opencode_canonicalize, _single_mutation_body
+    f = facts_fixture(full_hash=digest("TRUSTED FULL DIFF\n"))
+    calls = _run_opencode_canonicalize(tmp_path, [f['comment'], f['ledgerComment']], [f['comment'], f['ledgerComment']],
+        check_runs=[f['canonicalCheck'], f['check']], workflow_runs=[f['originalRun'], f['driverRun']],
+        run_jobs_by_attempt={'700:1': f['originalJobs'], '800:1': f['driverJobs']},
+        run_id='750', outcome='skipped', diff_mode='unchanged', unchanged_since_previous='true')
+    body = _single_mutation_body(calls)
+    state = json.loads(body.splitlines()[2][len('<!-- automation-state:'):-4])
+    assert state['attempt_status'] == 'success' and state['diff_mode'] == 'unchanged'
+    assert state['run_id'] == 750  # The later recovery driver (800) is never the review generation.
+    assert '### New findings\nNone' in body
+    assert ['output', 'publication_succeeded', 'true'] in calls
+
+
+def test_exact_invocation_keys_cannot_be_folded_into_comma_key():
+    f = facts_fixture()
+    prefix = '<!-- automation-budget-state:'
+    ledger = json.loads(f['ledgerComment']['body'].splitlines()[1][len(prefix):-4])
+    e = ledger['invocations'][0]
+    e['effort,elapsed_seconds'] = e.pop('effort')
+    e.pop('elapsed_seconds')
+    f['ledgerComment']['body'] = '<!-- automation:review-invocation-budget:opencode:v1 -->\n' + prefix + compact(ledger) + ' -->'
+    f['receipt']['original']['finalized_invocation_sha256'] = digest(compact(e))
+    f['check']['output']['text'] = '<!-- automation-opencode-recovery:' + compact(f['receipt']) + ' -->'
+    assert not node_validate(f)
+
+
+def test_missing_exact_driver_job_fails_closed():
+    f = facts_fixture()
+    f['driverJobs'] = []
+    result = discover(f)
+    assert 'error' in result and 'driver job' in result['error']
+
+
+@pytest.mark.parametrize('record', ['driverRun', 'originalRun', 'driverJobs'])
+@pytest.mark.parametrize('conclusion', [None, '', 'unknown-result'])
+def test_unresolved_terminal_conclusion_fails_closed(record, conclusion):
+    f = facts_fixture()
+    value = f[record][0] if record == 'driverJobs' else f[record]
+    value['conclusion'] = conclusion
+    assert 'error' in discover(f)
+
+
+@pytest.mark.parametrize('missing', [0, 1, 2])
+@pytest.mark.parametrize('kind', ['job', 'step', 'job-null', 'job-empty', 'step-null', 'step-empty'])
+def test_missing_original_job_prevents_live_mutations(tmp_path, missing, kind):
+    from test_review_workflow_logic import _run_opencode_canonicalize
+    f = facts_fixture()
+    if kind == 'job':
+        f['originalJobs'].pop(missing)
+    elif kind == 'step':
+        f['originalJobs'][missing]['steps'].pop(0)
+    elif kind.startswith('job-'):
+        f['originalJobs'][missing]['conclusion'] = None if kind.endswith('null') else ''
+    else:
+        f['originalJobs'][missing]['steps'][0]['conclusion'] = None if kind.endswith('null') else ''
+    result = discover(f)
+    assert 'original job' in result.get('error', '')
+    calls = _run_opencode_canonicalize(tmp_path, [], [f['comment'], f['ledgerComment']],
+        check_runs=[f['canonicalCheck'], f['check']], workflow_runs=[f['originalRun'], f['driverRun']],
+        run_jobs_by_attempt={'700:1': f['originalJobs'], '800:1': f['driverJobs']},
+        run_id='42', expect_error=True)
+    assert not [c for c in calls if c[0] in {'create', 'update', 'delete', 'create-check', 'update-check'}]
+
+
+def test_noncanonical_job_cannot_hide_a_second_failed_finalizer():
+    f = facts_fixture()
+    f['originalJobs'][0]['steps'].append(dict(name='Finalize OpenCode review budget', status='completed', conclusion='failure'))
+    assert not node_validate(f)
+
+
+@pytest.mark.parametrize('job', [0, 1, 2])
+def test_receipt_requires_original_producer_step_order(job):
+    f = facts_fixture()
+    f['originalJobs'][job]['steps'].reverse()
+    assert not node_validate(f)
+
+
+def test_original_workflow_head_may_differ_from_reviewed_head():
+    f = facts_fixture()
+    workflow_head = '98' * 20
+    f['receipt']['original']['workflow_head'] = workflow_head
+    f['originalRun']['head_sha'] = workflow_head
+    f['canonicalCheck']['head_sha'] = workflow_head
+    a = json.loads(f['canonicalCheck']['output']['text'][len('<!-- automation-attestation:'):-4])
+    a['workflow_head'] = workflow_head
+    f['canonicalCheck']['output']['text'] = '<!-- automation-attestation:' + compact(a) + ' -->'
+    f['check']['output']['text'] = '<!-- automation-opencode-recovery:' + compact(f['receipt']) + ' -->'
+    assert node_validate(f)
+    assert len(discover(f).get('records', [])) == 1
+
+
+def test_matched_receipt_candidates_are_bounded():
+    f = facts_fixture()
+    checks = [dict(f['check'], id=10000+i) for i in range(41)]
+    result = discover(f, checks=checks)
+    assert 'candidate limit' in result.get('error', '')
+    assert not any(c[0] == 'attempt' for c in result['calls'])
+
+
+def test_recent_recovery_selection_is_bounded_to_twenty():
+    f = facts_fixture()
+    runs = [dict(f['driverRun'], id=800+i, head_sha=f'{i+1:040x}') for i in range(21)]
+    result = discover(f, runs=runs)
+    assert result.get('records') == []
+    assert len([c for c in result['calls'] if c[0] == 'checks']) == 20
+
+
+def test_clean_normal_prepare_does_not_query_recovery(tmp_path):
+    from test_review_workflow_logic import _run_opencode_ctx
+    f = facts_fixture()
+    f['originalRun']['conclusion'] = 'success'
+    f['originalJobs'][2]['conclusion'] = 'success'
+    f['originalJobs'][2]['steps'][2]['conclusion'] = 'success'
+    output = _run_opencode_ctx(tmp_path, [f['comment']], check_runs=[f['canonicalCheck']],
+        workflow_runs=[f['originalRun']], run_jobs_by_attempt={'700:1': f['originalJobs']})
+    assert 'previous_sha=' + f['receipt']['original']['head_sha'] in output
+    assert 'event=workflow_dispatch' not in (tmp_path / 'gh-calls.log').read_text()
+
+
+def test_unauthenticated_recovery_pending_driver_prevents_live_writes(tmp_path):
+    from test_review_workflow_logic import _run_opencode_canonicalize
+    f = facts_fixture()
+    pending = dict(f['driverRun'], status='in_progress', conclusion=None)
+    calls = _run_opencode_canonicalize(tmp_path, [], [f['comment'], f['ledgerComment']],
+        check_runs=[f['canonicalCheck'], f['check']], workflow_runs=[f['originalRun'], f['driverRun']],
+        workflow_run_attempts=[f['originalRun'], pending],
+        run_jobs_by_attempt={'700:1': f['originalJobs'], '800:1': f['driverJobs']}, run_id='900', expect_error=True)
+    assert not [c for c in calls if c[0] in {'create', 'update', 'delete', 'create-check', 'update-check'}]
+
+
+@pytest.mark.parametrize('record', ['comment', 'ledgerComment'])
+def test_foreign_bot_identity_is_rejected(record):
+    f = facts_fixture()
+    f[record]['user']['login'] = 'foreign-bot[bot]'
+    assert not node_validate(f)
+
+
+def test_recovery_cannot_bind_a_different_prepared_attempt():
+    f = facts_fixture()
+    o = f['receipt']['original']
+    o['run_attempt'] = 2
+    f['originalRun']['run_attempt'] = 2
+    for job in f['originalJobs']:
+        job['run_attempt'] = 2
+    lines = f['comment']['body'].splitlines()
+    state = json.loads(lines[2][len('<!-- automation-state:'):-4])
+    state['run_attempt'] = 2
+    lines[2] = '<!-- automation-state:' + compact(state) + ' -->'
+    f['comment']['body'] = '\n'.join(lines)
+    o['body_sha256'], o['state_sha256'] = digest(f['comment']['body']), digest(compact(state))
+    a = json.loads(f['canonicalCheck']['output']['text'][len('<!-- automation-attestation:'):-4])
+    a.update(run_attempt=2, body_sha256=o['body_sha256'], state_sha256=o['state_sha256'])
+    f['canonicalCheck']['output']['text'] = '<!-- automation-attestation:' + compact(a) + ' -->'
+    f['canonicalCheck']['external_id'] = f['canonicalCheck']['external_id'].replace(':700:1:', ':700:2:')
+    ledger = json.loads(f['ledgerComment']['body'].splitlines()[1][len('<!-- automation-budget-state:'):-4])
+    ledger['invocations'][0]['run_attempt'] = 2
+    o['finalized_invocation_sha256'] = digest(compact(ledger['invocations'][0]))
+    f['ledgerComment']['body'] = '<!-- automation:review-invocation-budget:opencode:v1 -->\n<!-- automation-budget-state:' + compact(ledger) + ' -->'
+    f['check']['external_id'] = f['check']['external_id'].replace(':700:1:', ':700:2:')
+    f['check']['output']['text'] = '<!-- automation-opencode-recovery:' + compact(f['receipt']) + ' -->'
+    assert not node_validate(f)
+
+
+def test_receipt_requires_compact_single_line_json():
+    f = facts_fixture()
+    f['check']['output']['text'] = '<!-- automation-opencode-recovery:' + json.dumps(f['receipt']) + ' -->'
+    assert not node_validate(f)
+
+
+def test_immutable_server_path_is_independent_from_named_server_ref():
+    f = facts_fixture(pinned_original=True)
+    assert node_validate(f)
+    assert len(discover(f).get('records', [])) == 1
+
+
+def test_original_tag_path_remains_exact_server_provenance():
+    assert node_validate(facts_fixture(pinned_original=False))
+
+
+def test_original_named_ref_mismatch_is_rejected():
+    f = facts_fixture()
+    f['originalRun']['referenced_workflows'][0]['ref'] = 'refs/tags/changed'
+    assert not node_validate(f)

--- a/tests/test_opencode_recovery_transport.py
+++ b/tests/test_opencode_recovery_transport.py
@@ -1,0 +1,310 @@
+"""Recovery transport tests: real evidence/replay/transition, only HTTP is simulated."""
+import base64
+import copy
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from opencode_recovery_fixtures import original_bundle, encode
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / ".github/actions/recover-opencode-review"
+sys.path.insert(0, str(HELPER))
+
+
+@pytest.fixture
+def transport():
+    import transport as module
+    return module
+
+
+class FakeAPI:
+    def __init__(self, bundle):
+        self.bundle = bundle
+        self.comments = copy.deepcopy([bundle["ledger_comment"], bundle["canonical_comment"]])
+        self.checks = [copy.deepcopy(bundle["original_check"])]
+        self.driver = {"id": 800, "run_attempt": 1, "head_sha": "e" * 40,
+            "status": "in_progress", "conclusion": None, "event": "workflow_dispatch",
+            "repository": {"full_name": "example/repo"},
+            "path": ".github/workflows/opencode-auto-review.yml",
+            "referenced_workflows": [{"path": "jhw7500/automation/.github/workflows/"
+                "opencode-recover-finalization.yml@" + "f" * 40, "sha": "f" * 40}]}
+        self.calls = []
+        self.patch_mode = "ok"
+        self.post_mode = "ok"
+        self.failed_patch = False
+        self.timeline = []
+        self.permissions = {}
+        self.before_patch = None
+        self.pr_reads = 0
+
+    def request(self, method, path, payload=None):
+        self.calls.append((method, path, copy.deepcopy(payload)))
+        route = path.split("?")[0]
+        b = self.bundle
+        if method == "PATCH":
+            self.failed_patch = True
+            if self.patch_mode in ("ok", "committed_timeout"):
+                self.comments[0]["body"] = payload["body"]
+            elif self.patch_mode == "conflicting_timeout":
+                self.comments[0]["body"] += "\nforeign-write"
+            if self.patch_mode != "ok":
+                raise TimeoutError("simulated uncertain PATCH")
+            return copy.deepcopy(self.comments[0])
+        if method == "POST":
+            check = dict(payload, id=1000, app={"id": 15368, "slug": "github-actions"})
+            check["output"] = dict(payload["output"], annotations_count=0,
+                annotations_url="https://api.github.com/repos/example/repo/check-runs/1000/annotations")
+            if self.post_mode != "unchanged_timeout":
+                self.checks.append(check)
+            if self.post_mode != "ok":
+                raise TimeoutError("simulated uncertain POST")
+            return copy.deepcopy(check)
+        if route.endswith("/pulls/52"):
+            self.pr_reads += 1
+            if self.before_patch and self.pr_reads >= 2:
+                self.before_patch(self)
+            return copy.deepcopy(b["pr"])
+        if route.endswith("/issues/52/comments"):
+            if self.failed_patch and self.patch_mode == "unavailable_timeout":
+                raise TimeoutError("simulated unavailable readback")
+            return copy.deepcopy(self.comments)
+        if "/issues/comments/" in route:
+            if self.failed_patch and self.patch_mode == "unavailable_timeout":
+                raise TimeoutError("simulated unavailable readback")
+            return copy.deepcopy(next(c for c in self.comments if c["id"] == int(route.rsplit("/", 1)[1])))
+        if route.endswith("/issues/52/timeline"):
+            return copy.deepcopy(self.timeline)
+        if "/collaborators/" in route:
+            login = route.split("/collaborators/")[1].split("/")[0]
+            return {"permission": self.permissions[login], "user": {"login": login}}
+        if route.endswith("/actions/runs"):
+            event = "workflow_dispatch" if "workflow_dispatch" in path else "pull_request"
+            runs = [self.driver] if event == "workflow_dispatch" else b["history"]["runs"]
+            return {"total_count": len(runs), "workflow_runs": copy.deepcopy(runs)}
+        if re.search(r"/actions/runs/\d+/attempts/\d+$", route):
+            run_id = int(route.split("/runs/")[1].split("/")[0])
+            return copy.deepcopy(self.driver if run_id == 800 else b["original_run"])
+        if route.endswith("/jobs"):
+            if "/800/" in route:
+                jobs = [{"id": 1201, "name": "opencode-recovery / opencode-recover-finalization", "run_id": 800,
+                    "run_attempt": 1, "status": self.driver["status"], "conclusion": self.driver["conclusion"], "steps": []}]
+            else:
+                jobs = b["original_jobs"]
+            return {"total_count": len(jobs), "jobs": copy.deepcopy(jobs)}
+        if route.endswith("/check-runs"):
+            head = route.split("/commits/")[1].split("/")[0]
+            checks = [c for c in self.checks if c["head_sha"] == head]
+            if "check_name=" in path:
+                from urllib.parse import parse_qs, urlsplit
+                name = parse_qs(urlsplit(path).query)["check_name"][0]
+                checks = [c for c in checks if c["name"] == name]
+            return {"total_count": len(checks), "check_runs": copy.deepcopy(checks)}
+        if "/check-runs/" in route:
+            return copy.deepcopy(next(c for c in self.checks if c["id"] == int(route.rsplit("/", 1)[1])))
+        if route.endswith("/artifacts") and "/runs/" in route:
+            values = [copy.deepcopy(a["metadata"]) for a in b["artifacts"].values()]
+            return {"total_count": len(values), "artifacts": values}
+        if "/actions/artifacts/" in route:
+            return copy.deepcopy(next(a["metadata"] for a in b["artifacts"].values()
+                                      if a["metadata"]["id"] == int(route.rsplit("/", 1)[1])))
+        if "/contents/" in route:
+            name = route.split("/contents/")[1]
+            return {"type": "file", "path": name, "encoding": "base64",
+                "size": len(b["workflow_source"].encode()),
+                "content": base64.b64encode(b["workflow_source"].encode()).decode()}
+        raise AssertionError((method, path))
+
+    def download(self, path):
+        self.calls.append(("DOWNLOAD", path, None))
+        identifier = int(path.split("/artifacts/")[1].split("/")[0])
+        return next(a["payload"] for a in self.bundle["artifacts"].values()
+                    if a["metadata"]["id"] == identifier)
+
+    @property
+    def patches(self):
+        return [c for c in self.calls if c[0] == "PATCH"]
+
+    @property
+    def posts(self):
+        return [c for c in self.calls if c[0] == "POST"]
+
+
+def execute(module, bundle, api):
+    target = module.RecoveryTarget(**bundle["target"])
+    return module.recover(target, api, bundle["workspace"], driver_run_id=800,
+                          driver_run_attempt=1, central_sha="f" * 40)
+
+
+@pytest.mark.parametrize("patch_mode", ["ok", "committed_timeout"])
+def test_finalizes_original_once_after_normal_or_lost_patch_response(tmp_path, transport, patch_mode):
+    bundle = original_bundle(tmp_path)
+    api = FakeAPI(bundle)
+    api.patch_mode = patch_mode
+    result = execute(transport, bundle, api)
+    assert result["decision"] == "finalized"
+    assert result["provider_calls"] == 0
+    assert len(api.patches) == len(api.posts) == 1
+    state = transport.budget.parse_ledger(api.comments[0]["body"], repository="example/repo", pr=52, reviewer="opencode")
+    assert len(state.invocations) == 1
+    item = state.invocations[0]
+    assert (item.run_id, item.run_attempt, item.call_count, item.elapsed_seconds, item.round_number) == (700, 1, 1, 45, 1)
+    receipt = transport.parse_receipt(api.checks[-1])
+    assert receipt["original"]["run_id"] == 700
+    assert receipt["recovery"]["run_id"] == 800
+    assert receipt["recovery"]["provider_calls"] == 0
+    assert api.bundle["original_run"]["conclusion"] == "failure"
+
+
+@pytest.mark.parametrize("mode", ["unchanged_timeout", "conflicting_timeout", "unavailable_timeout"])
+def test_uncertain_patch_never_blindly_retries_or_publishes_receipt(tmp_path, transport, mode):
+    b = original_bundle(tmp_path)
+    api = FakeAPI(b)
+    api.patch_mode = mode
+    with pytest.raises(transport.RecoveryError):
+        execute(transport, b, api)
+    assert len(api.patches) == 1
+    assert not api.posts
+
+
+@pytest.mark.parametrize("mode,success", [("committed_timeout", True), ("unchanged_timeout", False)])
+def test_lost_receipt_response_is_resolved_without_duplicate_post(tmp_path, transport, mode, success):
+    b = original_bundle(tmp_path)
+    api = FakeAPI(b)
+    api.post_mode = mode
+    if success:
+        assert execute(transport, b, api)["decision"] == "finalized"
+    else:
+        with pytest.raises(transport.RecoveryError):
+            execute(transport, b, api)
+    assert len(api.patches) == len(api.posts) == 1
+
+
+@pytest.mark.parametrize("change", ["head", "base", "canonical", "ledger", "check"])
+def test_prewrite_drift_refuses_without_any_write(tmp_path, transport, change):
+    b = original_bundle(tmp_path)
+    api = FakeAPI(b)
+    def drift(a):
+        if change in ("head", "base"):
+            b["pr"][change]["sha"] = "9" * 40
+        elif change == "canonical":
+            a.comments[1]["body"] += "\nchanged"
+        elif change == "ledger":
+            a.comments[0]["body"] += "\nchanged"
+        else:
+            a.checks[0]["conclusion"] = "failure"
+    api.before_patch = drift
+    with pytest.raises(transport.RecoveryError):
+        execute(transport, b, api)
+    assert not api.patches and not api.posts
+
+
+def test_existing_completed_receipt_allows_noop_after_artifact_expiry(tmp_path, transport):
+    b = original_bundle(tmp_path)
+    api = FakeAPI(b)
+    execute(transport, b, api)
+    api.driver.update(status="completed", conclusion="success")
+    for artifact in b["artifacts"].values():
+        artifact["metadata"]["expired"] = True
+    api.calls.clear()
+    result = execute(transport, b, api)
+    assert result["decision"] == "already_recovered"
+    assert not api.patches and not api.posts
+    assert not any("artifacts" in path for _, path, _ in api.calls)
+
+
+def test_finalized_without_receipt_retries_only_receipt_publication(tmp_path, transport):
+    b = original_bundle(tmp_path)
+    api = FakeAPI(b)
+    api.post_mode = "unchanged_timeout"
+    with pytest.raises(transport.RecoveryError):
+        execute(transport, b, api)
+    api.calls.clear()
+    api.post_mode = "ok"
+    assert execute(transport, b, api)["decision"] == "finalized"
+    assert not api.patches and len(api.posts) == 1
+
+
+def test_current_workflow_uses_tokenless_recovery_discovery_during_replay(tmp_path, transport):
+    b = original_bundle(tmp_path)
+    b["workflow_source"] = (ROOT / ".github/workflows/opencode-auto-review.yml").read_text()
+    api = FakeAPI(b)
+    assert execute(transport, b, api)["decision"] == "finalized"
+    assert len(api.patches) == len(api.posts) == 1
+
+
+def test_current_history_authenticates_completed_receipt_from_server_facts(tmp_path, transport):
+    b = original_bundle(tmp_path)
+    b["workflow_source"] = (ROOT / ".github/workflows/opencode-auto-review.yml").read_text()
+    api = FakeAPI(b)
+    execute(transport, b, api)
+    api.driver.update(status="completed", conclusion="success")
+    api.calls.clear()
+    target = transport.RecoveryTarget(**b['target'])
+    bundle = transport.collect_evidence(target, api, b['workspace'], b['pr'], api.comments)
+    history = bundle['history']
+    # An already-recovered original is handled before replay by recover(). Check
+    # that the read-only history nevertheless supplies every verifier dependency.
+    assert transport.receipt_valid({'receipt': transport.parse_receipt(api.checks[-1]),
+        'check': api.checks[-1], 'driverRun': history['attempts']['800:1']['run'],
+        'driverJobs': history['attempts']['800:1']['jobs'],
+        'originalRun': history['attempts']['700:1']['run'],
+        'originalJobs': history['attempts']['700:1']['jobs'],
+        'canonicalCheck': b['original_check'], 'comment': api.comments[1],
+        'ledgerComment': api.comments[0]})
+    assert not api.patches and not api.posts
+
+
+@pytest.mark.parametrize('permission', ['write', 'maintain', 'admin', 'read'])
+def test_fresh_dismissal_permissions_are_preserved_in_finalized_ledger(tmp_path, transport, permission):
+    b = original_bundle(tmp_path)
+    api = FakeAPI(b)
+    api.timeline = [{"event": "commented", "id": 999, "actor": {"login": "maintainer"},
+        "body": "dismiss RVW-111111111111 resolved upstream"}]
+    api.permissions = {"maintainer": permission}
+    execute(transport, b, api)
+    state = transport.budget.parse_ledger(api.comments[0]["body"], repository="example/repo", pr=52, reviewer="opencode")
+    assert bool(state.dismissed_findings) == (permission != 'read')
+    assert len(api.patches) == 1
+
+
+@pytest.mark.parametrize('role', ['handoff', 'claim', 'candidate'])
+def test_expired_original_evidence_cannot_start_recovery(tmp_path, transport, role):
+    b = original_bundle(tmp_path)
+    b['artifacts'][role]['metadata']['expired'] = True
+    api = FakeAPI(b)
+    with pytest.raises(transport.RecoveryError):
+        execute(transport, b, api)
+    assert not api.patches and not api.posts
+
+
+def test_driver_requires_literal_immutable_central_reference(tmp_path, transport):
+    b = original_bundle(tmp_path)
+    api = FakeAPI(b)
+    api.driver['referenced_workflows'][0]['path'] = api.driver['referenced_workflows'][0]['path'].split('@')[0] + '@main'
+    with pytest.raises(transport.RecoveryError):
+        execute(transport, b, api)
+    assert not api.patches and not api.posts
+
+
+@pytest.mark.parametrize("field,value", [
+    ("event", "pull_request"), ("id", 801), ("run_attempt", 2),
+    ("head_sha", "bad"), ("path", "../wrong.yml"),
+])
+def test_wrong_driver_identity_cannot_write(tmp_path, transport, field, value):
+    b = original_bundle(tmp_path)
+    api = FakeAPI(b)
+    api.driver[field] = value
+    with pytest.raises(transport.RecoveryError):
+        execute(transport, b, api)
+    assert not api.patches and not api.posts
+
+
+@pytest.mark.parametrize("value", ["01", "0", "-1", "1.0", "1e2", " 1", "1\n", "9007199254740992"])
+def test_noncanonical_numeric_inputs_refused(transport, value):
+    with pytest.raises(transport.RecoveryError):
+        transport.positive_input(value)

--- a/tests/test_opencode_recovery_workflow.py
+++ b/tests/test_opencode_recovery_workflow.py
@@ -1,0 +1,118 @@
+"""Execute recovery driver validation and caller routing with no GitHub mutations."""
+import itertools
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def workflow(path):
+    return yaml.load((ROOT / path).read_text(), Loader=yaml.BaseLoader)
+
+
+def node(script, value):
+    result = subprocess.run(["node", "-e", script], input=json.dumps(value), text=True,
+                            capture_output=True, check=True, timeout=15)
+    return json.loads(result.stdout)
+
+
+@pytest.mark.parametrize("force,recover,partial", itertools.product([False, True], [False, True], range(16)))
+def test_recovery_dispatch_excludes_every_provider_route(force, recover, partial):
+    caller = workflow("examples/baseline-workflows/.github/workflows/opencode-auto-review.yml")
+    names = ["recovery_original_run_id", "recovery_original_run_attempt",
+             "recovery_expected_head_sha", "recovery_expected_base_sha"]
+    inputs = {"force_review": force, "recover_finalization": recover}
+    inputs.update({name: "present" if partial & (1 << index) else "" for index, name in enumerate(names)})
+    conditions = {name: caller["jobs"][name]["if"] for name in
+                  ["opencode-review", "opencode-recovery", "reject-conflicting-dispatch"]}
+    selected = node("""
+const f=JSON.parse(require('fs').readFileSync(0,'utf8'));
+const github={event_name:'workflow_dispatch'};
+const result=Object.entries(f.conditions).filter(([name,expression]) =>
+  new Function('github','inputs', 'return Boolean('+expression+');')(github,f.inputs)).map(([name])=>name);
+process.stdout.write(JSON.stringify(result));
+""", {"conditions": conditions, "inputs": inputs})
+    if recover or partial:
+        assert selected == ["reject-conflicting-dispatch" if force else "opencode-recovery"]
+    else:
+        assert selected == (["opencode-review"] if force else [])
+
+
+def driver_validation(**changes):
+    document = workflow(".github/workflows/opencode-recover-finalization.yml")
+    steps = document["jobs"]["opencode-recover-finalization"]["steps"]
+    script = steps[0]["with"]["script"]
+    env = {"RECOVERY_PR": "52", "ORIGINAL_RUN_ID": "700", "ORIGINAL_RUN_ATTEMPT": "1",
+        "EXPECTED_HEAD_SHA": "a" * 40, "EXPECTED_BASE_SHA": "b" * 40,
+        "GITHUB_RUN_ID": "800", "GITHUB_RUN_ATTEMPT": "1",
+        "GITHUB_REPOSITORY": "example/repo", "GITHUB_SERVER_URL": "https://github.com"}
+    run = {"id": 800, "run_attempt": 1, "status": "in_progress", "event": "workflow_dispatch",
+        "repository": {"full_name": "example/repo"}, "head_sha": "c" * 40,
+        "path": ".github/workflows/opencode-auto-review.yml",
+        "referenced_workflows": [{"path": "jhw7500/automation/.github/workflows/"
+            "opencode-recover-finalization.yml@" + "d" * 40, "sha": "d" * 40}]}
+    env.update(changes.get("env", {}))
+    run.update(changes.get("run", {}))
+    return node("""
+const f=JSON.parse(require('fs').readFileSync(0,'utf8')), outputs={}, calls=[];
+Object.assign(process.env,f.env);
+const github={rest:{actions:{getWorkflowRunAttempt:async(args)=>{calls.push(args);return {data:f.run}}}}};
+const AsyncFunction=Object.getPrototypeOf(async function(){}).constructor;
+new AsyncFunction('github','context','core',f.script)(github,{eventName:f.event,repo:{owner:'example',repo:'repo'}},
+ {setOutput:(k,v)=>outputs[k]=v})
+ .then(()=>process.stdout.write(JSON.stringify({outputs,calls})))
+ .catch(()=>process.stdout.write(JSON.stringify({refused:true,outputs,calls})));
+""", {"script": script, "env": env, "run": run, "event": changes.get("event", "workflow_dispatch")})
+
+
+def test_driver_uses_only_exact_server_resolved_central_sha():
+    result = driver_validation()
+    assert result["outputs"] == {"central_sha": "d" * 40}
+    assert result["calls"] == [{"owner": "example", "repo": "repo", "run_id": 800, "attempt_number": 1}]
+
+
+@pytest.mark.parametrize("env", [
+    {"RECOVERY_PR": "052"}, {"RECOVERY_PR": "1e2"}, {"ORIGINAL_RUN_ID": "0"},
+    {"ORIGINAL_RUN_ATTEMPT": "-1"}, {"EXPECTED_HEAD_SHA": "a" * 39},
+    {"EXPECTED_BASE_SHA": "A" * 40}, {"GITHUB_RUN_ATTEMPT": "2.0"},
+])
+def test_invalid_inputs_stop_before_server_lookup(env):
+    result = driver_validation(env=env)
+    assert result.get("refused") is True and not result["outputs"] and not result["calls"]
+
+
+@pytest.mark.parametrize("run", [
+    {"id": 801}, {"run_attempt": 2}, {"repository": {"full_name": "other/repo"}},
+    {"event": "pull_request"}, {"head_sha": "invalid"}, {"path": "../review.yml"},
+    {"referenced_workflows": []},
+    {"referenced_workflows": [{"path": "jhw7500/automation/.github/workflows/"
+      "opencode-recover-finalization.yml@main", "sha": "d" * 40}]},
+])
+def test_mismatched_server_driver_cannot_select_helper_checkout(run):
+    result = driver_validation(run=run)
+    assert result.get("refused") is True and not result["outputs"]
+
+
+def test_workflow_keeps_writer_serialization_and_isolated_trusted_source():
+    document = workflow(".github/workflows/opencode-recover-finalization.yml")
+    assert set(document["on"]) == {"workflow_call"}
+    assert document["concurrency"] == {
+        "group": "automation-opencode-auto-review-${{ github.repository }}-${{ inputs.pr_number }}",
+        "cancel-in-progress": "false"}
+    job = document["jobs"]["opencode-recover-finalization"]
+    assert job["permissions"] == {"actions": "read", "checks": "write", "contents": "read",
+                                 "issues": "write", "pull-requests": "read"}
+    trusted, target, recover = job["steps"][1:4]
+    assert trusted["with"]["repository"] == "jhw7500/automation"
+    assert trusted["with"]["ref"] == "${{ steps.driver.outputs.central_sha }}"
+    assert target["with"]["ref"] == "${{ inputs.expected_head_sha }}"
+    assert trusted["with"]["path"] != target["with"]["path"]
+    assert trusted["with"]["persist-credentials"] == target["with"]["persist-credentials"] == "false"
+    assert recover["working-directory"] == trusted["with"]["path"]
+    assert "secrets" not in document["on"]["workflow_call"]
+    caller = workflow("examples/baseline-workflows/.github/workflows/opencode-auto-review.yml")
+    assert "secrets" not in caller["jobs"]["opencode-recovery"]

--- a/tests/test_prepare_workflow_rollout.py
+++ b/tests/test_prepare_workflow_rollout.py
@@ -20,6 +20,7 @@ from scripts.prepare_workflow_rollout import (  # noqa: E402
     RolloutError,
     apply_render_plan,
     render_repository,
+    render_caller,
 )
 from scripts.workflow_catalog import load_catalog, load_fleet_config  # noqa: E402
 
@@ -124,7 +125,9 @@ def test_every_profile_renders_exactly_its_canonical_caller_bytes(
     for entry in selected:
         canonical_path = CANONICAL / entry.path.relative_to(".github")
         template = canonical_path.read_bytes()
-        assert template.count(b"@__AUTOMATION_COMMIT__") == 1
+        assert template.count(b"@__AUTOMATION_COMMIT__") == (
+            2 if entry.path.name == "opencode-auto-review.yml" else 1
+        )
         expected = template.replace(
             b"@__AUTOMATION_COMMIT__", f"@{COMMIT}".encode()
         )
@@ -316,6 +319,31 @@ def test_selected_optional_callers_are_created(tmp_path: Path) -> None:
     plan = render_profile(make_existing_repo(tmp_path / "repo"), "wlan-package")
     assert plan.after(".github/workflows/opencode.yml") is not None
     assert plan.after(".github/workflows/opencode-auto-review.yml") is not None
+
+
+def test_recovery_and_normal_callers_render_the_same_immutable_commit(tmp_path):
+    import yaml
+
+    plan = render_profile(make_existing_repo(tmp_path / "repo"), "wlan-package")
+    assert plan.status == "drift", plan.reason
+    jobs = yaml.safe_load(plan.after(".github/workflows/opencode-auto-review.yml"))["jobs"]
+    assert jobs["opencode-review"]["uses"] == (
+        "jhw7500/automation/.github/workflows/opencode-auto-review.yml@" + COMMIT
+    )
+    assert jobs["opencode-recovery"]["uses"] == (
+        "jhw7500/automation/.github/workflows/opencode-recover-finalization.yml@" + COMMIT
+    )
+    assert "secrets" not in jobs["opencode-recovery"]
+
+
+@pytest.mark.parametrize("replacement", ["opencode.yml", "gemini-auto-review.yml"])
+def test_recovery_render_rejects_foreign_second_target(replacement):
+    entry = next(e for e in CATALOG.callers if e.path.name == "opencode-auto-review.yml")
+    template = (CANONICAL / "workflows/opencode-auto-review.yml").read_bytes().replace(
+        b"opencode-recover-finalization.yml@", replacement.encode() + b"@"
+    )
+    with pytest.raises(RolloutError):
+        render_caller(template, entry, PROFILES["wlan-package"], COMMIT)
 
 
 def test_unselected_optional_caller_is_deleted(tmp_path: Path) -> None:

--- a/tests/test_review_invocation_budget_recovery.py
+++ b/tests/test_review_invocation_budget_recovery.py
@@ -1,0 +1,405 @@
+from dataclasses import replace
+
+import pytest
+
+from test_review_invocation_budget import (
+    FINDING_1,
+    HASH_1,
+    HASH_2,
+    HEAD_A,
+    HEAD_B,
+    ROUTES,
+    budget,
+    claim_provenances,
+    claimed_state,
+    finalize_request,
+    request,
+    valid_provenances,
+)
+
+
+def recovery_case():
+    state = claimed_state("opencode")
+    original_claim = state.invocations[0]
+    recovery_request = finalize_request(
+        reviewer="opencode",
+        calls=1,
+        elapsed=45,
+        outcome="success",
+        authenticated_review=budget.AuthenticatedReview(
+            True,
+            HEAD_A,
+            HASH_1,
+        ),
+    )
+    return state, original_claim, recovery_request
+
+
+def test_recovery_finalizes_the_original_invocation_without_appending_a_round():
+    state, original_claim, recovery_request = recovery_case()
+
+    result = budget.recover_finalize(
+        state,
+        original_claim,
+        recovery_request,
+        valid_provenances(state),
+    )
+
+    assert result.decision == "finalized"
+    assert result.state.invocations[0].run_attempt == 1
+    assert result.state.invocations[0].call_count == 1
+    assert result.state.invocations[0].elapsed_seconds == 45
+    assert len(result.state.invocations) == 1
+    assert result.allow_invocation is False
+    assert result.mutate_comment is True
+
+
+def test_recovery_preserves_authenticated_quality_filtered_outcome_and_findings():
+    state, original_claim, recovery_request = recovery_case()
+    recovery_request = replace(
+        recovery_request,
+        outcome="quality_filtered",
+        stop_reason="quality_filtered",
+        remaining_finding_ids=(FINDING_1,),
+    )
+
+    result = budget.recover_finalize(
+        state,
+        original_claim,
+        recovery_request,
+        valid_provenances(state),
+    )
+
+    assert result.decision == "finalized"
+    assert result.state.invocations[0].outcome == "quality_filtered"
+    assert result.state.invocations[0].remaining_finding_ids == (FINDING_1,)
+    assert len(result.state.invocations) == 1
+
+
+def test_identical_recovery_repeat_is_an_unchanged_successful_transition():
+    state, original_claim, recovery_request = recovery_case()
+    result = budget.recover_finalize(
+        state,
+        original_claim,
+        recovery_request,
+        valid_provenances(state),
+    )
+
+    repeat = budget.recover_finalize(
+        result.state,
+        original_claim,
+        recovery_request,
+        valid_provenances(result.state),
+    )
+
+    assert repeat.decision == "finalized"
+    assert repeat.stop_reason == "success"
+    assert repeat.state == result.state
+    assert repeat.round_number == 1
+    assert repeat.invocation_key == "700:1"
+    assert repeat.allow_invocation is False
+    assert repeat.mutate_comment is False
+
+
+def test_ordinary_finalize_still_refuses_a_repeat():
+    state, original_claim, recovery_request = recovery_case()
+    recovered = budget.recover_finalize(
+        state,
+        original_claim,
+        recovery_request,
+        valid_provenances(state),
+    )
+
+    repeated = budget.finalize(
+        recovered.state,
+        recovery_request,
+        valid_provenances(recovered.state),
+    )
+
+    assert repeated.decision == "state_invalid"
+    assert repeated.stop_reason == "invocation_not_claimed"
+    assert repeated.mutate_comment is False
+
+
+def test_provider_failure_is_outside_recovery_even_with_inherited_reuse_findings():
+    reuse_request = request(reviewer="opencode", diff_mode="unchanged", authenticated_review=budget.AuthenticatedReview(
+        True, HEAD_A, HASH_1, (FINDING_1,)))
+    reused = budget.claim(None, reuse_request, claim_provenances(None, reuse_request)).state
+    assert not reused.invocations
+    assert reused.handoff.remaining_finding_ids == (FINDING_1,)
+    next_request = request(reviewer="opencode", head=HEAD_B, full_hash=HASH_2, run_id=701)
+    state = budget.claim(reused, next_request, claim_provenances(reused, next_request)).state
+    recovery_request = finalize_request(reviewer="opencode", head=HEAD_B, full_hash=HASH_2,
+                                        run_id=701, outcome="provider_failure")
+    original = state.invocations[-1]
+    refused = budget.recover_finalize(state, original, recovery_request, valid_provenances(state))
+    assert refused.decision == "state_invalid"
+    assert refused.mutate_comment is False
+    first = budget.finalize(state, recovery_request, valid_provenances(state))
+    assert first.decision == "finalized"
+    assert first.state.invocations[-1].remaining_finding_ids == (FINDING_1,)
+    repeat = budget.recover_finalize(first.state, original, recovery_request,
+                                     valid_provenances(first.state))
+    assert repeat.decision == "state_invalid"
+    assert repeat.state == first.state
+    assert repeat.mutate_comment is False
+
+
+def test_recovery_requires_authenticated_success_before_any_finalization():
+    state, original, recovery_request = recovery_case()
+    result = budget.recover_finalize(state, original, replace(recovery_request,
+        authenticated_review=budget.AuthenticatedReview(False, None, None)), valid_provenances(state))
+    assert result.decision == "state_invalid"
+    assert result.state == state
+    assert result.mutate_comment is False
+
+
+def test_recovery_is_restricted_to_opencode():
+    state = claimed_state("claude")
+    original_claim = state.invocations[0]
+    recovery_request = finalize_request(reviewer="claude", calls=1, elapsed=45)
+
+    result = budget.recover_finalize(
+        state,
+        original_claim,
+        recovery_request,
+        valid_provenances(state),
+    )
+
+    assert result.decision == "state_invalid"
+    assert result.stop_reason == "recovery_reviewer_invalid"
+    assert result.state == state
+    assert result.mutate_comment is False
+
+
+@pytest.mark.parametrize(
+    ("change", "value"),
+    [
+        ("run_id", 701),
+        ("run_attempt", 2),
+        ("head_sha", HEAD_B),
+        ("full_diff_sha256", HASH_2),
+    ],
+)
+def test_recovery_rejects_request_identity_drift(change, value):
+    state, original_claim, recovery_request = recovery_case()
+
+    result = budget.recover_finalize(
+        state,
+        original_claim,
+        replace(recovery_request, **{change: value}),
+        valid_provenances(state),
+    )
+
+    assert result.decision == "state_invalid"
+    assert result.stop_reason == "recovery_request_mismatch"
+    assert result.state == state
+    assert result.mutate_comment is False
+
+
+@pytest.mark.parametrize(
+    ("change", "value"),
+    [
+        ("caller_workflow_path", ".github/workflows/other-caller.yml"),
+        ("referenced_workflow_sha", "e" * 40),
+        ("estimated_input_tokens", 49_999),
+        ("effort", "high"),
+    ],
+)
+def test_recovery_rejects_changed_original_claim_fields(change, value):
+    state, original_claim, recovery_request = recovery_case()
+
+    result = budget.recover_finalize(
+        state,
+        replace(original_claim, **{change: value}),
+        recovery_request,
+        valid_provenances(state),
+    )
+
+    assert result.decision == "state_invalid"
+    assert result.stop_reason == "original_claim_mismatch"
+    assert result.state == state
+    assert result.mutate_comment is False
+
+
+def test_recovery_rejects_an_original_invocation_with_a_newer_generation():
+    state, original_claim, recovery_request = recovery_case()
+    finalized = budget.finalize(
+        state,
+        recovery_request,
+        valid_provenances(state),
+    ).state
+    next_request = request(
+        reviewer="opencode",
+        head=HEAD_B,
+        full_hash=HASH_2,
+        run_id=701,
+    )
+    newer = budget.claim(
+        finalized,
+        next_request,
+        claim_provenances(finalized, next_request),
+    ).state
+
+    result = budget.recover_finalize(
+        newer,
+        original_claim,
+        recovery_request,
+        valid_provenances(newer),
+    )
+
+    assert result.decision == "state_invalid"
+    assert result.stop_reason == "newer_invocation_exists"
+    assert result.state == newer
+    assert result.mutate_comment is False
+
+
+def test_recovery_repeat_rejects_changed_original_immutable_fields():
+    state, original_claim, recovery_request = recovery_case()
+    recovered = budget.recover_finalize(
+        state,
+        original_claim,
+        recovery_request,
+        valid_provenances(state),
+    )
+
+    repeat = budget.recover_finalize(
+        recovered.state,
+        replace(original_claim, referenced_workflow_ref="refs/tags/v1.48"),
+        recovery_request,
+        valid_provenances(recovered.state),
+    )
+
+    assert repeat.decision == "state_invalid"
+    assert repeat.stop_reason == "original_claim_mismatch"
+    assert repeat.state == recovered.state
+    assert repeat.mutate_comment is False
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"call_count": 2},
+        {"elapsed_seconds": 46},
+        {"outcome": "provider_failure", "stop_reason": "provider_failure"},
+        {"stop_reason": "different_success_reason"},
+        {"remaining_finding_ids": (FINDING_1,)},
+        {"model_route": ROUTES["opencode"] + ("unexpected-fallback",)},
+        {"effort": "high"},
+    ],
+)
+def test_recovery_rejects_changed_finalization_details_on_repeat(changes):
+    state, original_claim, recovery_request = recovery_case()
+    recovered = budget.recover_finalize(
+        state,
+        original_claim,
+        recovery_request,
+        valid_provenances(state),
+    )
+
+    repeat = budget.recover_finalize(
+        recovered.state,
+        original_claim,
+        replace(recovery_request, **changes),
+        valid_provenances(recovered.state),
+    )
+
+    assert repeat.decision == "state_invalid"
+    assert repeat.stop_reason == "recovery_finalization_conflict"
+    assert repeat.state == recovered.state
+    assert repeat.mutate_comment is False
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"call_count": 2},
+        {"elapsed_seconds": 46},
+        {"outcome": "provider_failure", "stop_reason": "provider_failure"},
+        {"remaining_finding_ids": (FINDING_1,)},
+    ],
+)
+def test_recovery_repeat_rejects_changed_live_finalized_fields(changes):
+    state, original_claim, recovery_request = recovery_case()
+    recovered = budget.recover_finalize(
+        state,
+        original_claim,
+        recovery_request,
+        valid_provenances(state),
+    )
+    changed_entry = replace(recovered.state.invocations[0], **changes)
+    changed_handoff = replace(
+        recovered.state.handoff,
+        round_usage=((
+            changed_entry.round_number,
+            changed_entry.call_count,
+            changed_entry.estimated_input_tokens,
+            changed_entry.elapsed_seconds,
+        ),),
+        outcome=changed_entry.outcome,
+        stop_reason=changed_entry.stop_reason,
+        remaining_finding_ids=changed_entry.remaining_finding_ids,
+    )
+    changed_state = replace(
+        recovered.state,
+        invocations=(changed_entry,),
+        last_decision=replace(
+            recovered.state.last_decision,
+            stop_reason=changed_entry.stop_reason,
+        ),
+        handoff=changed_handoff,
+    )
+    budget.serialize_ledger(changed_state)
+
+    repeat = budget.recover_finalize(
+        changed_state,
+        original_claim,
+        recovery_request,
+        valid_provenances(changed_state),
+    )
+
+    assert repeat.decision == "state_invalid"
+    assert repeat.stop_reason == "recovery_finalization_conflict"
+    assert repeat.state == changed_state
+    assert repeat.mutate_comment is False
+
+
+def test_recovery_repeat_requires_live_original_run_provenance():
+    state, original_claim, recovery_request = recovery_case()
+    recovered = budget.recover_finalize(
+        state,
+        original_claim,
+        recovery_request,
+        valid_provenances(state),
+    )
+
+    repeat = budget.recover_finalize(
+        recovered.state,
+        original_claim,
+        recovery_request,
+        {},
+    )
+
+    assert repeat.decision == "state_invalid"
+    assert repeat.stop_reason == "provenance_mismatch"
+    assert repeat.state == recovered.state
+
+
+def test_recovery_rejects_malformed_live_state_without_mutating_it():
+    state, original_claim, recovery_request = recovery_case()
+    malformed = replace(
+        state,
+        invocations=(replace(state.invocations[0], call_count=1),),
+    )
+
+    result = budget.recover_finalize(
+        malformed,
+        original_claim,
+        recovery_request,
+        valid_provenances(state),
+    )
+
+    assert result.decision == "state_invalid"
+    assert result.stop_reason == "status_invalid"
+    assert result.state == malformed
+    assert result.mutate_comment is False

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -12620,6 +12620,7 @@ def _run_opencode_ctx(
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
     env["RUNNER_TEMP"] = str(runner_temp)
+    env["OPENCODE_RECOVERY_HELPER"] = str(ROOT / ".github/actions/recover-opencode-review/receipt.js")
     result = subprocess.run(
         ["bash", "-c", run], cwd=tmp_path, env=env, check=False,
         capture_output=True, text=True,
@@ -12755,7 +12756,9 @@ def test_opencode_collector_server_discovery_ignores_many_forged_receipt_ids(tmp
     assert f"previous_sha={attempt_head}" in text
     assert f"previous_full_hash={full_hash}" in text
     calls = (tmp_path / "gh-calls.log").read_text(encoding="utf-8").splitlines()
-    assert sum("/actions/runs --method GET" in call for call in calls) == 1
+    # Untrusted strict records also trigger one bounded, server-first recovery horizon.
+    assert sum("/actions/runs --method GET" in call and "event=pull_request" in call for call in calls) == 1
+    assert sum("/actions/runs --method GET" in call and "event=workflow_dispatch" in call for call in calls) == 1
     assert sum("/commits/" in call and "/check-runs --method GET" in call for call in calls) <= 20
     assert not any(re.search(r"/check-runs/[1-9][0-9]*", call) for call in calls)
     exact_attempts = [call for call in calls if re.search(r"/actions/runs/[1-9][0-9]*/attempts/[1-9][0-9]* --method GET", call)]
@@ -13968,6 +13971,7 @@ def _run_opencode_canonicalize(
         elif candidate_artifact_case == "tampered":
             candidate_path.write_bytes(b"\xff")
     env = {
+        "OPENCODE_RECOVERY_HELPER": str(ROOT / ".github/actions/recover-opencode-review/receipt.js"),
         "PR_NUMBER": "7",
         "RUN_URL": f"https://github.com/example/repo/actions/runs/{run_id}",
         "RUN_ID": run_id,
@@ -16384,7 +16388,9 @@ def test_opencode_many_new_v2_claims_are_quarantined_without_selecting_receipt_i
     assert len({comment["id"] for comment in forged} & quarantined) == 20
     assert len([call for call in calls if call[0] in {"update", "delete"}]) <= 42
     assert any(call[0] == "create-check" for call in calls)
-    assert sum(call[0] == "list-runs" for call in calls) <= 4
+    # Each transaction refresh has an ordinary and a recovery server horizon.
+    for event in ("pull_request", "workflow_dispatch"):
+        assert sum(call[0] == "list-runs" and call[1].get("event") == event for call in calls) <= 4
     assert not any(call[0] == "get-check" and call[1]["check_run_id"] in {
         900000 + comment["id"] for comment in forged
     } for call in calls)

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -32,6 +32,7 @@ from release_fixture_helpers import (
     restore_pre_v171_opencode_dismissals,
     restore_pre_v172_opencode_context_budget,
     restore_pre_v173_opencode_active_section_order,
+    restore_pre_v176_opencode_recovery,
     restore_pre_v170_opencode_finding_ids,
     restore_retired_manual_pr_review,
     restore_pre_v166_label_mismatch_decline,
@@ -40,6 +41,119 @@ from release_fixture_helpers import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+
+RECOVERY_RELEASE_FILES = (
+    ".github/actions/recover-opencode-review/evidence.py",
+    ".github/actions/recover-opencode-review/replay.js",
+    ".github/actions/recover-opencode-review/receipt.js",
+    ".github/actions/recover-opencode-review/transport.py",
+)
+
+
+@pytest.fixture
+def recovery_release_repo(tmp_path):
+    repo = tmp_path / "recovery-release"
+    repo.mkdir()
+    for relative in (*RELEASE_PATHS, *RECOVERY_RELEASE_FILES):
+        source, target = ROOT / relative, repo / relative
+        if target.exists():
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_dir():
+            shutil.copytree(source, target)
+        else:
+            shutil.copy2(source, target)
+    git(repo, "init", "-q")
+    git(repo, "config", "user.name", "Test")
+    git(repo, "config", "user.email", "test@example.com")
+    return repo, commit(repo, "v1.76 recovery candidate")
+
+
+def test_v176_accepts_recovery_and_rejects_old_release_identity(recovery_release_repo):
+    repo, candidate = recovery_release_repo
+    assert release_verifier.verify_commit_content(repo, "v1.76", candidate) == candidate
+    for ref in ("v1.74", "v1.75"):
+        with pytest.raises(ReleaseVerificationError):
+            release_verifier.verify_commit_content(repo, ref, candidate)
+
+
+def test_v176_inventory_owns_all_recovery_executables_only_from_v176(recovery_release_repo):
+    repo, candidate = recovery_release_repo
+    tree = release_verifier.VerifiedCommitTree.open(repo, candidate)
+    paths = release_inventory.release_paths_for("v1.76")
+    assert set(RECOVERY_RELEASE_FILES) <= set(paths)
+    for ref in ("v1.74", "v1.75"):
+        assert not set(RECOVERY_RELEASE_FILES) & set(release_inventory.release_paths_for(ref))
+    listing = tree.listing(paths)
+    blobs = release_inventory.validate_release_listing(
+        listing, release_inventory.release_roots_for("v1.76")
+    )
+    assert set(RECOVERY_RELEASE_FILES) <= {blob.path.as_posix() for blob in blobs}
+
+
+@pytest.mark.parametrize("relative", RECOVERY_RELEASE_FILES)
+def test_v176_rejects_recovery_executable_byte_drift(recovery_release_repo, relative):
+    repo, _ = recovery_release_repo
+    path = repo / relative
+    path.write_bytes(path.read_bytes() + b"\n# unapproved executable change\n")
+    bad = commit(repo, "mutate recovery executable")
+    with pytest.raises(ReleaseVerificationError, match="recovery.*digest"):
+        release_verifier.verify_commit_content(repo, "v1.76", bad)
+
+
+@pytest.mark.parametrize(("old", "new"), [
+    ("cancel-in-progress: false", "cancel-in-progress: true"),
+    ("automation-opencode-auto-review-", "unserialized-recovery-"),
+    ("      contents: read", "      contents: write"),
+    ("ref: ${{ steps.driver.outputs.central_sha }}", "ref: main"),
+    ("repository: jhw7500/automation", "repository: ${{ github.repository }}"),
+    ("persist-credentials: false", "persist-credentials: true"),
+    ("Number.isSafeInteger(Number(value))", "true"),
+    ("refs[0].path !== prefix + refs[0].sha", "false"),
+    ("working-directory: automation-recovery", "working-directory: review-target"),
+    ("          GH_TOKEN: ${{ github.token }}", "          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}"),
+])
+def test_v176_recovery_security_gates_survive_raw_digest_reseal(
+    recovery_release_repo, monkeypatch, old, new
+):
+    repo, _ = recovery_release_repo
+    relative = ".github/workflows/opencode-recover-finalization.yml"
+    path = repo / relative
+    replace(path, old, new, count=1)
+    monkeypatch.setitem(release_verifier.EXPECTED_OPENCODE_RECOVERY_SHA256,
+                        relative, hashlib.sha256(path.read_bytes()).hexdigest())
+    bad = commit(repo, "weaken recovery execution contract")
+    with pytest.raises(ReleaseVerificationError, match="recovery execution/caller contract"):
+        release_verifier.verify_commit_content(repo, "v1.76", bad)
+
+
+@pytest.mark.parametrize(("old", "new"), [
+    ("!inputs.force_review", "true"),
+    ("!inputs.recovery_original_run_id", "true"),
+    ("opencode-recover-finalization.yml@__AUTOMATION_COMMIT__", "opencode-auto-review.yml@__AUTOMATION_COMMIT__"),
+    ("      pull-requests: read", "      pull-requests: write"),
+    ("      original_run_attempt: ${{ inputs.recovery_original_run_attempt }}", "      original_run_attempt: '2'"),
+])
+def test_v176_rejects_caller_mode_or_identity_drift(recovery_release_repo, old, new):
+    repo, _ = recovery_release_repo
+    replace(repo / release_verifier.RECOVERY_CALLER, old, new, count=1)
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.76", commit(repo, "weaken caller routing"))
+
+
+def test_v176_rejects_relaxed_ordinary_failed_run_trust(recovery_release_repo):
+    repo, _ = recovery_release_repo
+    path = repo / ".github/workflows/opencode-auto-review.yml"
+    replace(path, "if (run.conclusion !== 'success')", "if (false)", count=1)
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.76", commit(repo, "trust ordinary failed run"))
+
+
+def test_v176_rejects_unowned_recovery_executable(recovery_release_repo):
+    repo, _ = recovery_release_repo
+    (repo / ".github/actions/recover-opencode-review/unowned.py").write_text("print('unexpected')\n")
+    with pytest.raises(ReleaseVerificationError, match="recovery inventory is not closed"):
+        release_verifier.verify_commit_content(repo, "v1.76", commit(repo, "add unowned helper"))
 
 CANONICAL_REMOTE = "https://github.com/jhw7500/automation.git"
 HERMETIC_LOCAL_GIT_ENV = {
@@ -530,6 +644,7 @@ def assert_pre_v160_workflow_bytes(repo: Path) -> None:
 
 
 def restore_pre_v175_claude_validation(repo: Path) -> None:
+    restore_pre_v176_opencode_recovery(repo)
     tree = release_verifier.VerifiedCommitTree.open(
         ROOT, "eb460b7e547a85f831820f8f25d30f134b2c6254"
     )
@@ -2229,6 +2344,7 @@ def prepare_v173(repo: Path) -> str:
     ):
         shutil.copy2(ROOT / relative, repo / relative)
     restore_pre_v174_expanded_review_budget(repo)
+    restore_pre_v176_opencode_recovery(repo)
     return commit(repo, "v1.73 candidate")
 
 
@@ -2236,6 +2352,7 @@ def prepare_v174(repo: Path) -> str:
     prepare_v173(repo)
     relative = ".github/actions/review-invocation-budget/review_invocation_budget.py"
     shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v176_opencode_recovery(repo)
     return commit(repo, "v1.74 candidate")
 
 
@@ -3296,6 +3413,11 @@ def test_v147_budget_helper_semantics_bind_live_ast_relationships(
             "        return refuse(validated, request, \"duplicate_head\")\n",
         )
     elif mutation == "final-cap-dead-decoy":
+        # Mutate the ordinary finalize function, not the independent recovery
+        # reconstruction which applies the same cap to the original invocation.
+        start = source.index("def finalize(")
+        end = source.index("\ndef ", start + 1)
+        prefix, source, suffix = source[:start], source[start:end], source[end:]
         substitute(
             "    if request.call_count > state.budgets.max_calls_per_round:\n"
             "        outcome, stop_reason = \"checkpoint_failure\", "
@@ -3308,6 +3430,7 @@ def test_v147_budget_helper_semantics_bind_live_ast_relationships(
             "        outcome, stop_reason = \"provider_failure\", "
             "\"provider_failure\"\n",
         )
+        source = prefix + source + suffix
     elif mutation == "rvw-bound-dead-decoy":
         count = source.count("len(findings) > 8")
         assert count > 1

--- a/tests/test_workflow_catalog.py
+++ b/tests/test_workflow_catalog.py
@@ -85,7 +85,7 @@ def test_catalog_and_profiles_are_closed() -> None:
         assert entry.trigger["pull_request"]["types"] == [
             "opened", "synchronize", "ready_for_review", "labeled",
         ]
-        assert "review_mode" in entry.caller_jobs[0].with_keys
+        assert "review_mode" in entry.caller_jobs[-1].with_keys
 
 
 def test_live_configures_ordered_additional_branch_targets() -> None:


### PR DESCRIPTION
OpenCode can publish a valid review and then fail while finalizing its invocation budget. This change recovers that original invocation without another model call or review round.

- Validate the original attempt, unexpired artifacts, PR HEAD/base, canonical output, and claim provenance before the ledger update.
- Publish a separately authenticated recovery receipt so later reviews can reuse the original result. Exact repeats are idempotent.
- Add a serialized recovery dispatch path with no model secrets, plus v1.76 release validation and caller rendering.

Validation: [Test Fleet Tools CI](https://github.com/jhw7500/automation/actions/runs/34463776546) passed all 3,558 tests and 48 subtests, workflow YAML parsing, 106 Bash blocks, and actionlint. One non-blocking pytest 10 deprecation warning concerns passing an itertools.product iterator to parametrize in the dispatch-routing test. The exact committed tree also passed the v1.76 release-content verifier. Archived original canary replay preserved one original provider call and added zero calls.

Pre-PR tribunal round 1 passed at commit 586691374bec19fa6fc796900a15a63447e548c8 (diff SHA256 ddd809bb8ddbcb9ce29228b4f613702dead200840438328f11bca9ff07b819aa), with zero CRITICAL/HIGH blockers. The empirical reviewer independently passed 611 selected tests and three additional sequential-driver scenarios.

Known MEDIUM limitation from independent review: a later recovery may fail closed when its original publication inherited an earlier recovered finding and deleted that predecessor's canonical comment. This does not affect the original first-review canary; no unsafe ledger write was demonstrated.

Live recovery has not been dispatched. First recovery still requires unexpired original artifacts and unchanged target HEAD/base. The original failed Actions result remains failed; the prewrite comparison is not atomic CAS against external writers.

Refs #179.
