### PR TITLE
fix(review): make token estimates observational

### DIFF
--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -649,8 +649,6 @@ def _validate_state_shape(state: LedgerState) -> None:
         )
         if item.call_count > state.budgets.max_calls_per_round and not call_failure:
             raise BudgetStateError("call_budget_exhausted")
-        if item.estimated_input_tokens > state.budgets.max_estimated_tokens_per_round:
-            raise BudgetStateError("input_budget_exhausted")
         call_first_dual_failure = call_failure and item.call_count > state.budgets.max_calls_per_round
         if (item.elapsed_seconds > state.budgets.max_wall_seconds_per_round and
                 not (wall_failure or call_first_dual_failure)):
@@ -710,13 +708,6 @@ def _validate_state_shape(state: LedgerState) -> None:
         )
     ):
         raise BudgetStateError("override_invalid")
-    automatic_total = sum(item.estimated_input_tokens for item in automatic)
-    total_limit = state.budgets.max_estimated_tokens_total
-    if automatic_total > total_limit:
-        raise BudgetStateError("total_usage_budget_exhausted")
-    total_limit += len(overrides) * state.budgets.max_estimated_tokens_per_round
-    if sum(item.estimated_input_tokens for item in state.invocations) > total_limit:
-        raise BudgetStateError("total_usage_budget_exhausted")
     _validate_dismissed_findings(state.dismissed_findings)
     DecisionRecord.from_dict(state.last_decision.to_dict())
     handoff = Handoff.from_dict(state.handoff.to_dict())
@@ -1177,8 +1168,6 @@ def claim(state: LedgerState | None, request: ClaimRequest,
         for item in validated.invocations
     ):
         return refuse(validated, request, "duplicate_effective_diff")
-    if request.estimated_input_tokens > validated.budgets.max_estimated_tokens_per_round:
-        return refuse(validated, request, "input_budget_exhausted")
     override_count = sum(
         item.override_event_id is not None for item in validated.invocations
     )
@@ -1194,13 +1183,6 @@ def claim(state: LedgerState | None, request: ClaimRequest,
         override = choose_override(validated, request.override_events)
         if override is None:
             return refuse(validated, request, "round_budget_exhausted")
-    total_limit = (
-        validated.budgets.max_estimated_tokens_total
-        + (override_count + int(override is not None))
-        * validated.budgets.max_estimated_tokens_per_round
-    )
-    if estimated_total(validated) + request.estimated_input_tokens > total_limit:
-        return refuse(validated, request, "total_usage_budget_exhausted")
     return append_claim(
         validated, request, override,
         provenances[(request.run_id, request.run_attempt)],
@@ -1473,6 +1455,7 @@ def _summary(state: LedgerState, *, server_url: str) -> str:
         f"- Decision: {handoff.decision}\n"
         f"- Automatic rounds: {handoff.automatic_rounds}/{budgets.max_rounds}\n"
         f"- Override rounds: {handoff.override_rounds}/{override_limit}\n"
+        f"- Estimated input tokens: {estimated_total(state)} total\n"
         f"- Current run: {run_url}\n"
         f"- Stop reason: {handoff.stop_reason}\n"
         f"{dismissed_line}\n"

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -104,6 +104,20 @@ the updated normal receipt collectors and budget helper. Immutable v1.74/v1.75
 acceptance remains unchanged. This implementation pass performs no release publication,
 consumer adoption, live recovery or provider execution; those remain separate actions.
 
+## Observational review-input estimates (v1.77)
+
+Starting with v1.77, estimated input tokens are telemetry, not invocation admission gates.
+The budget helper still computes and records each estimate in the invocation ledger,
+checkpoint, handoff round usage, and metrics consumed by workflow summaries. The schema-1
+`max_estimated_tokens_per_round` and `max_estimated_tokens_total` fields, along with historical
+`input_budget_exhausted` and `total_usage_budget_exhausted` decisions, remain readable for
+backward compatibility but do not reject a new claim. The model provider's actual context
+limit is authoritative; a real context rejection is reported through the provider-failure
+path instead of being predicted by the budget helper.
+
+Round, override, call-count, wall-time, authenticated-checkpoint, and provenance gates are
+unchanged. Immutable v1.76 and earlier release identities retain their historical token gates.
+
 ## Same-name credential mappings
 
 Model credential names are fixed by authentication family, and every mapping uses the
@@ -1275,11 +1289,10 @@ up to two additional rounds; each requires a different `review-budget-override` 
 timeline-event ID and each ID is consumed exactly once. Once the first override is consumed,
 automatic rounds do not resume: another round requires another explicit approval event.
 OpenCode remains automatic-only because its canonicalizer cannot publish a dispatch override.
-Estimated
-input is `ceil(sum(input_file_bytes) / 4) + 20_000`, capped at 200,000 tokens per
-round, 400,000 across automatic rounds, 600,000 after the first override, and 800,000
-after the second. Every
-round has a 600-second provider wall-time cap. Call units and caps are one Claude
+Estimated input is `ceil(sum(input_file_bytes) / 4) + 20_000`. From v1.77 the estimate
+is recorded per round and in aggregate without imposing either the historical 200,000-token
+per-round limit or the 400,000-token accumulated limit. Every round has a 600-second
+provider wall-time cap. Call units and caps are one Claude
 action session, three Gemini `generate_content` requests across primary, retries, and
 configured same-reviewer fallback, and two OpenCode `opencode run` sessions including
 format repair.
@@ -1340,9 +1353,9 @@ Neither a failed force run nor budget exhaustion is merge approval, and orchestr
 as satisfied.
 
 Claim decisions are applied in this order: invalid state/provenance/head/diff;
-authenticated unchanged reuse; normal duplicate head; normal duplicate effective diff; per-round
-input exhaustion; force authorization or automatic-round exhaustion and eligible override consumption;
-aggregate usage exhaustion; then `claimed` with `allow-invocation=true`. The claim is
+authenticated unchanged reuse; normal duplicate head; normal duplicate effective diff;
+force authorization or automatic-round exhaustion and eligible override consumption; then
+`claimed` with `allow-invocation=true`. The claim is
 persisted before provider execution. Cancelled, timed-out, provider-failed,
 quality-filtered, and unfinalized claims remain consumed. Immediately before ledger
 mutation, the action refetches both PR head and prior comment; any mismatch returns

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -61,6 +61,7 @@ from scripts.workflow_release_inventory import (
     release_supports_expanded_review_budget,
     release_supports_claude_workflow_validation,
     release_supports_opencode_recovery,
+    release_supports_observational_token_estimates,
     release_retires_manual_pr_review,
     release_supports_same_head_cancel_guard,
     release_supports_review_policy,
@@ -847,6 +848,8 @@ EXPECTED_OPENCODE_RECOVERY_WORKFLOW_SHA256 = {
     "opencode": "9cc171e9c11de4c6719d73922fed0373c5db0281feae7488c55c7447025bf0ab",
 }
 EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V176 = "3e8decf2bf21d007d40c0dc011b173ed0af6b2e15ae8827ae51f6986e90b813f"
+EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V177 = "5b53efd67b4728e01ddbd029c13dd039d93cc0c94b86bccb4e1fc1a4486c6cda"
+EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_AST_SHA256_V177 = "e6596be9b7670a75cad740496a34b5f3f1714e0b37b5c0dab06a7f4762ce323e"
 EXPECTED_OPENCODE_RECOVERY_SHA256 = {
     ".github/actions/recover-opencode-review/evidence.py": "3b43f256e77c89fbd123cc155dc8931cf02701d2a642bf280cbc795253ea81b8",
     ".github/actions/recover-opencode-review/replay.js": "1756d715e529dbe66dbea0674b2ca157a80fee5069309ec902eec7de19556a3b",
@@ -3819,6 +3822,37 @@ def _ast_statement_matches(node: ast.AST, statement: str) -> bool:
     ) == ast.dump(expected[0], include_attributes=False)
 
 
+_AST_STRUCTURAL_IGNORED_FIELDS = frozenset({
+    "type_comment", "type_ignores", "type_params",
+})
+
+
+def _stable_ast_structure(value: object) -> object:
+    if isinstance(value, ast.AST):
+        return [
+            type(value).__name__,
+            [
+                [name, _stable_ast_structure(item)]
+                for name, item in ast.iter_fields(value)
+                if name not in _AST_STRUCTURAL_IGNORED_FIELDS
+            ],
+        ]
+    if isinstance(value, (list, tuple)):
+        return [_stable_ast_structure(item) for item in value]
+    if value is None or isinstance(value, (bool, float, int, str)):
+        return value
+    return [type(value).__name__, repr(value)]
+
+
+def _ast_structural_sha256(module: ast.Module) -> str:
+    payload = json.dumps(
+        _stable_ast_structure(module),
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+    return hashlib.sha256(payload).hexdigest()
+
+
 def _record_shape(
     node: ast.ClassDef,
 ) -> tuple[tuple[str, str, str | None], ...]:
@@ -4398,8 +4432,9 @@ def require_budget_helper_contract(
     filter_reasons: bool = False,
     dismissals: bool = False,
     expanded_budget: bool = False,
+    observational_token_estimates: bool = False,
 ) -> None:
-    """Require the authenticated schema-1 helper and every fixed policy gate."""
+    """Require the authenticated schema-1 helper and release-specific policy gates."""
 
     # v1.60 resolves the round budget through effective_budgets(), which renames the
     # owner of the round caps and adds three statements ahead of the ledger checks.
@@ -4884,36 +4919,60 @@ def require_budget_helper_contract(
             if dismissals
             else ""
         )
-        claim_budget_policy = (
-            "    override_count = sum(item.override_event_id is not None "
-            "for item in validated.invocations)\n"
-            "    override = None\n"
-            "    needs_override = (override_count > 0 or request.force_review or "
-            f"automatic_rounds(validated) >= {claim_rounds})\n"
-            "    if needs_override:\n"
-            "        if not request.force_review:\n"
-            "            return refuse(validated, request, 'round_budget_exhausted')\n"
-            "        override = choose_override(validated, request.override_events)\n"
-            "        if override is None:\n"
-            "            return refuse(validated, request, 'round_budget_exhausted')\n"
-            "    total_limit = (validated.budgets.max_estimated_tokens_total "
-            "+ (override_count + int(override is not None)) * "
-            "validated.budgets.max_estimated_tokens_per_round)\n"
-            if expanded_budget
+        if observational_token_estimates and not expanded_budget:
+            raise ValueError("observational token estimates require expanded budget")
+        if expanded_budget:
+            claim_budget_policy = (
+                "    override_count = sum(item.override_event_id is not None "
+                "for item in validated.invocations)\n"
+                "    override = None\n"
+                "    needs_override = (override_count > 0 or request.force_review or "
+                f"automatic_rounds(validated) >= {claim_rounds})\n"
+                "    if needs_override:\n"
+                "        if not request.force_review:\n"
+                "            return refuse(validated, request, 'round_budget_exhausted')\n"
+                "        override = choose_override(validated, request.override_events)\n"
+                "        if override is None:\n"
+                "            return refuse(validated, request, 'round_budget_exhausted')\n"
+            )
+            if not observational_token_estimates:
+                claim_budget_policy += (
+                    "    total_limit = (validated.budgets.max_estimated_tokens_total "
+                    "+ (override_count + int(override is not None)) * "
+                    "validated.budgets.max_estimated_tokens_per_round)\n"
+                )
+        else:
+            claim_budget_policy = (
+                "    override = None\n"
+                "    if any(item.override_event_id is not None "
+                "for item in validated.invocations):\n"
+                "        return refuse(validated, request, 'round_budget_exhausted')\n"
+                "    if request.force_review:\n"
+                "        override = choose_override(validated, request.override_events)\n"
+                "        if override is None:\n"
+                "            return refuse(validated, request, 'round_budget_exhausted')\n"
+                f"    elif automatic_rounds(validated) >= {claim_rounds}:\n"
+                "        override = choose_override(validated, request.override_events)\n"
+                "        if override is None:\n"
+                "            return refuse(validated, request, 'round_budget_exhausted')\n"
+                "    total_limit = 600_000 if override is not None else 400_000\n"
+            )
+        claim_input_token_gate = (
+            ""
+            if observational_token_estimates
             else
-            "    override = None\n"
-            "    if any(item.override_event_id is not None "
-            "for item in validated.invocations):\n"
-            "        return refuse(validated, request, 'round_budget_exhausted')\n"
-            "    if request.force_review:\n"
-            "        override = choose_override(validated, request.override_events)\n"
-            "        if override is None:\n"
-            "            return refuse(validated, request, 'round_budget_exhausted')\n"
-            f"    elif automatic_rounds(validated) >= {claim_rounds}:\n"
-            "        override = choose_override(validated, request.override_events)\n"
-            "        if override is None:\n"
-            "            return refuse(validated, request, 'round_budget_exhausted')\n"
-            "    total_limit = 600_000 if override is not None else 400_000\n"
+            "    if request.estimated_input_tokens > "
+            "validated.budgets.max_estimated_tokens_per_round:\n"
+            "        return refuse(validated, request, 'input_budget_exhausted')\n"
+        )
+        claim_total_token_gate = (
+            ""
+            if observational_token_estimates
+            else
+            "    if estimated_total(validated) + request.estimated_input_tokens "
+            "> total_limit:\n"
+            "        return refuse(validated, request, "
+            "'total_usage_budget_exhausted')\n"
         )
         expected_claim = ast.parse(
             "def expected(state, request, provenances):\n"
@@ -4947,14 +5006,9 @@ def require_budget_helper_contract(
             "item.full_diff_sha256 == request.full_diff_sha256 "
             "for item in validated.invocations):\n"
             "        return refuse(validated, request, 'duplicate_effective_diff')\n"
-            "    if request.estimated_input_tokens > "
-            "validated.budgets.max_estimated_tokens_per_round:\n"
-            "        return refuse(validated, request, 'input_budget_exhausted')\n"
+            f"{claim_input_token_gate}"
             f"{claim_budget_policy}"
-            "    if estimated_total(validated) + request.estimated_input_tokens "
-            "> total_limit:\n"
-            "        return refuse(validated, request, "
-            "'total_usage_budget_exhausted')\n"
+            f"{claim_total_token_gate}"
             "    return append_claim(validated, request, override, "
             "provenances[(request.run_id, request.run_attempt)])\n"
         ).body[0]
@@ -4991,6 +5045,14 @@ def require_budget_helper_contract(
             if isinstance(statement, ast.For)
             and _ast_expression_matches(statement.iter, "state.invocations")
         ]
+        stored_input_token_gate = (
+            ""
+            if observational_token_estimates
+            else
+            "    if item.estimated_input_tokens > "
+            "state.budgets.max_estimated_tokens_per_round:\n"
+            "        raise BudgetStateError('input_budget_exhausted')\n"
+        )
         expected_invocation_loop = ast.parse(
             "for item in state.invocations:\n"
             "    Invocation.from_dict(item.to_dict())\n"
@@ -5004,9 +5066,7 @@ def require_budget_helper_contract(
             "    if item.call_count > state.budgets.max_calls_per_round "
             "and not call_failure:\n"
             "        raise BudgetStateError('call_budget_exhausted')\n"
-            "    if item.estimated_input_tokens > "
-            "state.budgets.max_estimated_tokens_per_round:\n"
-            "        raise BudgetStateError('input_budget_exhausted')\n"
+            f"{stored_input_token_gate}"
             "    call_first_dual_failure = call_failure and "
             "item.call_count > state.budgets.max_calls_per_round\n"
             "    if item.elapsed_seconds > "
@@ -5122,22 +5182,36 @@ def require_budget_helper_contract(
             include_attributes=False,
         ):
             raise ValueError("forced duplicate policy differs")
-        for expression, reason in (
-            (
-                f"len(automatic) > {rounds_owner}.max_rounds or "
-                f"len(overrides) > {rounds_owner}.max_override_rounds",
-                "rounds_invalid",
-            ),
-            (
-                "automatic_total > total_limit",
-                "total_usage_budget_exhausted",
-            ),
-            (
-                "sum(item.estimated_input_tokens "
-                "for item in state.invocations) > total_limit",
-                "total_usage_budget_exhausted",
-            ),
-        ):
+        state_guards = [(
+            f"len(automatic) > {rounds_owner}.max_rounds or "
+            f"len(overrides) > {rounds_owner}.max_override_rounds",
+            "rounds_invalid",
+        )]
+        if observational_token_estimates:
+            forbidden_token_decisions = {
+                node.value
+                for node in ast.walk(state_shape)
+                if isinstance(node, ast.Constant)
+                and node.value in {
+                    "input_budget_exhausted",
+                    "total_usage_budget_exhausted",
+                }
+            }
+            if forbidden_token_decisions:
+                raise ValueError("stored token estimate gate remains")
+        else:
+            state_guards.extend((
+                (
+                    "automatic_total > total_limit",
+                    "total_usage_budget_exhausted",
+                ),
+                (
+                    "sum(item.estimated_input_tokens "
+                    "for item in state.invocations) > total_limit",
+                    "total_usage_budget_exhausted",
+                ),
+            ))
+        for expression, reason in state_guards:
             _direct_guard(
                 state_shape.body, expression, "BudgetStateError", reason
             )
@@ -5442,6 +5516,12 @@ def require_budget_helper_contract(
             )
         ):
             raise ValueError("compare-and-swap refusal differs")
+        if (
+            observational_token_estimates
+            and _ast_structural_sha256(module)
+            != EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_AST_SHA256_V177
+        ):
+            raise ValueError("observational token helper structure differs")
     except (StopIteration, SyntaxError, TypeError, ValueError):
         raise ReleaseVerificationError(
             "invocation-budget helper contract is invalid"
@@ -6180,6 +6260,7 @@ def _verify_review_invocation_budget(
         release_supports_filter_reason_surface(ref),
         release_supports_finding_dismissal(ref),
         release_supports_expanded_review_budget(ref),
+        release_supports_observational_token_estimates(ref),
     )
     for reviewer, workflow in REVIEWER_WORKFLOWS.items():
         require_budget_workflow_contract(
@@ -6202,7 +6283,9 @@ def _verify_review_invocation_budget(
         ),
         REVIEW_INVOCATION_BUDGET_HELPER_ROOT.path.as_posix(): (
             helper_payload,
-            EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V176
+            EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V177
+            if release_supports_observational_token_estimates(ref)
+            else EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V176
             if release_supports_opencode_recovery(ref)
             else EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V174
             if release_supports_expanded_review_budget(ref)

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -169,6 +169,7 @@ OPENCODE_ACTIVE_SECTION_ORDER_RELEASE = (1, 73)
 EXPANDED_REVIEW_BUDGET_RELEASE = (1, 74)
 CLAUDE_WORKFLOW_VALIDATION_RELEASE = (1, 75)
 OPENCODE_RECOVERY_RELEASE = (1, 76)
+OBSERVATIONAL_TOKEN_ESTIMATES_RELEASE = (1, 77)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -294,6 +295,12 @@ def release_supports_claude_workflow_validation(ref: str) -> bool:
 def release_supports_opencode_recovery(ref: str) -> bool:
     """Return whether the release owns original-attempt finalization recovery."""
     return _release_version(ref) >= OPENCODE_RECOVERY_RELEASE
+
+
+def release_supports_observational_token_estimates(ref: str) -> bool:
+    """Return whether estimated input tokens are telemetry rather than invocation gates."""
+
+    return _release_version(ref) >= OBSERVATIONAL_TOKEN_ESTIMATES_RELEASE
 
 
 def release_retires_manual_pr_review(ref: str) -> bool:

--- a/tests/test_review_invocation_budget.py
+++ b/tests/test_review_invocation_budget.py
@@ -688,6 +688,7 @@ def test_comment_summary_and_handoff_are_exact_and_workflow_owned():
         "- Decision: duplicate_head\n"
         "- Automatic rounds: 1/5\n"
         "- Override rounds: 0/2\n"
+        "- Estimated input tokens: 50000 total\n"
         "- Current run: https://github.com/example/repo/actions/runs/700\n"
         "- Stop reason: duplicate_head\n"
         "- Dismissed findings: none\n\n"
@@ -1021,60 +1022,82 @@ def test_stored_elapsed_seconds_enforces_each_reviewer_round_boundary(
     )
 
 
-def test_stored_estimated_input_enforces_round_boundary():
-    at_limit = budget.LedgerState.initial(
-        REPOSITORY, PR, "claude", invocations=(invocation(estimated_input_tokens=200_000),),
+@pytest.mark.parametrize("reviewer", ("claude", "gemini", "opencode"))
+def test_first_claim_above_legacy_token_limit_is_allowed_and_recorded(reviewer):
+    estimated_tokens = 250_001
+    claim_request = request(
+        reviewer=reviewer,
+        estimated_input_tokens=estimated_tokens,
     )
-    assert budget.parse_ledger(
-        ledger_body(at_limit), repository=REPOSITORY, pr=PR, reviewer="claude",
-    ) == at_limit
-    above_limit = replace(
-        at_limit,
-        invocations=(replace(at_limit.invocations[0], estimated_input_tokens=200_001),),
+
+    claimed = budget.claim(
+        None,
+        claim_request,
+        claim_provenances(None, claim_request),
     )
-    assert_stored_state_rejected(above_limit, "input_budget_exhausted")
+
+    assert claimed.allow_invocation
+    assert claimed.decision == "claimed"
+    assert claimed.state.invocations[-1].estimated_input_tokens == estimated_tokens
+    assert claimed.state.handoff.round_usage == ((1, 0, estimated_tokens, 0),)
+    assert "- Estimated input tokens: 250001 total\n" in budget.render_summary(
+        claimed.state
+    )
+    assert budget.load_checkpoint(budget.render_checkpoint(claimed.state)) == claimed.state
 
 
-def test_stored_automatic_and_override_aggregate_boundaries():
-    first = invocation(estimated_input_tokens=200_000)
+@pytest.mark.parametrize("reviewer", ("claude", "gemini", "opencode"))
+def test_later_claim_above_legacy_accumulated_token_limit_is_allowed(reviewer):
+    first = invocation(reviewer=reviewer, estimated_input_tokens=210_001)
     second = invocation(
-        head=HEAD_B, full_hash=HASH_2, run_id=502, round_number=2,
-        estimated_input_tokens=200_000,
+        reviewer=reviewer,
+        head=HEAD_B,
+        full_hash=HASH_2,
+        run_id=502,
+        round_number=2,
+        estimated_input_tokens=210_001,
     )
-    automatic_limit = budget.LedgerState.initial(
-        REPOSITORY, PR, "claude", invocations=(first, second),
+    state = budget.LedgerState.initial(
+        REPOSITORY,
+        PR,
+        reviewer,
+        invocations=(first, second),
     )
-    assert budget.parse_ledger(
-        ledger_body(automatic_limit), repository=REPOSITORY, pr=PR, reviewer="claude",
-    ) == automatic_limit
+    claim_request = request(
+        reviewer=reviewer,
+        head=HEAD_C,
+        full_hash=HASH_3,
+        run_id=503,
+        estimated_input_tokens=210_001,
+    )
 
-    third = invocation(
-        head=HEAD_C, full_hash=HASH_3, run_id=503, round_number=3,
-        override_event_id=9001, estimated_input_tokens=200_000,
+    claimed = budget.claim(
+        state,
+        claim_request,
+        claim_provenances(state, claim_request),
     )
-    override_limit = budget.LedgerState.initial(
-        REPOSITORY, PR, "claude", invocations=(first, second, third),
-        consumed_override_event_ids=(9001,),
-    )
-    override_limit = replace(
-        override_limit,
-        budgets=replace(
-            override_limit.budgets,
-            max_rounds=2,
-            max_override_rounds=1,
-        ),
-    )
-    assert budget.parse_ledger(
-        ledger_body(override_limit), repository=REPOSITORY, pr=PR, reviewer="claude",
-    ) == override_limit
 
-    above_override_limit = replace(
-        override_limit,
-        invocations=override_limit.invocations[:2] + (
-            replace(override_limit.invocations[2], estimated_input_tokens=200_001),
-        ),
+    assert claimed.allow_invocation
+    assert claimed.round_number == 3
+    assert [
+        item.estimated_input_tokens for item in claimed.state.invocations
+    ] == [210_001, 210_001, 210_001]
+    assert budget.load_checkpoint(budget.render_checkpoint(claimed.state)) == claimed.state
+
+
+@pytest.mark.parametrize(
+    "decision",
+    ("input_budget_exhausted", "total_usage_budget_exhausted"),
+)
+def test_legacy_token_budget_decisions_remain_readable(decision):
+    state = replace(
+        budget.LedgerState.initial(REPOSITORY, PR, "claude"),
+        last_decision=budget.DecisionRecord(decision, decision, 700, 1),
     )
-    assert_stored_state_rejected(above_override_limit, "input_budget_exhausted")
+
+    assert budget.parse_ledger(
+        ledger_body(state), repository=REPOSITORY, pr=PR, reviewer="claude",
+    ) == state
 
 
 # --- configurable automatic round budget (issue #114) ---
@@ -1797,6 +1820,7 @@ def test_comment_summary_lists_dismissals_and_documents_the_command():
         "- Decision: claimed\n"
         "- Automatic rounds: 1/5\n"
         "- Override rounds: 0/2\n"
+        "- Estimated input tokens: 50000 total\n"
         "- Current run: https://github.com/example/repo/actions/runs/700\n"
         "- Stop reason: claimed\n"
         "- Dismissed findings: "

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -41,6 +41,10 @@ from release_fixture_helpers import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+V176_REVIEW_BUDGET_COMMIT = "444a7347aee169ed178aae80e8bd8d10eca52e02"
+REVIEW_INVOCATION_BUDGET_HELPER = (
+    ".github/actions/review-invocation-budget/review_invocation_budget.py"
+)
 
 RECOVERY_RELEASE_FILES = (
     ".github/actions/recover-opencode-review/evidence.py",
@@ -48,6 +52,17 @@ RECOVERY_RELEASE_FILES = (
     ".github/actions/recover-opencode-review/receipt.js",
     ".github/actions/recover-opencode-review/transport.py",
 )
+
+
+def restore_pre_v177_token_estimate_policy(repo: Path) -> None:
+    """Restore the authenticated v1.76 invocation-budget helper bytes."""
+
+    tree = release_verifier.VerifiedCommitTree.open(ROOT, V176_REVIEW_BUDGET_COMMIT)
+    payload = tree.read_file(REVIEW_INVOCATION_BUDGET_HELPER)
+    assert hashlib.sha256(payload).hexdigest() == (
+        release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_HELPER_SHA256_V176
+    )
+    (repo / REVIEW_INVOCATION_BUDGET_HELPER).write_bytes(payload)
 
 
 @pytest.fixture
@@ -63,10 +78,16 @@ def recovery_release_repo(tmp_path):
             shutil.copytree(source, target)
         else:
             shutil.copy2(source, target)
+    restore_pre_v177_token_estimate_policy(repo)
     git(repo, "init", "-q")
     git(repo, "config", "user.name", "Test")
     git(repo, "config", "user.email", "test@example.com")
     return repo, commit(repo, "v1.76 recovery candidate")
+
+
+def prepare_v177(repo: Path) -> str:
+    shutil.copy2(ROOT / REVIEW_INVOCATION_BUDGET_HELPER, repo / REVIEW_INVOCATION_BUDGET_HELPER)
+    return commit(repo, "v1.77 observational token estimate candidate")
 
 
 def test_v176_accepts_recovery_and_rejects_old_release_identity(recovery_release_repo):
@@ -75,6 +96,209 @@ def test_v176_accepts_recovery_and_rejects_old_release_identity(recovery_release
     for ref in ("v1.74", "v1.75"):
         with pytest.raises(ReleaseVerificationError):
             release_verifier.verify_commit_content(repo, ref, candidate)
+
+
+def test_token_estimate_observability_release_boundary() -> None:
+    assert release_inventory.release_supports_observational_token_estimates("v1.76") is False
+    assert release_inventory.release_supports_observational_token_estimates("v1.77") is True
+
+
+def test_v177_accepts_observational_token_estimate_contract(recovery_release_repo):
+    repo, _ = recovery_release_repo
+    candidate = prepare_v177(repo)
+
+    assert release_verifier.verify_commit_content(repo, "v1.77", candidate) == candidate
+
+
+def test_v177_structural_contract_ignores_nonsemantic_comments() -> None:
+    source = (ROOT / REVIEW_INVOCATION_BUDGET_HELPER).read_text(encoding="utf-8")
+
+    release_verifier.require_budget_helper_contract(
+        "# nonsemantic release-verifier probe\n" + source,
+        rounds_variable=True,
+        filter_reasons=True,
+        dismissals=True,
+        expanded_budget=True,
+        observational_token_estimates=True,
+    )
+
+
+def test_v177_helper_is_rejected_on_v176_release_line(recovery_release_repo):
+    repo, _ = recovery_release_repo
+    candidate = prepare_v177(repo)
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.76", candidate)
+
+
+def test_v176_helper_is_rejected_on_v177_release_line(recovery_release_repo):
+    repo, candidate = recovery_release_repo
+
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.77", candidate)
+
+
+def test_v177_rejects_reintroduced_estimated_token_gate() -> None:
+    source = (ROOT / REVIEW_INVOCATION_BUDGET_HELPER).read_text(encoding="utf-8")
+    insertion = (
+        "    if request.estimated_input_tokens > "
+        "validated.budgets.max_estimated_tokens_per_round:\n"
+        "        return refuse(validated, request, 'input_budget_exhausted')\n"
+        "    override_count = sum(\n"
+    )
+    source = source.replace("    override_count = sum(\n", insertion, 1)
+
+    with pytest.raises(
+        ReleaseVerificationError,
+        match="invocation-budget helper contract",
+    ):
+        release_verifier.require_budget_helper_contract(
+            source,
+            rounds_variable=True,
+            filter_reasons=True,
+            dismissals=True,
+            expanded_budget=True,
+            observational_token_estimates=True,
+        )
+
+
+def test_v177_rejects_estimated_token_gate_relocated_to_append_claim() -> None:
+    source = (ROOT / REVIEW_INVOCATION_BUDGET_HELPER).read_text(encoding="utf-8")
+    insertion = (
+        "        provenance: RunProvenance) -> Transition:\n"
+        "    round_estimate = request.estimated_input_tokens\n"
+        "    round_limit = state.budgets.max_estimated_tokens_per_round\n"
+        "    if round_estimate > round_limit:\n"
+        "        return refuse(state, request, 'round_budget_exhausted')\n"
+        "    round_number = len(state.invocations) + 1\n"
+    )
+    source = source.replace(
+        "        provenance: RunProvenance) -> Transition:\n"
+        "    round_number = len(state.invocations) + 1\n",
+        insertion,
+        1,
+    )
+
+    with pytest.raises(
+        ReleaseVerificationError,
+        match="invocation-budget helper contract",
+    ):
+        release_verifier.require_budget_helper_contract(
+            source,
+            rounds_variable=True,
+            filter_reasons=True,
+            dismissals=True,
+            expanded_budget=True,
+            observational_token_estimates=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("setup", "condition"),
+    (
+        (
+            "round_estimate_box = (request.estimated_input_tokens,)",
+            "round_estimate_box[0] > 200_000",
+        ),
+        (
+            "round_estimate_box = [request.estimated_input_tokens]",
+            "round_estimate_box[0] > 200_000",
+        ),
+        (
+            "round_estimate_box = {'value': request.estimated_input_tokens}",
+            "round_estimate_box['value'] > 200_000",
+        ),
+        (
+            "round_estimate_box.value = request.estimated_input_tokens",
+            "round_estimate_box.value > 200_000",
+        ),
+    ),
+)
+def test_v177_rejects_container_indirected_token_gate_in_append_claim(
+    setup: str, condition: str,
+) -> None:
+    source = (ROOT / REVIEW_INVOCATION_BUDGET_HELPER).read_text(encoding="utf-8")
+    insertion = (
+        "        provenance: RunProvenance) -> Transition:\n"
+        f"    {setup}\n"
+        f"    if {condition}:\n"
+        "        return refuse(state, request, 'round_budget_exhausted')\n"
+        "    round_number = len(state.invocations) + 1\n"
+    )
+    source = source.replace(
+        "        provenance: RunProvenance) -> Transition:\n"
+        "    round_number = len(state.invocations) + 1\n",
+        insertion,
+        1,
+    )
+
+    with pytest.raises(
+        ReleaseVerificationError,
+        match="invocation-budget helper contract",
+    ):
+        release_verifier.require_budget_helper_contract(
+            source,
+            rounds_variable=True,
+            filter_reasons=True,
+            dismissals=True,
+            expanded_budget=True,
+            observational_token_estimates=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("anchor", "replacement"),
+    (
+        (
+            "def _integer(value: object, name: str, *, positive: bool = False, "
+            "minimum: int | None = None) -> int:\n"
+            "    if isinstance(value, bool) or not isinstance(value, int):\n",
+            "def _integer(value: object, name: str, *, positive: bool = False, "
+            "minimum: int | None = None) -> int:\n"
+            "    if name == 'estimated_input_tokens' and value > 200_000:\n"
+            "        raise BudgetStateError('input_budget_exhausted')\n"
+            "    if isinstance(value, bool) or not isinstance(value, int):\n",
+        ),
+        (
+            "        provenance: RunProvenance) -> Transition:\n"
+            "    round_number = len(state.invocations) + 1\n",
+            "        provenance: RunProvenance) -> Transition:\n"
+            "    round_estimate = request.estimated_input_tokens\n"
+            "    def over_legacy_limit():\n"
+            "        return round_estimate > 200_000\n"
+            "    if over_legacy_limit():\n"
+            "        return refuse(state, request, 'round_budget_exhausted')\n"
+            "    round_number = len(state.invocations) + 1\n",
+        ),
+        (
+            "        provenance: RunProvenance) -> Transition:\n"
+            "    round_number = len(state.invocations) + 1\n",
+            "        provenance: RunProvenance) -> Transition:\n"
+            "    request.estimated_input_tokens > 200_000 and "
+            "(_ for _ in ()).throw(BudgetStateError('input_budget_exhausted'))\n"
+            "    round_number = len(state.invocations) + 1\n",
+        ),
+    ),
+)
+def test_v177_rejects_indirect_token_gate_control_forms(
+    anchor: str, replacement: str,
+) -> None:
+    source = (ROOT / REVIEW_INVOCATION_BUDGET_HELPER).read_text(encoding="utf-8")
+    mutated = source.replace(anchor, replacement, 1)
+    assert mutated != source
+
+    with pytest.raises(
+        ReleaseVerificationError,
+        match="invocation-budget helper contract",
+    ):
+        release_verifier.require_budget_helper_contract(
+            mutated,
+            rounds_variable=True,
+            filter_reasons=True,
+            dismissals=True,
+            expanded_budget=True,
+            observational_token_estimates=True,
+        )
 
 
 def test_v176_inventory_owns_all_recovery_executables_only_from_v176(recovery_release_repo):
@@ -3356,6 +3580,7 @@ def test_v147_budget_helper_semantics_reject_authenticated_mutations(
             filter_reasons=True,
             dismissals=True,
             expanded_budget=True,
+            observational_token_estimates=True,
         )
 
 
@@ -3489,6 +3714,7 @@ def test_v147_budget_helper_semantics_bind_live_ast_relationships(
             filter_reasons=True,
             dismissals=True,
             expanded_budget=True,
+            observational_token_estimates=True,
         )
 
 


### PR DESCRIPTION
Remove estimated-token admission gates while preserving usage telemetry, schema compatibility, and non-token review limits.

Refs #183
