### PR TITLE
feat: add authenticated Claude caller rollout fallback

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,6 +6,7 @@ paths:
   .github/workflows/claude-code-review.yml:
     ignore:
       - 'specifying action "\$/\.github/actions/prepare-review-diff" in invalid format because ref is missing'
+      - 'specifying action "\$/\.github/actions/claude-rollout-fallback" in invalid format because ref is missing'
       - 'specifying action "\$/\.github/actions/review-invocation-budget" in invalid format because ref is missing'
       - 'specifying action "\$/\.github/actions/canonicalize-review" in invalid format because ref is missing'
       - 'specifying action "\$/\.github/actions/resolve-review-policy" in invalid format because ref is missing'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,6 +3,10 @@
 # although the hosted runner does; keep the narrowly scoped compatibility
 # exception and continue linting every other action reference.
 paths:
+  .github/workflows/claude.yml:
+    ignore:
+      - 'specifying action "\$/\.github/actions/claude-rollout-fallback" in invalid format because ref is missing'
+      - 'reusable workflow call "\$/\.github/workflows/claude-code-review\.yml" at "uses" is not following the format'
   .github/workflows/claude-code-review.yml:
     ignore:
       - 'specifying action "\$/\.github/actions/prepare-review-diff" in invalid format because ref is missing'

--- a/.github/actions/claude-rollout-fallback/action.yml
+++ b/.github/actions/claude-rollout-fallback/action.yml
@@ -1,0 +1,157 @@
+name: Authenticate Claude rollout fallback
+description: Classify and authenticate one bounded managed rollout review request
+
+inputs:
+  github-token:
+    required: true
+
+outputs:
+  route:
+    value: ${{ steps.verify.outputs.route }}
+  reason:
+    value: ${{ steps.verify.outputs.reason }}
+  request-comment-id:
+    value: ${{ steps.verify.outputs.request-comment-id }}
+  request-nonce:
+    value: ${{ steps.verify.outputs.request-nonce }}
+  expected-head-sha:
+    value: ${{ steps.verify.outputs.expected-head-sha }}
+  expected-base-sha:
+    value: ${{ steps.verify.outputs.expected-base-sha }}
+  original-run-id:
+    value: ${{ steps.verify.outputs.original-run-id }}
+  original-run-attempt:
+    value: ${{ steps.verify.outputs.original-run-attempt }}
+  release-commit:
+    value: ${{ steps.verify.outputs.release-commit }}
+  managed-diff-sha256:
+    value: ${{ steps.verify.outputs.managed-diff-sha256 }}
+  automatic-comment-id:
+    value: ${{ steps.verify.outputs.automatic-comment-id }}
+  automatic-state-sha256:
+    value: ${{ steps.verify.outputs.automatic-state-sha256 }}
+
+runs:
+  using: composite
+  steps:
+    - id: collect
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        umask 077
+        work_directory="$(mktemp -d "${RUNNER_TEMP:?}/claude-rollout-fallback.XXXXXX")"
+        chmod 0700 "$work_directory"
+        cleanup() {
+          rm -rf -- "$work_directory"
+        }
+        trap cleanup EXIT
+
+        plan_file="$work_directory/plan.json"
+        evidence_directory="$work_directory/evidence"
+        python3 -I -S -B "${{ github.action_path }}/contract.py" plan \
+          --event-name "${{ github.event_name }}" \
+          --event-file "${GITHUB_EVENT_PATH:?}" \
+          --plan-file "$plan_file" \
+          --github-output "$GITHUB_OUTPUT"
+
+        if [[ ! -f "$plan_file" ]]; then
+          printf 'candidate=false\nwork-directory=\n' >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        mkdir "$evidence_directory"
+        chmod 0700 "$evidence_directory"
+        requests_file="$work_directory/requests.tsv"
+        PLAN_FILE="$plan_file" REQUESTS_FILE="$requests_file" python3 -I -S -B <<'PY'
+        import json
+        import os
+        from pathlib import Path
+        import re
+
+        plan = json.loads(Path(os.environ["PLAN_FILE"]).read_text(encoding="ascii"))
+        requests = plan.get("requests")
+        if not isinstance(requests, list) or len(requests) != 14:
+            raise SystemExit("plan_invalid")
+        name_re = re.compile(r"(?:comment|pull_request|original_run|original_jobs|comments-[0-9]{2})\.json\Z")
+        endpoint_re = re.compile(r"repos/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/[A-Za-z0-9_./?=&-]+\Z")
+        rows = []
+        for item in requests:
+            if not isinstance(item, dict) or set(item) != {"endpoint", "name"}:
+                raise SystemExit("plan_invalid")
+            name, endpoint = item["name"], item["endpoint"]
+            if not isinstance(name, str) or name_re.fullmatch(name) is None:
+                raise SystemExit("plan_invalid")
+            if not isinstance(endpoint, str) or endpoint_re.fullmatch(endpoint) is None:
+                raise SystemExit("plan_invalid")
+            rows.append(f"{name}\t{endpoint}\n")
+        path = Path(os.environ["REQUESTS_FILE"])
+        path.write_text("".join(rows), encoding="ascii")
+        path.chmod(0o600)
+        PY
+
+        while IFS=$'\t' read -r response_name endpoint; do
+          response_file="$evidence_directory/$response_name"
+          gh api --hostname github.com --method GET \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "$endpoint" > "$response_file"
+          chmod 0600 "$response_file"
+          if [[ "$response_name" == comments-*.json ]]; then
+            count="$(RESPONSE_FILE="$response_file" python3 -I -S -B <<'PY'
+        import json
+        import os
+        from pathlib import Path
+
+        value = json.loads(Path(os.environ["RESPONSE_FILE"]).read_text(encoding="utf-8"))
+        if not isinstance(value, list) or len(value) > 100:
+            raise SystemExit("comment_page_invalid")
+        print(len(value))
+        PY
+            )"
+            if (( count < 100 )); then
+              break
+            fi
+          fi
+        done < "$requests_file"
+
+        printf 'candidate=true\nwork-directory=%s\n' "$work_directory" >> "$GITHUB_OUTPUT"
+        trap - EXIT
+
+    - id: verify
+      shell: bash
+      env:
+        CANDIDATE: ${{ steps.collect.outputs.candidate }}
+        COLLECT_ROUTE: ${{ steps.collect.outputs.route }}
+        COLLECT_REASON: ${{ steps.collect.outputs.reason }}
+        WORK_DIRECTORY: ${{ steps.collect.outputs.work-directory }}
+      run: |
+        set -euo pipefail
+        umask 077
+        empty_evidence() {
+          printf '%s=\n' \
+            request-comment-id request-nonce expected-head-sha expected-base-sha \
+            original-run-id original-run-attempt release-commit managed-diff-sha256 \
+            automatic-comment-id automatic-state-sha256 >> "$GITHUB_OUTPUT"
+        }
+
+        if [[ "$CANDIDATE" != 'true' ]]; then
+          [[ "$COLLECT_ROUTE" =~ ^(interactive|invalid)$ ]]
+          [[ "$COLLECT_REASON" =~ ^[a-z_]*$ ]]
+          printf 'route=%s\nreason=%s\n' "$COLLECT_ROUTE" "$COLLECT_REASON" >> "$GITHUB_OUTPUT"
+          empty_evidence
+          exit 0
+        fi
+
+        [[ "$WORK_DIRECTORY" == "${RUNNER_TEMP:?}"/claude-rollout-fallback.* ]]
+        [[ -d "$WORK_DIRECTORY" && ! -L "$WORK_DIRECTORY" ]]
+        cleanup() {
+          rm -rf -- "$WORK_DIRECTORY"
+        }
+        trap cleanup EXIT
+        python3 -I -S -B "${{ github.action_path }}/contract.py" verify \
+          --plan-file "$WORK_DIRECTORY/plan.json" \
+          --evidence-directory "$WORK_DIRECTORY/evidence" \
+          --admission-file "$WORK_DIRECTORY/admission.json" \
+          --github-output "$GITHUB_OUTPUT"

--- a/.github/actions/claude-rollout-fallback/contract.py
+++ b/.github/actions/claude-rollout-fallback/contract.py
@@ -1,0 +1,1003 @@
+#!/usr/bin/env python3
+"""Pure parsing and authenticated admission for Claude rollout fallbacks."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+
+
+class ContractError(ValueError):
+    """A bounded refusal whose message is safe to expose as an output."""
+
+
+VISIBLE_PREFIX = "@claude managed rollout review for PR "
+HIDDEN_MARKER = "<!-- automation:claude-rollout-review-request:v1 "
+REQUEST_BODY_RE = re.compile(
+    r"\A@claude managed rollout review for PR (?P<visible_pr>[1-9][0-9]{0,15})\n"
+    r"<!-- automation:claude-rollout-review-request:v1 (?P<json>\{[^\r\n]*\}) -->\n?\Z",
+    re.ASCII,
+)
+REQUEST_KEYS = frozenset(
+    {
+        "repository",
+        "pr",
+        "expected_head_sha",
+        "expected_base_sha",
+        "original_run_id",
+        "original_run_attempt",
+        "release_commit",
+        "managed_diff_sha256",
+        "nonce",
+    }
+)
+SHA_RE = re.compile(r"[0-9a-f]{40}\Z", re.ASCII)
+DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+NONCE_RE = re.compile(r"[0-9a-f]{32}\Z", re.ASCII)
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\Z", re.ASCII)
+MAX_SAFE_INTEGER = 2**53 - 1
+ALLOWED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+AUTOMATIC_HEADER = "## Claude Code Review (latest)"
+AUTOMATIC_MARKER = "<!-- automation:claude-code-review:v3 -->"
+STATE_LINE_RE = re.compile(r"<!-- automation-state:(?P<json>\{[^\r\n]*\}) -->\Z")
+FAILURE_STATE_KEYS = frozenset(
+    {
+        "schema",
+        "reviewer",
+        "pr",
+        "run_id",
+        "run_attempt",
+        "attempt_head",
+        "successful_head",
+        "attempt_status",
+        "diff_mode",
+        "review_execution",
+        "full_diff_sha256",
+        "quality_schema",
+        "accepted_count",
+        "filtered_count",
+        "normalized_count",
+        "filtered_max_severity",
+        "failure_reason",
+    }
+)
+FALLBACK_ROUTE_KEYS = frozenset(
+    {
+        "managed_diff_sha256",
+        "original_failed_run_id",
+        "release_commit",
+        "request_comment_id",
+        "reviewed_base_sha",
+        "route",
+    }
+)
+OUTPUT_NAMES = (
+    "route",
+    "reason",
+    "request-comment-id",
+    "request-nonce",
+    "expected-head-sha",
+    "expected-base-sha",
+    "original-run-id",
+    "original-run-attempt",
+    "release-commit",
+    "managed-diff-sha256",
+    "automatic-comment-id",
+    "automatic-state-sha256",
+)
+
+
+@dataclass(frozen=True)
+class FallbackRequest:
+    repository: str
+    pr: int
+    expected_head_sha: str
+    expected_base_sha: str
+    original_run_id: int
+    original_run_attempt: int
+    release_commit: str
+    managed_diff_sha256: str
+    nonce: str
+
+    @classmethod
+    def from_dict(cls, value: object) -> "FallbackRequest":
+        if not isinstance(value, dict) or set(value) != REQUEST_KEYS:
+            raise ContractError("request_invalid")
+        integers = (
+            value["pr"],
+            value["original_run_id"],
+            value["original_run_attempt"],
+        )
+        if any(
+            type(item) is not int or not 1 <= item <= MAX_SAFE_INTEGER
+            for item in integers
+        ):
+            raise ContractError("request_invalid")
+        repository = value["repository"]
+        shas = (
+            value["expected_head_sha"],
+            value["expected_base_sha"],
+            value["release_commit"],
+        )
+        if not isinstance(repository, str) or REPOSITORY_RE.fullmatch(repository) is None:
+            raise ContractError("request_invalid")
+        if any(
+            not isinstance(item, str) or SHA_RE.fullmatch(item) is None
+            for item in shas
+        ):
+            raise ContractError("request_invalid")
+        digest, nonce = value["managed_diff_sha256"], value["nonce"]
+        if not isinstance(digest, str) or DIGEST_RE.fullmatch(digest) is None:
+            raise ContractError("request_invalid")
+        if not isinstance(nonce, str) or NONCE_RE.fullmatch(nonce) is None:
+            raise ContractError("request_invalid")
+        return cls(
+            repository=repository,
+            pr=value["pr"],
+            expected_head_sha=value["expected_head_sha"],
+            expected_base_sha=value["expected_base_sha"],
+            original_run_id=value["original_run_id"],
+            original_run_attempt=value["original_run_attempt"],
+            release_commit=value["release_commit"],
+            managed_diff_sha256=digest,
+            nonce=nonce,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {name: getattr(self, name) for name in REQUEST_KEYS}
+
+
+@dataclass(frozen=True)
+class RequestClassification:
+    route: str
+    reason: str
+    request: FallbackRequest | None
+
+
+@dataclass(frozen=True)
+class EvidenceBundle:
+    event_name: object
+    event: object
+    comment: object
+    pull_request: object
+    original_run: object
+    original_jobs: object
+    issue_comments: object
+
+
+@dataclass(frozen=True)
+class FallbackAdmission:
+    request_comment_id: int
+    request: FallbackRequest
+    automatic_comment_id: int
+    automatic_state_sha256: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "automatic_comment_id": self.automatic_comment_id,
+            "automatic_state_sha256": self.automatic_state_sha256,
+            "request": self.request.to_dict(),
+            "request_comment_id": self.request_comment_id,
+            "schema": 1,
+        }
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ContractError("request_invalid")
+        result[key] = value
+    return result
+
+
+def canonical_request_body(request: FallbackRequest) -> str:
+    payload = json.dumps(
+        request.to_dict(), ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    )
+    return f"{VISIBLE_PREFIX}{request.pr}\n{HIDDEN_MARKER}{payload} -->"
+
+
+def parse_request_body(body: object) -> FallbackRequest:
+    if not isinstance(body, str):
+        raise ContractError("request_invalid")
+    try:
+        encoded = body.encode("utf-8")
+    except UnicodeEncodeError:
+        raise ContractError("request_invalid") from None
+    if len(encoded) > 4096:
+        raise ContractError("request_invalid")
+    match = REQUEST_BODY_RE.fullmatch(body)
+    if match is None:
+        raise ContractError("request_invalid")
+    try:
+        value = json.loads(match.group("json"), object_pairs_hook=_unique_object)
+    except (json.JSONDecodeError, ContractError):
+        raise ContractError("request_invalid") from None
+    request = FallbackRequest.from_dict(value)
+    canonical = canonical_request_body(request)
+    if int(match.group("visible_pr")) != request.pr or body not in {
+        canonical,
+        canonical + "\n",
+    }:
+        raise ContractError("request_invalid")
+    return request
+
+
+def event_text_fields(event_name: object, event: object) -> tuple[str, ...]:
+    if not isinstance(event, dict):
+        return ()
+    values: tuple[object, ...]
+    if event_name in {"issue_comment", "pull_request_review_comment"}:
+        comment = event.get("comment")
+        values = (comment.get("body"),) if isinstance(comment, dict) else ()
+    elif event_name == "pull_request_review":
+        review = event.get("review")
+        values = (review.get("body"),) if isinstance(review, dict) else ()
+    elif event_name == "issues":
+        issue = event.get("issue")
+        values = (
+            (issue.get("title"), issue.get("body"))
+            if isinstance(issue, dict)
+            else ()
+        )
+    else:
+        values = ()
+    return tuple(value for value in values if isinstance(value, str))
+
+
+def classify_event(event_name: object, event: object) -> RequestClassification:
+    texts = event_text_fields(event_name, event)
+    reserved = any(
+        VISIBLE_PREFIX in value or HIDDEN_MARKER in value for value in texts
+    )
+    if not reserved:
+        return RequestClassification("interactive", "", None)
+    if event_name != "issue_comment" or len(texts) != 1:
+        return RequestClassification("invalid", "request_invalid", None)
+    try:
+        request = parse_request_body(texts[0])
+    except ContractError as error:
+        return RequestClassification("invalid", str(error), None)
+    return RequestClassification("managed_candidate", "", request)
+
+
+def event_comment_body(event: object) -> str:
+    if not isinstance(event, dict) or not isinstance(event.get("comment"), dict):
+        raise ContractError("event_invalid")
+    body = event["comment"].get("body")
+    if not isinstance(body, str):
+        raise ContractError("event_invalid")
+    return body
+
+
+def positive_id(value: object, reason: str) -> int:
+    if type(value) is not int or not 1 <= value <= MAX_SAFE_INTEGER:
+        raise ContractError(reason)
+    return value
+
+
+def require_managed_created_event(
+    event_name: object, event: object
+) -> FallbackRequest:
+    if event_name != "issue_comment" or not isinstance(event, dict):
+        raise ContractError("event_invalid")
+    if event.get("action") != "created":
+        raise ContractError("event_invalid")
+    request = parse_request_body(event_comment_body(event))
+    repository = event.get("repository")
+    issue = event.get("issue")
+    comment = event.get("comment")
+    if (
+        not isinstance(repository, dict)
+        or repository.get("full_name") != request.repository
+        or not isinstance(issue, dict)
+        or issue.get("number") != request.pr
+        or issue.get("state") != "open"
+        or not isinstance(issue.get("pull_request"), dict)
+        or not isinstance(comment, dict)
+    ):
+        raise ContractError("event_invalid")
+    positive_id(comment.get("id"), "event_invalid")
+    return request
+
+
+def require_exact_comment(
+    comment: object, event: object, request: FallbackRequest
+) -> None:
+    if not isinstance(comment, dict) or not isinstance(event, dict):
+        raise ContractError("comment_invalid")
+    event_comment = event.get("comment")
+    if not isinstance(event_comment, dict):
+        raise ContractError("comment_invalid")
+    comment_id = positive_id(comment.get("id"), "comment_invalid")
+    event_comment_id = positive_id(event_comment.get("id"), "comment_invalid")
+    body = comment.get("body")
+    event_body = event_comment.get("body")
+    if (
+        comment_id != event_comment_id
+        or not isinstance(body, str)
+        or body != event_body
+        or comment.get("created_at") != event_comment.get("created_at")
+        or comment.get("author_association")
+        != event_comment.get("author_association")
+        or parse_request_body(body) != request
+    ):
+        raise ContractError("comment_invalid")
+    user = comment.get("user")
+    event_user = event_comment.get("user")
+    if (
+        comment.get("author_association") not in ALLOWED_ASSOCIATIONS
+        or not isinstance(user, dict)
+        or user.get("type") != "User"
+        or not isinstance(user.get("login"), str)
+        or not user["login"]
+        or not isinstance(event_user, dict)
+        or event_user.get("login") != user["login"]
+        or event_user.get("type") != user["type"]
+    ):
+        raise ContractError("actor_unauthorized")
+
+
+def require_exact_open_same_repository_pr(
+    pull_request: object, request: FallbackRequest
+) -> None:
+    if not isinstance(pull_request, dict):
+        raise ContractError("pull_request_invalid")
+    head = pull_request.get("head")
+    base = pull_request.get("base")
+    if (
+        pull_request.get("number") != request.pr
+        or pull_request.get("state") != "open"
+        or pull_request.get("merged") is not False
+        or not isinstance(head, dict)
+        or not isinstance(base, dict)
+        or head.get("sha") != request.expected_head_sha
+        or base.get("sha") != request.expected_base_sha
+        or not isinstance(head.get("repo"), dict)
+        or not isinstance(base.get("repo"), dict)
+        or head["repo"].get("full_name") != request.repository
+        or head["repo"].get("fork") is not False
+        or base["repo"].get("full_name") != request.repository
+    ):
+        raise ContractError("pull_request_invalid")
+
+
+def require_exact_automatic_run(run: object, request: FallbackRequest) -> None:
+    if not isinstance(run, dict):
+        raise ContractError("original_run_invalid")
+    bindings = run.get("pull_requests")
+    references = run.get("referenced_workflows")
+    reference_prefix = "jhw7500/automation/.github/workflows/claude-code-review.yml@"
+    reference_path = (
+        references[0].get("path")
+        if isinstance(references, list)
+        and len(references) == 1
+        and isinstance(references[0], dict)
+        else None
+    )
+    if (
+        run.get("id") != request.original_run_id
+        or run.get("run_attempt") != request.original_run_attempt
+        or run.get("name") != "Claude Code Review"
+        or run.get("event") != "pull_request"
+        or run.get("status") != "completed"
+        or run.get("conclusion") != "failure"
+        or run.get("head_sha") != request.expected_head_sha
+        or not isinstance(run.get("repository"), dict)
+        or run["repository"].get("full_name") != request.repository
+        or not isinstance(bindings, list)
+        or len(bindings) != 1
+        or not isinstance(bindings[0], dict)
+        or bindings[0].get("number") != request.pr
+        or not isinstance(bindings[0].get("head"), dict)
+        or bindings[0]["head"].get("sha") != request.expected_head_sha
+        or not isinstance(bindings[0].get("base"), dict)
+        or bindings[0]["base"].get("sha") != request.expected_base_sha
+        or not isinstance(references, list)
+        or len(references) != 1
+        or not isinstance(references[0], dict)
+        or not isinstance(reference_path, str)
+        or not reference_path.startswith(reference_prefix)
+        or not reference_path[len(reference_prefix) :]
+        or references[0].get("sha") != request.release_commit
+    ):
+        raise ContractError("original_run_invalid")
+
+
+def _github_time(value: object) -> datetime:
+    if not isinstance(value, str) or re.fullmatch(
+        r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z", value
+    ) is None:
+        raise ContractError("request_order_invalid")
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError:
+        raise ContractError("request_order_invalid") from None
+
+
+def require_causal_order(run: object, comment: object) -> None:
+    if not isinstance(run, dict) or not isinstance(comment, dict):
+        raise ContractError("request_order_invalid")
+    if _github_time(run.get("updated_at")) > _github_time(comment.get("created_at")):
+        raise ContractError("request_order_invalid")
+
+
+def _completed_step(steps: list[dict[str, object]], name: str) -> dict[str, object]:
+    matches = [step for step in steps if step.get("name") == name]
+    if len(matches) != 1 or matches[0].get("status") != "completed":
+        raise ContractError("original_jobs_invalid")
+    return matches[0]
+
+
+def require_failed_before_provider(jobs: object) -> None:
+    if not isinstance(jobs, dict):
+        raise ContractError("original_jobs_invalid")
+    total = jobs.get("total_count")
+    items = jobs.get("jobs")
+    if (
+        type(total) is not int
+        or not 1 <= total <= 100
+        or not isinstance(items, list)
+        or len(items) != total
+        or not all(isinstance(item, dict) for item in items)
+    ):
+        raise ContractError("original_jobs_invalid")
+    matches = [
+        item
+        for item in items
+        if re.search(r"(?:^| / )claude-review\Z", str(item.get("name", "")))
+    ]
+    if len(matches) != 1:
+        raise ContractError("original_jobs_invalid")
+    job = matches[0]
+    steps_value = job.get("steps")
+    if (
+        job.get("status") != "completed"
+        or job.get("conclusion") != "failure"
+        or type(job.get("run_id")) is not int
+        or not isinstance(steps_value, list)
+        or not 1 <= len(steps_value) <= 100
+        or not all(isinstance(step, dict) for step in steps_value)
+    ):
+        raise ContractError("original_jobs_invalid")
+    steps: list[dict[str, object]] = steps_value
+    numbers = [step.get("number") for step in steps]
+    if (
+        any(type(number) is not int or not 1 <= number <= MAX_SAFE_INTEGER for number in numbers)
+        or numbers != sorted(set(numbers))
+    ):
+        raise ContractError("original_jobs_invalid")
+    validation = _completed_step(steps, "Validate Claude caller workflow")
+    claim = _completed_step(steps, "Claim Claude review budget")
+    provider = _completed_step(steps, "Run Claude Code Review")
+    if validation.get("conclusion") != "failure":
+        raise ContractError("original_jobs_invalid")
+    if claim.get("conclusion") != "skipped":
+        raise ContractError("budget_claimed")
+    if provider.get("conclusion") != "skipped":
+        raise ContractError("provider_entered")
+    if not validation["number"] < claim["number"] < provider["number"]:
+        raise ContractError("original_jobs_invalid")
+
+
+def _request_tuple(request: FallbackRequest) -> tuple[object, ...]:
+    return (
+        request.repository,
+        request.pr,
+        request.expected_head_sha,
+        request.expected_base_sha,
+        request.original_run_id,
+        request.original_run_attempt,
+        request.release_commit,
+        request.managed_diff_sha256,
+    )
+
+
+def _comment_list(comments: object) -> list[dict[str, object]]:
+    if not isinstance(comments, list) or not all(
+        isinstance(comment, dict) for comment in comments
+    ):
+        raise ContractError("comments_invalid")
+    if len(comments) >= 1000:
+        raise ContractError("comment_horizon_exceeded")
+    return comments
+
+
+def require_unique_request(
+    comments: object, current_comment_id: int, request: FallbackRequest
+) -> None:
+    matches: list[int] = []
+    for comment in _comment_list(comments):
+        body = comment.get("body")
+        if not isinstance(body, str):
+            continue
+        try:
+            candidate = parse_request_body(body)
+        except ContractError:
+            continue
+        if _request_tuple(candidate) == _request_tuple(request):
+            matches.append(positive_id(comment.get("id"), "request_ambiguous"))
+    if matches != [current_comment_id]:
+        raise ContractError("request_ambiguous")
+
+
+def _strict_state_json(raw: str) -> dict[str, object]:
+    def unique(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ContractError("automatic_state_invalid")
+            result[key] = value
+        return result
+
+    def reject_constant(_: str) -> object:
+        raise ContractError("automatic_state_invalid")
+
+    try:
+        value = json.loads(
+            raw, object_pairs_hook=unique, parse_constant=reject_constant
+        )
+    except (json.JSONDecodeError, ContractError, RecursionError):
+        raise ContractError("automatic_state_invalid") from None
+    if not isinstance(value, dict):
+        raise ContractError("automatic_state_invalid")
+    return value
+
+
+def _state_comments(
+    comments: object,
+) -> list[tuple[dict[str, object], dict[str, object], bytes]]:
+    records: list[tuple[dict[str, object], dict[str, object], bytes]] = []
+    for comment in _comment_list(comments):
+        user = comment.get("user")
+        body = comment.get("body")
+        if (
+            not isinstance(user, dict)
+            or user.get("login") != "github-actions[bot]"
+            or user.get("type") != "Bot"
+            or not isinstance(body, str)
+        ):
+            continue
+        try:
+            body_bytes = body.encode("utf-8")
+        except UnicodeEncodeError:
+            raise ContractError("automatic_state_invalid") from None
+        if len(body_bytes) > 65536:
+            raise ContractError("automatic_state_invalid")
+        lines = body.split("\n")
+        if len(lines) < 3 or lines[0] != AUTOMATIC_HEADER or lines[1] != AUTOMATIC_MARKER:
+            continue
+        match = STATE_LINE_RE.fullmatch(lines[2])
+        if match is None:
+            raise ContractError("automatic_state_invalid")
+        raw = match.group("json")
+        records.append((comment, _strict_state_json(raw), raw.encode("utf-8")))
+    return records
+
+
+def _valid_preserved_quality(state: dict[str, object]) -> bool:
+    successful = state.get("successful_head")
+    digest = state.get("full_diff_sha256")
+    values = (
+        state.get("accepted_count"),
+        state.get("filtered_count"),
+        state.get("normalized_count"),
+    )
+    severity = state.get("filtered_max_severity")
+    if successful is None:
+        return digest is None and all(value is None for value in values) and severity is None
+    return (
+        isinstance(successful, str)
+        and SHA_RE.fullmatch(successful) is not None
+        and isinstance(digest, str)
+        and DIGEST_RE.fullmatch(digest) is not None
+        and all(type(value) is int and 0 <= value <= MAX_SAFE_INTEGER for value in values)
+        and severity in {"none", "MEDIUM", "HIGH", "CRITICAL"}
+    )
+
+
+def require_automatic_failure_state(
+    comments: object, request: FallbackRequest
+) -> tuple[int, bytes]:
+    matches: list[tuple[int, bytes]] = []
+    for comment, state, raw in _state_comments(comments):
+        if (
+            state.get("reviewer") != "claude"
+            or state.get("pr") != request.pr
+            or state.get("run_id") != request.original_run_id
+            or state.get("run_attempt") != request.original_run_attempt
+        ):
+            continue
+        if (
+            set(state) != FAILURE_STATE_KEYS
+            or state.get("schema") != 3
+            or state.get("quality_schema") != 1
+            or state.get("attempt_head") != request.expected_head_sha
+            or state.get("attempt_status") != "failure"
+            or state.get("diff_mode") not in {"full", "delta", "unavailable"}
+            or state.get("review_execution") != "not_performed"
+            or state.get("failure_reason") != "workflow_validation_mismatch"
+            or not _valid_preserved_quality(state)
+        ):
+            raise ContractError("automatic_state_invalid")
+        matches.append(
+            (positive_id(comment.get("id"), "automatic_state_invalid"), raw)
+        )
+    if len(matches) != 1:
+        raise ContractError("automatic_state_ambiguous")
+    return matches[0]
+
+
+def require_no_successful_fallback(
+    comments: object, request: FallbackRequest
+) -> None:
+    for _, state, _ in _state_comments(comments):
+        route = state.get("route")
+        if (
+            state.get("schema") == 3
+            and state.get("reviewer") == "claude"
+            and state.get("pr") == request.pr
+            and state.get("attempt_status") == "success"
+            and state.get("successful_head") == request.expected_head_sha
+            and isinstance(route, dict)
+            and set(route) == FALLBACK_ROUTE_KEYS
+            and route.get("route") == "default_branch_rollout_fallback"
+            and route.get("original_failed_run_id") == request.original_run_id
+            and route.get("reviewed_base_sha") == request.expected_base_sha
+            and route.get("release_commit") == request.release_commit
+            and route.get("managed_diff_sha256") == request.managed_diff_sha256
+        ):
+            raise ContractError("fallback_already_succeeded")
+
+
+def admit(bundle: EvidenceBundle) -> FallbackAdmission:
+    request = require_managed_created_event(bundle.event_name, bundle.event)
+    require_exact_comment(bundle.comment, bundle.event, request)
+    require_exact_open_same_repository_pr(bundle.pull_request, request)
+    require_exact_automatic_run(bundle.original_run, request)
+    require_causal_order(bundle.original_run, bundle.comment)
+    require_failed_before_provider(bundle.original_jobs)
+    jobs = bundle.original_jobs["jobs"]
+    if any(
+        job.get("run_id") != request.original_run_id
+        or (
+            "run_attempt" in job
+            and job.get("run_attempt") != request.original_run_attempt
+        )
+        for job in jobs
+    ):
+        raise ContractError("original_jobs_invalid")
+    request_comment_id = positive_id(
+        bundle.comment["id"], "request_comment_id_invalid"
+    )
+    require_unique_request(bundle.issue_comments, request_comment_id, request)
+    comment_id, state_bytes = require_automatic_failure_state(
+        bundle.issue_comments, request
+    )
+    require_no_successful_fallback(bundle.issue_comments, request)
+    return FallbackAdmission(
+        request_comment_id=request_comment_id,
+        request=request,
+        automatic_comment_id=comment_id,
+        automatic_state_sha256=hashlib.sha256(state_bytes).hexdigest(),
+    )
+
+
+def _read_json(path: Path, reason: str, *, limit: int, private: bool = False) -> object:
+    try:
+        info = path.lstat()
+        if not stat.S_ISREG(info.st_mode):
+            raise ContractError(reason)
+        if private and (
+            info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) & 0o077
+        ):
+            raise ContractError(reason)
+        payload = path.read_bytes()
+    except (OSError, ContractError):
+        raise ContractError(reason) from None
+    if len(payload) > limit:
+        raise ContractError(reason)
+
+    def unique(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ContractError(reason)
+            result[key] = value
+        return result
+
+    def reject_constant(_: str) -> object:
+        raise ContractError(reason)
+
+    try:
+        return json.loads(
+            payload, object_pairs_hook=unique, parse_constant=reject_constant
+        )
+    except (UnicodeError, ValueError, TypeError, RecursionError):
+        raise ContractError(reason) from None
+
+
+def _write_private_json(path: Path, value: dict[str, object]) -> None:
+    payload = json.dumps(
+        value, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("ascii") + b"\n"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, 0o600)
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "wb", closefd=False) as stream:
+                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+        finally:
+            os.close(descriptor)
+        info = path.lstat()
+    except OSError:
+        raise ContractError("private_file_invalid") from None
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or info.st_uid != os.getuid()
+        or stat.S_IMODE(info.st_mode) != 0o600
+    ):
+        raise ContractError("private_file_invalid")
+
+
+def _build_plan(
+    event_name: str, event: dict[str, object], request: FallbackRequest
+) -> dict[str, object]:
+    comment = event.get("comment")
+    if not isinstance(comment, dict):
+        raise ContractError("event_invalid")
+    comment_id = positive_id(comment.get("id"), "event_invalid")
+    repository = request.repository
+    run_root = (
+        f"repos/{repository}/actions/runs/{request.original_run_id}/attempts/"
+        f"{request.original_run_attempt}"
+    )
+    requests: list[dict[str, str]] = [
+        {
+            "endpoint": f"repos/{repository}/issues/comments/{comment_id}",
+            "name": "comment.json",
+        },
+        {
+            "endpoint": f"repos/{repository}/pulls/{request.pr}",
+            "name": "pull_request.json",
+        },
+        {"endpoint": run_root, "name": "original_run.json"},
+        {"endpoint": f"{run_root}/jobs?per_page=100", "name": "original_jobs.json"},
+    ]
+    requests.extend(
+        {
+            "endpoint": (
+                f"repos/{repository}/issues/{request.pr}/comments"
+                f"?per_page=100&page={page}"
+            ),
+            "name": f"comments-{page:02d}.json",
+        }
+        for page in range(1, 11)
+    )
+    return {
+        "event": event,
+        "event_name": event_name,
+        "request": request.to_dict(),
+        "requests": requests,
+        "schema": 1,
+    }
+
+
+def _output_values(
+    route: str, reason: str, admission: FallbackAdmission | None = None
+) -> dict[str, str]:
+    values = {name: "" for name in OUTPUT_NAMES}
+    values["route"] = route
+    values["reason"] = reason
+    if admission is not None:
+        request = admission.request
+        values.update(
+            {
+                "request-comment-id": str(admission.request_comment_id),
+                "request-nonce": request.nonce,
+                "expected-head-sha": request.expected_head_sha,
+                "expected-base-sha": request.expected_base_sha,
+                "original-run-id": str(request.original_run_id),
+                "original-run-attempt": str(request.original_run_attempt),
+                "release-commit": request.release_commit,
+                "managed-diff-sha256": request.managed_diff_sha256,
+                "automatic-comment-id": str(admission.automatic_comment_id),
+                "automatic-state-sha256": admission.automatic_state_sha256,
+            }
+        )
+    return values
+
+
+def _append_outputs(path: Path, values: dict[str, str], *, only_route: bool = False) -> None:
+    names = OUTPUT_NAMES[:2] if only_route else OUTPUT_NAMES
+    patterns = {
+        "route": re.compile(r"(?:interactive|invalid|managed)\Z"),
+        "reason": re.compile(r"[a-z_]*\Z"),
+        "request-comment-id": re.compile(r"(?:|[1-9][0-9]{0,15})\Z"),
+        "request-nonce": re.compile(r"(?:|[0-9a-f]{32})\Z"),
+        "expected-head-sha": re.compile(r"(?:|[0-9a-f]{40})\Z"),
+        "expected-base-sha": re.compile(r"(?:|[0-9a-f]{40})\Z"),
+        "original-run-id": re.compile(r"(?:|[1-9][0-9]{0,15})\Z"),
+        "original-run-attempt": re.compile(r"(?:|[1-9][0-9]{0,15})\Z"),
+        "release-commit": re.compile(r"(?:|[0-9a-f]{40})\Z"),
+        "managed-diff-sha256": re.compile(r"(?:|[0-9a-f]{64})\Z"),
+        "automatic-comment-id": re.compile(r"(?:|[1-9][0-9]{0,15})\Z"),
+        "automatic-state-sha256": re.compile(r"(?:|[0-9a-f]{64})\Z"),
+    }
+    if set(values) != set(OUTPUT_NAMES) or any(
+        patterns[name].fullmatch(values[name]) is None for name in names
+    ):
+        raise ContractError("output_invalid")
+    try:
+        with path.open("a", encoding="utf-8", newline="\n") as stream:
+            for name in names:
+                stream.write(f"{name}={values[name]}\n")
+    except OSError:
+        raise ContractError("output_invalid") from None
+
+
+def _plan_command(arguments: argparse.Namespace) -> int:
+    event_value = _read_json(Path(arguments.event_file), "event_invalid", limit=2_000_000)
+    classification = classify_event(arguments.event_name, event_value)
+    if classification.route != "managed_candidate":
+        _append_outputs(
+            Path(arguments.github_output),
+            _output_values(classification.route, classification.reason),
+            only_route=True,
+        )
+        return 0
+    if not isinstance(event_value, dict) or classification.request is None:
+        raise ContractError("event_invalid")
+    request = require_managed_created_event(arguments.event_name, event_value)
+    _write_private_json(
+        Path(arguments.plan_file),
+        _build_plan(arguments.event_name, event_value, request),
+    )
+    return 0
+
+
+def _verified_plan(path: Path) -> tuple[str, dict[str, object], FallbackRequest]:
+    plan = _read_json(path, "plan_invalid", limit=2_000_000, private=True)
+    if not isinstance(plan, dict) or set(plan) != {
+        "event",
+        "event_name",
+        "request",
+        "requests",
+        "schema",
+    }:
+        raise ContractError("plan_invalid")
+    event_name = plan.get("event_name")
+    event = plan.get("event")
+    if not isinstance(event_name, str) or not isinstance(event, dict):
+        raise ContractError("plan_invalid")
+    request = require_managed_created_event(event_name, event)
+    try:
+        planned_request = FallbackRequest.from_dict(plan.get("request"))
+    except ContractError:
+        raise ContractError("plan_invalid") from None
+    if planned_request != request or plan != _build_plan(event_name, event, request):
+        raise ContractError("plan_invalid")
+    return event_name, event, request
+
+
+def _evidence_bundle(plan_path: Path, directory: Path) -> EvidenceBundle:
+    event_name, event, _ = _verified_plan(plan_path)
+    try:
+        info = directory.lstat()
+    except OSError:
+        raise ContractError("evidence_invalid") from None
+    if (
+        not stat.S_ISDIR(info.st_mode)
+        or info.st_uid != os.getuid()
+        or stat.S_IMODE(info.st_mode) & 0o077
+    ):
+        raise ContractError("evidence_invalid")
+    fixed = {
+        name: _read_json(directory / name, "evidence_invalid", limit=8_000_000, private=True)
+        for name in (
+            "comment.json",
+            "pull_request.json",
+            "original_run.json",
+            "original_jobs.json",
+        )
+    }
+    comments: list[object] = []
+    complete = False
+    for page in range(1, 11):
+        page_path = directory / f"comments-{page:02d}.json"
+        if not page_path.exists():
+            if page == 1 or not complete:
+                raise ContractError("evidence_invalid")
+            break
+        if complete:
+            raise ContractError("evidence_invalid")
+        value = _read_json(page_path, "evidence_invalid", limit=8_000_000, private=True)
+        if not isinstance(value, list) or len(value) > 100:
+            raise ContractError("evidence_invalid")
+        comments.extend(value)
+        complete = len(value) < 100
+    if not complete:
+        raise ContractError("comment_horizon_exceeded")
+    return EvidenceBundle(
+        event_name=event_name,
+        event=event,
+        comment=fixed["comment.json"],
+        pull_request=fixed["pull_request.json"],
+        original_run=fixed["original_run.json"],
+        original_jobs=fixed["original_jobs.json"],
+        issue_comments=comments,
+    )
+
+
+def _verify_command(arguments: argparse.Namespace) -> int:
+    output_path = Path(arguments.github_output)
+    try:
+        admission = admit(
+            _evidence_bundle(
+                Path(arguments.plan_file), Path(arguments.evidence_directory)
+            )
+        )
+        _write_private_json(Path(arguments.admission_file), admission.to_dict())
+        _append_outputs(output_path, _output_values("managed", "", admission))
+    except ContractError as error:
+        reason = str(error)
+        if re.fullmatch(r"[a-z_]+", reason) is None:
+            reason = "admission_invalid"
+        _append_outputs(output_path, _output_values("invalid", reason))
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    plan = commands.add_parser("plan")
+    plan.add_argument("--event-name", required=True)
+    plan.add_argument("--event-file", required=True)
+    plan.add_argument("--plan-file", required=True)
+    plan.add_argument("--github-output", required=True)
+    verify = commands.add_parser("verify")
+    verify.add_argument("--plan-file", required=True)
+    verify.add_argument("--evidence-directory", required=True)
+    verify.add_argument("--admission-file", required=True)
+    verify.add_argument("--github-output", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    try:
+        if arguments.command == "plan":
+            return _plan_command(arguments)
+        return _verify_command(arguments)
+    except ContractError as error:
+        if arguments.command == "plan":
+            reason = str(error)
+            if re.fullmatch(r"[a-z_]+", reason) is None:
+                reason = "request_invalid"
+            _append_outputs(
+                Path(arguments.github_output),
+                _output_values("invalid", reason),
+                only_route=True,
+            )
+            return 0
+        raise
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/claude-rollout-fallback/contract.py
+++ b/.github/actions/claude-rollout-fallback/contract.py
@@ -461,6 +461,15 @@ def require_failed_before_provider(jobs: object) -> None:
     if len(matches) != 1:
         raise ContractError("original_jobs_invalid")
     job = matches[0]
+    if any(
+        item is not job
+        and (
+            item.get("status") != "completed"
+            or item.get("conclusion") not in {"success", "skipped"}
+        )
+        for item in items
+    ):
+        raise ContractError("original_jobs_invalid")
     steps_value = job.get("steps")
     if (
         job.get("status") != "completed"
@@ -487,6 +496,15 @@ def require_failed_before_provider(jobs: object) -> None:
         raise ContractError("budget_claimed")
     if provider.get("conclusion") != "skipped":
         raise ContractError("provider_entered")
+    if any(
+        step is not validation
+        and (
+            step.get("status") != "completed"
+            or step.get("conclusion") not in {"success", "skipped"}
+        )
+        for step in steps
+    ):
+        raise ContractError("original_jobs_invalid")
     if not validation["number"] < claim["number"] < provider["number"]:
         raise ContractError("original_jobs_invalid")
 

--- a/.github/actions/recover-opencode-review/evidence.py
+++ b/.github/actions/recover-opencode-review/evidence.py
@@ -84,15 +84,17 @@ def read_artifact(metadata: dict, payload: bytes, expected_name: str, run_id: in
     except (zipfile.BadZipFile, NotImplementedError, RuntimeError, OSError) as exc:
         raise RecoveryError("artifact_zip_invalid") from exc
 
-# Only the reviewed v1.74/v1.75 and v1.76 canonicalizers are executable in recovery.
+# Only the reviewed v1.74 through v1.77 canonicalizers are executable in recovery.
 # Future formats must add a reviewed replay contract; unknown source fails closed.
 APPROVED_REPLAY_SHA256 = frozenset({
     "b8804d0c387e4f7e554443a1d0edd5862d9c4b1c1435de4140c621c241a25df5",
     "3915f9bc32985745996d2246017cff9122460d25a071ca72568ac73c75339371",
+    "deb5353681c02b8932b9da47c49c28549654f6b8dc5852c58e7497de84e6623a",
 })
 APPROVED_WORKFLOW_SHA256 = frozenset({
     "f81db9665847aea815c8691caea7c6458011595cbed28c13809f051c381b5e91",
     "9cc171e9c11de4c6719d73922fed0373c5db0281feae7488c55c7447025bf0ab",
+    "ff4b2acfb3a87f66a77e5e9821d0d60237b6335cbe2a7afd6e7af484a80d66bb",
 })
 
 def _budget_module():

--- a/.github/actions/recover-opencode-review/receipt.js
+++ b/.github/actions/recover-opencode-review/receipt.js
@@ -27,10 +27,11 @@ const STATE_KEYS = ['schema', 'reviewer', 'pr', 'run_id', 'run_attempt', 'attemp
 const ATTESTATION_KEYS = ['schema', 'repository', 'workflow', 'caller_workflow_path', 'caller_event',
   'referenced_workflow_path', 'referenced_workflow_sha', 'pr', 'attempt_head', 'workflow_head',
   'successful_head', 'run_id', 'run_attempt', 'prepared_run_attempt', 'comment_id', 'body_sha256', 'state_sha256'];
-const INVOCATION_KEYS = ['run_id', 'run_attempt', 'head_sha', 'full_diff_sha256', 'caller_workflow_path',
+const INVOCATION_KEYS_V1 = ['run_id', 'run_attempt', 'head_sha', 'full_diff_sha256', 'caller_workflow_path',
   'caller_event', 'referenced_workflow_path', 'referenced_workflow_ref', 'referenced_workflow_sha',
   'round_number', 'override_event_id', 'model_route', 'effort', 'call_unit', 'call_count',
   'estimated_input_tokens', 'elapsed_seconds', 'status', 'outcome', 'stop_reason', 'remaining_finding_ids'];
+const INVOCATION_KEYS_V2 = [...INVOCATION_KEYS_V1, 'route'];
 
 // Python's ensure_ascii=True and recursive code-point key ordering, including
 // numeric-looking keys (which JSON.stringify on a reconstructed object reorders).
@@ -109,6 +110,11 @@ function receiptShape(r) {
     && exact(o.artifacts, ['handoff', 'claim', 'candidate'])
     && Object.values(o.artifacts).every((a) => exact(a, ['id', 'sha256']) && positive(a.id) && hash(a.sha256))
     && new Set(Object.values(o.artifacts).map((a) => a.id)).size === 3;
+}
+function invocationShape(entry, schema) {
+  if (schema === 1) return exact(entry, INVOCATION_KEYS_V1);
+  return schema === 2 && exact(entry, INVOCATION_KEYS_V2)
+    && exact(entry.route, ['kind']) && entry.route.kind === 'automatic';
 }
 function runMatches(run, binding, repository, event) {
   return run?.id === binding.run_id && run.run_attempt === binding.run_attempt
@@ -196,13 +202,13 @@ function validateReceipt(facts) {
     const ledgerLines = (ledgerComment.body || '').split('\n');
     if (ledgerLines[0] !== LEDGER) return false;
     const ledger = envelope(ledgerLines[1], 'automation-budget-state');
-    if (ledger.schema !== 1 || ledger.repository !== r.repository || ledger.pr !== r.pr || ledger.reviewer !== 'opencode'
+    if (![1, 2].includes(ledger.schema) || ledger.repository !== r.repository || ledger.pr !== r.pr || ledger.reviewer !== 'opencode'
       || !Array.isArray(ledger.invocations) || ledger.invocations.length > 100
       || ledgerLines[1] !== `<!-- automation-budget-state:${canonicalJson(ledger)} -->`) return false;
     const entries = ledger.invocations.filter((e) => e.run_id === o.run_id && e.run_attempt === o.run_attempt);
     if (entries.length !== 1) return false;
     const entry = entries[0];
-    return exact(entry, INVOCATION_KEYS) && entry.status === 'finalized' && ['success', 'quality_filtered'].includes(entry.outcome)
+    return invocationShape(entry, ledger.schema) && entry.status === 'finalized' && ['success', 'quality_filtered'].includes(entry.outcome)
       && entry.caller_event === 'pull_request'
       && ['head_sha', 'full_diff_sha256', 'caller_workflow_path', 'referenced_workflow_path', 'referenced_workflow_sha']
         .every((key) => entry[key] === o[key])

--- a/.github/actions/recover-opencode-review/receipt.js
+++ b/.github/actions/recover-opencode-review/receipt.js
@@ -116,6 +116,12 @@ function invocationShape(entry, schema) {
   return schema === 2 && exact(entry, INVOCATION_KEYS_V2)
     && exact(entry.route, ['kind']) && entry.route.kind === 'automatic';
 }
+function invocationDigestMatches(entry, schema, expected) {
+  if (sha(canonicalJson(entry)) === expected) return true;
+  if (schema !== 2 || entry.route.kind !== 'automatic') return false;
+  const historical = Object.fromEntries(INVOCATION_KEYS_V1.map((key) => [key, entry[key]]));
+  return sha(canonicalJson(historical)) === expected;
+}
 function runMatches(run, binding, repository, event) {
   return run?.id === binding.run_id && run.run_attempt === binding.run_attempt
     && run.repository?.full_name === repository && run.head_sha === binding.workflow_head
@@ -215,7 +221,7 @@ function validateReceipt(facts) {
       && originalRun.referenced_workflows.some((ref) => ref.path === o.referenced_workflow_path
         && ref.sha === o.referenced_workflow_sha
         && entry.referenced_workflow_ref === ('ref' in ref ? ref.ref : ref.sha))
-      && sha(canonicalJson(entry)) === o.finalized_invocation_sha256;
+      && invocationDigestMatches(entry, ledger.schema, o.finalized_invocation_sha256);
   } catch { return false; }
 }
 

--- a/.github/actions/recover-opencode-review/replay.js
+++ b/.github/actions/recover-opencode-review/replay.js
@@ -6,7 +6,8 @@ const crypto = require('node:crypto');
 const childProcess = require('node:child_process');
 const input = JSON.parse(fs.readFileSync(0, 'utf8'));
 const approved = new Set(['b8804d0c387e4f7e554443a1d0edd5862d9c4b1c1435de4140c621c241a25df5',
-  '3915f9bc32985745996d2246017cff9122460d25a071ca72568ac73c75339371']);
+  '3915f9bc32985745996d2246017cff9122460d25a071ca72568ac73c75339371',
+  'deb5353681c02b8932b9da47c49c28549654f6b8dc5852c58e7497de84e6623a']);
 if (!approved.has(crypto.createHash('sha256').update(input.source).digest('hex'))) {
   throw new Error('original_replay_unsupported');
 }

--- a/.github/actions/review-invocation-budget/action.yml
+++ b/.github/actions/review-invocation-budget/action.yml
@@ -18,6 +18,9 @@ inputs:
   force-review:
     required: false
     default: 'false'
+  invocation-route-json:
+    required: false
+    default: '{"kind":"automatic"}'
   input-files-json:
     required: true
   authenticated-review-json:
@@ -75,6 +78,7 @@ runs:
         FULL_DIFF_SHA256: ${{ inputs.full-diff-sha256 }}
         DIFF_MODE: ${{ inputs.diff-mode }}
         FORCE_REVIEW: ${{ inputs.force-review }}
+        INVOCATION_ROUTE_JSON: ${{ inputs.invocation-route-json }}
         INPUT_FILES_JSON: ${{ inputs.input-files-json }}
         AUTHENTICATED_REVIEW_JSON: ${{ inputs.authenticated-review-json }}
         MODEL_ROUTE_JSON: ${{ inputs.model-route-json }}
@@ -140,7 +144,7 @@ runs:
           "$BUDGET_MODE" "$GITHUB_REPOSITORY" "$PR_NUMBER" "$REVIEWER" \
           "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" "$EXPECTED_HEAD_SHA" \
           "$FULL_DIFF_SHA256" "$DIFF_MODE" "$INPUT_FILES_JSON" \
-          "$FORCE_REVIEW" \
+          "$FORCE_REVIEW" "$INVOCATION_ROUTE_JSON" \
           "$AUTHENTICATED_REVIEW_JSON" "$MODEL_ROUTE_JSON" "$EFFORT" \
           "$ACTUAL_CALL_COUNT" "$ELAPSED_SECONDS" "$REVIEW_OUTCOME" \
           "$STOP_REASON" "$REMAINING_FINDING_IDS_JSON" "$CHECKPOINT_FILE" \
@@ -152,7 +156,7 @@ runs:
         names = (
             "operation", "repository", "pr", "reviewer", "run_id", "run_attempt",
             "head_sha", "full_diff_sha256", "diff_mode", "input_files_json",
-            "force_review",
+            "force_review", "invocation_route_json",
             "authenticated_review_json", "model_route_json", "effort", "actual_call_count",
             "elapsed_seconds", "outcome", "stop_reason", "remaining_finding_ids_json",
             "checkpoint_file", "github_workspace", "server_url",
@@ -282,6 +286,11 @@ runs:
         expected = json.loads(Path(sys.argv[1]).read_text())
         pull = json.loads(Path(sys.argv[2]).read_text())
         if pull.get("head", {}).get("sha") != expected["expected-head-sha"]:
+            raise SystemExit(1)
+        if (
+            expected["expected-base-sha"]
+            and pull.get("base", {}).get("sha") != expected["expected-base-sha"]
+        ):
             raise SystemExit(1)
         if expected["mutation"] == "patch":
             current = json.loads(Path(sys.argv[3]).read_text())

--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -1696,11 +1696,15 @@ def load_checkpoint(payload: bytes) -> LedgerState:
     raw = _exact_keys(raw, {"schema", "ledger", "handoff"}, "checkpoint")
     if _integer(raw["schema"], "schema", positive=True) != CHECKPOINT_SCHEMA:
         raise BudgetStateError("checkpoint_schema_invalid")
+    source_schema = raw["ledger"].get("schema") if isinstance(raw["ledger"], dict) else None
     state = LedgerState.from_dict(raw["ledger"])
     handoff = Handoff.from_dict(raw["handoff"])
     if handoff != state.handoff:
         raise BudgetStateError("checkpoint_handoff_mismatch")
-    if payload != render_checkpoint(state):
+    expected = render_checkpoint(state) if source_schema == SCHEMA else (
+        json.dumps(raw, ensure_ascii=True, separators=(",", ":"), sort_keys=True).encode("ascii") + b"\n"
+    )
+    if payload != expected:
         raise BudgetStateError("checkpoint_json_noncanonical")
     return state
 

--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -1456,7 +1456,15 @@ def finalize(
     index, entry = exact[0]
     if entry.status != "claimed":
         return _finalization_refusal(state, request, "invocation_not_claimed")
-    if request.route.to_dict() != entry.route.to_dict():
+    # The composite action's historical force-review callers pass the force flag only
+    # while claiming. Their finalization uses the default automatic route. The exact
+    # same-run ledger entry has already authenticated and consumed the override event,
+    # so retain that stored route for this one legacy default instead of stranding the
+    # provider call. Explicit non-default routes must still match byte-for-byte.
+    final_route = entry.route if (
+        entry.route.kind == "authorized_override" and request.route.kind == "automatic"
+    ) else request.route
+    if final_route.to_dict() != entry.route.to_dict():
         return _finalization_refusal(state, request, "invocation_route_mismatch")
     if request.model_route[0] != entry.model_route[0]:
         return _finalization_refusal(state, request, "model_route_unknown")

--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -1880,7 +1880,10 @@ def _model_route(request: Mapping[str, object]) -> tuple[str, ...]:
 
 
 def _invocation_route(request: Mapping[str, object]) -> InvocationRoute:
-    return InvocationRoute.from_dict(_embedded_json(request, "invocation_route_json"))
+    route = InvocationRoute.from_dict(_embedded_json(request, "invocation_route_json"))
+    if request["force_review"] is True and route.kind == "automatic":
+        return InvocationRoute(kind="authorized_override")
+    return route
 
 
 def _remaining_findings(request: Mapping[str, object]) -> tuple[str, ...]:

--- a/.github/actions/review-invocation-budget/review_invocation_budget.py
+++ b/.github/actions/review-invocation-budget/review_invocation_budget.py
@@ -20,7 +20,8 @@ Reviewer = Literal["claude", "gemini", "opencode"]
 Outcome = Literal["success", "provider_failure", "quality_filtered", "checkpoint_failure", "wall_time_exhausted"]
 Decision = Literal["claimed", "finalized", "state_invalid", "diff_unavailable", "authenticated_reuse", "duplicate_head", "duplicate_effective_diff", "input_budget_exhausted", "round_budget_exhausted", "total_usage_budget_exhausted"]
 
-SCHEMA = 1
+SCHEMA = 2
+CHECKPOINT_SCHEMA = 1
 STATE_PREFIX = "<!-- automation-budget-state:"
 STATE_SUFFIX = " -->"
 MARKERS = {
@@ -37,6 +38,7 @@ CENTRAL_REPOSITORY = "jhw7500/automation"
 
 _HEAD = re.compile(r"[0-9a-f]{40}\Z")
 _HASH = re.compile(r"[0-9a-f]{64}\Z")
+_NONCE = re.compile(r"[0-9a-f]{32}\Z")
 _FINDING = re.compile(r"RVW-[0-9a-f]{12}\Z")
 _CALLER_WORKFLOW = re.compile(r"\.github/workflows/[A-Za-z0-9_./-]+\.ya?ml\Z")
 _WORKFLOW_REF = re.compile(r"[^\x00-\x20\x7f]{1,256}\Z")
@@ -222,6 +224,121 @@ class RunProvenance:
 
 
 @dataclass(frozen=True)
+class InvocationRoute:
+    kind: Literal[
+        "automatic", "authorized_override", "default_branch_rollout_fallback"
+    ]
+    request_comment_id: int | None = None
+    request_nonce: str | None = None
+    original_run_id: int | None = None
+    original_run_attempt: int | None = None
+    expected_base_sha: str | None = None
+    release_commit: str | None = None
+    managed_diff_sha256: str | None = None
+    automatic_comment_id: int | None = None
+    automatic_state_sha256: str | None = None
+
+    @classmethod
+    def automatic(cls) -> "InvocationRoute":
+        return cls(kind="automatic")
+
+    @classmethod
+    def from_legacy_event(cls, event: str) -> "InvocationRoute":
+        kinds = {
+            "pull_request": "automatic",
+            "workflow_dispatch": "authorized_override",
+        }
+        if event not in kinds:
+            raise BudgetStateError("invocation_route_invalid")
+        return cls(kind=kinds[event])
+
+    def to_dict(self) -> dict[str, object]:
+        if self.kind in {"automatic", "authorized_override"}:
+            if any(
+                value is not None
+                for value in (
+                    self.request_comment_id, self.request_nonce,
+                    self.original_run_id, self.original_run_attempt,
+                    self.expected_base_sha, self.release_commit,
+                    self.managed_diff_sha256, self.automatic_comment_id,
+                    self.automatic_state_sha256,
+                )
+            ):
+                raise BudgetStateError("invocation_route_invalid")
+            return {"kind": self.kind}
+        payload = {
+            "kind": self.kind,
+            "request_comment_id": self.request_comment_id,
+            "request_nonce": self.request_nonce,
+            "original_run_id": self.original_run_id,
+            "original_run_attempt": self.original_run_attempt,
+            "expected_base_sha": self.expected_base_sha,
+            "release_commit": self.release_commit,
+            "managed_diff_sha256": self.managed_diff_sha256,
+            "automatic_comment_id": self.automatic_comment_id,
+            "automatic_state_sha256": self.automatic_state_sha256,
+        }
+        InvocationRoute.from_dict(payload)
+        return payload
+
+    @classmethod
+    def from_dict(cls, value: object) -> "InvocationRoute":
+        try:
+            if not isinstance(value, dict):
+                raise BudgetStateError("invocation_route_invalid")
+            kind = value.get("kind")
+            if kind in {"automatic", "authorized_override"}:
+                _exact_keys(value, {"kind"}, "invocation_route")
+                return cls(kind=kind)
+            if kind != "default_branch_rollout_fallback":
+                raise BudgetStateError("invocation_route_invalid")
+            keys = {
+                "kind", "request_comment_id", "request_nonce", "original_run_id",
+                "original_run_attempt", "expected_base_sha", "release_commit",
+                "managed_diff_sha256", "automatic_comment_id", "automatic_state_sha256",
+            }
+            value = _exact_keys(value, keys, "invocation_route")
+            return cls(
+                kind=kind,
+                request_comment_id=_integer(
+                    value["request_comment_id"], "request_comment_id", positive=True,
+                ),
+                request_nonce=_hash(value["request_nonce"], _NONCE, "request_nonce"),
+                original_run_id=_integer(
+                    value["original_run_id"], "original_run_id", positive=True,
+                ),
+                original_run_attempt=_integer(
+                    value["original_run_attempt"], "original_run_attempt", positive=True,
+                ),
+                expected_base_sha=_hash(
+                    value["expected_base_sha"], _HEAD, "expected_base_sha",
+                ),
+                release_commit=_hash(value["release_commit"], _HEAD, "release_commit"),
+                managed_diff_sha256=_hash(
+                    value["managed_diff_sha256"], _HASH, "managed_diff_sha256",
+                ),
+                automatic_comment_id=_integer(
+                    value["automatic_comment_id"], "automatic_comment_id", positive=True,
+                ),
+                automatic_state_sha256=_hash(
+                    value["automatic_state_sha256"], _HASH, "automatic_state_sha256",
+                ),
+            )
+        except (BudgetStateError, KeyError, TypeError) as exc:
+            raise BudgetStateError("invocation_route_invalid") from exc
+
+
+def decode_invocation_route(
+    value: object, *, schema: int, caller_event: str,
+) -> InvocationRoute:
+    if schema == 1:
+        return InvocationRoute.from_legacy_event(caller_event)
+    if schema == 2:
+        return InvocationRoute.from_dict(value)
+    raise BudgetStateError("schema_invalid")
+
+
+@dataclass(frozen=True)
 class Invocation:
     run_id: int
     run_attempt: int
@@ -244,6 +361,7 @@ class Invocation:
     outcome: Outcome | None
     stop_reason: str
     remaining_finding_ids: tuple[str, ...]
+    route: InvocationRoute
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -262,6 +380,7 @@ class Invocation:
             "outcome": self.outcome,
             "override_event_id": self.override_event_id,
             "remaining_finding_ids": list(self.remaining_finding_ids),
+            "route": self.route.to_dict(),
             "round_number": self.round_number,
             "run_attempt": self.run_attempt,
             "run_id": self.run_id,
@@ -271,7 +390,7 @@ class Invocation:
         }
 
     @classmethod
-    def from_dict(cls, value: object) -> "Invocation":
+    def from_dict(cls, value: object, *, schema: int) -> "Invocation":
         keys = {
             "run_id", "run_attempt", "head_sha", "full_diff_sha256",
             "caller_workflow_path", "caller_event", "referenced_workflow_path",
@@ -280,6 +399,8 @@ class Invocation:
             "estimated_input_tokens", "elapsed_seconds", "status", "outcome", "stop_reason",
             "remaining_finding_ids",
         }
+        if schema == 2:
+            keys.add("route")
         value = _exact_keys(value, keys, "invocation")
         route = value["model_route"]
         findings = value["remaining_finding_ids"]
@@ -326,6 +447,10 @@ class Invocation:
             elapsed_seconds=_integer(value["elapsed_seconds"], "elapsed_seconds", minimum=0),
             status=status, outcome=outcome, stop_reason=_string(value["stop_reason"], "stop_reason"),
             remaining_finding_ids=tuple(findings),
+            route=decode_invocation_route(
+                value.get("route"), schema=schema,
+                caller_event=_string(value["caller_event"], "caller_event"),
+            ),
         )
 
 
@@ -520,7 +645,8 @@ class LedgerState:
             dismissed = value["dismissed_findings"]
             if not isinstance(dismissed, list) or not dismissed:
                 raise BudgetStateError("dismissed_findings_invalid")
-        if _integer(value["schema"], "schema", positive=True) != SCHEMA:
+        schema = _integer(value["schema"], "schema", positive=True)
+        if schema not in {1, SCHEMA}:
             raise BudgetStateError("schema_invalid")
         reviewer = _string(value["reviewer"], "reviewer")
         if reviewer not in MARKERS:
@@ -532,7 +658,7 @@ class LedgerState:
         state = cls(
             repository=_string(value["repository"], "repository"), pr=_integer(value["pr"], "pr", positive=True),
             reviewer=reviewer, budgets=BudgetPolicy.from_dict(value["budgets"]),
-            invocations=tuple(Invocation.from_dict(item) for item in invocations),
+            invocations=tuple(Invocation.from_dict(item, schema=schema) for item in invocations),
             consumed_override_event_ids=tuple(_integer(item, "consumed_override_event_id", positive=True) for item in consumed),
             last_decision=DecisionRecord.from_dict(value["last_decision"]), handoff=Handoff.from_dict(value["handoff"]),
             dismissed_findings=tuple(DismissedFinding.from_dict(item) for item in dismissed),
@@ -559,6 +685,7 @@ class ClaimRequest:
     call_unit: str
     force_review: bool = False
     dismiss_events: tuple[DismissEvent, ...] = ()
+    route: InvocationRoute = field(default_factory=InvocationRoute.automatic)
 
 
 @dataclass(frozen=True)
@@ -579,6 +706,7 @@ class FinalizeRequest:
     authenticated_review: AuthenticatedReview
     remaining_finding_ids: tuple[str, ...]
     dismiss_events: tuple[DismissEvent, ...] = ()
+    route: InvocationRoute = field(default_factory=InvocationRoute.automatic)
 
 
 @dataclass(frozen=True)
@@ -637,7 +765,7 @@ def _validate_state_shape(state: LedgerState) -> None:
     if any(isinstance(item, bool) or not isinstance(item, int) or item <= 0 for item in state.consumed_override_event_ids):
         raise BudgetStateError("consumed_override_event_ids_invalid")
     for item in state.invocations:
-        Invocation.from_dict(item.to_dict())
+        Invocation.from_dict(item.to_dict(), schema=SCHEMA)
         _validate_stored_provenance_identity(item, state.reviewer)
         call_failure = (
             item.status == "finalized" and item.outcome == "checkpoint_failure" and
@@ -831,10 +959,13 @@ def parse_ledger(body: str | None, *, repository: str, pr: int, reviewer: Review
         raise BudgetStateError("ledger_marker_invalid")
     payload = body[start:end]
     try:
-        state = LedgerState.from_dict(json.loads(payload))
+        raw = json.loads(payload)
+        state = LedgerState.from_dict(raw)
     except (json.JSONDecodeError, TypeError) as exc:
         raise BudgetStateError("ledger_json_invalid") from exc
-    if payload != serialize_ledger(state):
+    if payload != json.dumps(
+        raw, ensure_ascii=True, separators=(",", ":"), sort_keys=True,
+    ):
         raise BudgetStateError("ledger_json_noncanonical")
     if state.repository != repository or state.pr != pr or state.reviewer != reviewer:
         raise BudgetStateError("ledger_identity_mismatch")
@@ -866,6 +997,18 @@ def _validate_request(request: ClaimRequest) -> None:
         raise BudgetStateError("force_review_invalid")
     if request.force_review and request.diff_mode != "changed":
         raise BudgetStateError("force_review_diff_invalid")
+    if not isinstance(request.route, InvocationRoute):
+        raise BudgetStateError("invocation_route_invalid")
+    InvocationRoute.from_dict(request.route.to_dict())
+    if (
+        request.route.kind == "default_branch_rollout_fallback"
+        and (request.reviewer != "claude" or request.force_review)
+    ):
+        raise BudgetStateError("invocation_route_invalid")
+    if request.route.kind == "authorized_override" and not request.force_review:
+        raise BudgetStateError("invocation_route_invalid")
+    if request.route.kind == "automatic" and request.force_review:
+        raise BudgetStateError("invocation_route_invalid")
     if not isinstance(request.authenticated_review, AuthenticatedReview):
         raise BudgetStateError("authenticated_review_invalid")
     review = request.authenticated_review
@@ -902,7 +1045,7 @@ def _expected_referenced_workflow_path(reviewer: Reviewer, sha: str) -> str:
 def _validate_provenance_identity(
         provenance: RunProvenance, reviewer: Reviewer) -> None:
     if (
-        provenance.caller_event not in {"pull_request", "workflow_dispatch"} or
+        provenance.caller_event not in {"pull_request", "workflow_dispatch", "issue_comment"} or
         not isinstance(provenance.caller_workflow_path, str) or
         _CALLER_WORKFLOW.fullmatch(provenance.caller_workflow_path) is None or
         ".." in Path(provenance.caller_workflow_path).parts or
@@ -917,10 +1060,43 @@ def _validate_provenance_identity(
         raise BudgetStateError("provenance_mismatch")
 
 
+def expected_caller_event(request: ClaimRequest | FinalizeRequest) -> str:
+    return {
+        "automatic": "pull_request",
+        "authorized_override": "workflow_dispatch",
+        "default_branch_rollout_fallback": "issue_comment",
+    }[request.route.kind]
+
+
+def provenance_head(
+        provenance: RunProvenance, request: ClaimRequest | FinalizeRequest) -> str:
+    if request.route.kind == "default_branch_rollout_fallback":
+        if request.reviewer != "claude" or (
+                isinstance(request, ClaimRequest) and request.force_review):
+            raise BudgetStateError("invocation_route_invalid")
+        return request.head_sha
+    return provenance.head_sha
+
+
+def _validate_route_provenance(
+        route: InvocationRoute, provenance: RunProvenance, reviewer: Reviewer) -> None:
+    if route.kind == "default_branch_rollout_fallback":
+        if (
+            reviewer != "claude"
+            or provenance.caller_event != "issue_comment"
+            or provenance.caller_workflow_path != ".github/workflows/claude.yml"
+        ):
+            raise BudgetStateError("provenance_mismatch")
+    elif provenance.caller_event != {
+        "automatic": "pull_request",
+        "authorized_override": "workflow_dispatch",
+    }[route.kind]:
+        raise BudgetStateError("provenance_mismatch")
+
+
 def _validate_stored_provenance_identity(
         invocation: Invocation, reviewer: Reviewer) -> None:
-    _validate_provenance_identity(
-        RunProvenance(
+    provenance = RunProvenance(
             repository="stored/stored",
             pr=1,
             head_sha=invocation.head_sha,
@@ -933,9 +1109,9 @@ def _validate_stored_provenance_identity(
             run_attempt=invocation.run_attempt,
             status=invocation.status,
             conclusion=invocation.outcome,
-        ),
-        reviewer,
-    )
+        )
+    _validate_provenance_identity(provenance, reviewer)
+    _validate_route_provenance(invocation.route, provenance, reviewer)
 
 
 def _validate_one_provenance(
@@ -948,19 +1124,14 @@ def _validate_one_provenance(
     expected_run_attempt = (
         request.run_attempt if invocation is None else invocation.run_attempt
     )
-    expected_event = (
-        invocation.caller_event
-        if invocation is not None
-        else (
-            "workflow_dispatch"
-            if isinstance(request, ClaimRequest) and request.force_review
-            else "pull_request"
-        )
-    )
+    expected_event = invocation.caller_event if invocation is not None else expected_caller_event(request)
+    route = invocation.route if invocation is not None else request.route
+    _validate_route_provenance(route, provenance, state.reviewer)
+    observed_head = provenance.head_sha if invocation is not None else provenance_head(provenance, request)
     if (
         provenance.repository != state.repository or
         provenance.pr != state.pr or
-        provenance.head_sha != expected_head or
+        observed_head != expected_head or
         provenance.caller_event != expected_event or
         provenance.run_id != expected_run_id or
         provenance.run_attempt != expected_run_attempt or
@@ -1117,7 +1288,7 @@ def append_claim(
         override_event_id=None if override is None else override.event_id, model_route=request.model_route,
         effort=request.effort, call_unit=request.call_unit, call_count=0,
         estimated_input_tokens=request.estimated_input_tokens, elapsed_seconds=0, status="claimed",
-        outcome=None, stop_reason="claimed", remaining_finding_ids=(),
+        outcome=None, stop_reason="claimed", remaining_finding_ids=(), route=request.route,
     )
     consumed = state.consumed_override_event_ids if override is None else state.consumed_override_event_ids + (override.event_id,)
     updated = replace(state, invocations=state.invocations + (item,), consumed_override_event_ids=consumed)
@@ -1215,6 +1386,11 @@ def _validate_finalize_request(request: FinalizeRequest) -> None:
     _integer(request.run_attempt, "run_attempt", positive=True)
     _hash(request.head_sha, _HEAD, "head_sha")
     _hash(request.full_diff_sha256, _HASH, "full_diff_sha256")
+    if not isinstance(request.route, InvocationRoute):
+        raise BudgetStateError("invocation_route_invalid")
+    InvocationRoute.from_dict(request.route.to_dict())
+    if request.route.kind == "default_branch_rollout_fallback" and request.reviewer != "claude":
+        raise BudgetStateError("invocation_route_invalid")
     _integer(request.call_count, "call_count", minimum=0)
     _integer(request.elapsed_seconds, "elapsed_seconds", minimum=0)
     if (not isinstance(request.model_route, tuple) or not request.model_route or
@@ -1298,6 +1474,8 @@ def finalize(
     index, entry = exact[0]
     if entry.status != "claimed":
         return _finalization_refusal(state, request, "invocation_not_claimed")
+    if request.route.to_dict() != entry.route.to_dict():
+        return _finalization_refusal(state, request, "invocation_route_mismatch")
     if request.model_route[0] != entry.model_route[0]:
         return _finalization_refusal(state, request, "model_route_unknown")
     outcome = request.outcome
@@ -1371,7 +1549,7 @@ def recover_finalize(
         _validate_state_shape(state)
         if not isinstance(original_claim, Invocation):
             raise BudgetStateError("original_claim_invalid")
-        Invocation.from_dict(original_claim.to_dict())
+        Invocation.from_dict(original_claim.to_dict(), schema=SCHEMA)
         if original_claim.status != "claimed" or original_claim.remaining_finding_ids:
             raise BudgetStateError("original_claim_invalid")
     except (AttributeError, BudgetStateError) as exc:
@@ -1386,6 +1564,8 @@ def recover_finalize(
             original_claim.run_id, original_claim.run_attempt,
             original_claim.head_sha, original_claim.full_diff_sha256):
         return _invalid_transition(state, request, "recovery_request_mismatch")
+    if request.route.to_dict() != original_claim.route.to_dict():
+        return _invalid_transition(state, request, "invocation_route_mismatch")
     if (request.outcome not in {"success", "quality_filtered"}
             or not request.authenticated_review.success
             or request.authenticated_review.head_sha != request.head_sha
@@ -1495,7 +1675,11 @@ def render_comment(state: LedgerState, *, server_url: str) -> str:
 
 def render_checkpoint(state: LedgerState) -> bytes:
     _validate_state_shape(state)
-    payload = {"schema": SCHEMA, "ledger": state.to_dict(), "handoff": state.handoff.to_dict()}
+    payload = {
+        "schema": CHECKPOINT_SCHEMA,
+        "ledger": state.to_dict(),
+        "handoff": state.handoff.to_dict(),
+    }
     return (
         json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True).encode("ascii") + b"\n"
     )
@@ -1510,7 +1694,7 @@ def load_checkpoint(payload: bytes) -> LedgerState:
     except (UnicodeDecodeError, json.JSONDecodeError, TypeError) as exc:
         raise BudgetStateError("checkpoint_json_invalid") from exc
     raw = _exact_keys(raw, {"schema", "ledger", "handoff"}, "checkpoint")
-    if _integer(raw["schema"], "schema", positive=True) != SCHEMA:
+    if _integer(raw["schema"], "schema", positive=True) != CHECKPOINT_SCHEMA:
         raise BudgetStateError("checkpoint_schema_invalid")
     state = LedgerState.from_dict(raw["ledger"])
     handoff = Handoff.from_dict(raw["handoff"])
@@ -1612,6 +1796,7 @@ def _transport_request(path: Path) -> dict[str, object]:
         "elapsed_seconds", "outcome", "stop_reason", "remaining_finding_ids_json",
         "checkpoint_file", "github_workspace", "server_url",
         "force_review",
+        "invocation_route_json",
     }
     value = dict(_exact_keys(value, keys, "request"))
     repository = _string(value["repository"], "repository")
@@ -1650,7 +1835,8 @@ def _transport_request(path: Path) -> dict[str, object]:
         raise TransportError("force_review_invalid")
     value["force_review"] = force_review == "true"
     for name in (
-        "input_files_json", "authenticated_review_json", "model_route_json", "effort",
+        "input_files_json", "authenticated_review_json", "invocation_route_json",
+        "model_route_json", "effort",
         "outcome", "stop_reason", "remaining_finding_ids_json", "checkpoint_file",
         "github_workspace", "server_url",
     ):
@@ -1689,6 +1875,10 @@ def _model_route(request: Mapping[str, object]) -> tuple[str, ...]:
     return tuple(value)
 
 
+def _invocation_route(request: Mapping[str, object]) -> InvocationRoute:
+    return InvocationRoute.from_dict(_embedded_json(request, "invocation_route_json"))
+
+
 def _remaining_findings(request: Mapping[str, object]) -> tuple[str, ...]:
     value = _embedded_json(request, "remaining_finding_ids_json")
     if not isinstance(value, list):
@@ -1707,6 +1897,7 @@ def _base_claim_request(
         estimated_input_tokens=estimated_input_tokens,
         diff_mode="changed" if request["diff_mode"] in {"full", "delta"} else request["diff_mode"],
         authenticated_review=_authenticated_review(request), override_events=override_events,
+        route=_invocation_route(request),
         model_route=_model_route(request), effort=request["effort"],
         call_unit=_CALL_UNITS[request["reviewer"]],
         force_review=request["force_review"],
@@ -1730,6 +1921,7 @@ def _finalize_request(
         authenticated_review=_authenticated_review(request),
         remaining_finding_ids=_remaining_findings(request),
         dismiss_events=dismiss_events,
+        route=_invocation_route(request),
     )
 
 
@@ -1792,7 +1984,9 @@ def _write_diagnostic(
     if re.fullmatch(r"[a-z0-9_]{1,128}", stop_reason) is None:
         stop_reason = "state_invalid"
     handoff = _diagnostic_handoff(raw_request, decision, stop_reason)
-    checkpoint = _json_bytes({"schema": SCHEMA, "ledger": None, "handoff": handoff})
+    checkpoint = _json_bytes({
+        "schema": CHECKPOINT_SCHEMA, "ledger": None, "handoff": handoff,
+    })
     summary = (
         "## Review invocation budget\n"
         f"- Decision: {decision}\n"
@@ -1842,11 +2036,16 @@ def _verify_pr(request: Mapping[str, object], output_directory: Path) -> None:
     if not isinstance(value, dict):
         raise TransportError("pr_invalid")
     head = value.get("head")
+    route = _invocation_route(request)
     if (
         value.get("number") != request["pr"] or not isinstance(head, dict) or
         head.get("sha") != request["head_sha"]
     ):
         raise TransportError("pr_head_mismatch")
+    if route.kind == "default_branch_rollout_fallback":
+        base = value.get("base")
+        if not isinstance(base, dict) or base.get("sha") != route.expected_base_sha:
+            raise TransportError("pr_base_mismatch")
 
 
 def _ledger_comment(
@@ -1994,6 +2193,7 @@ def _run_provenances(
     stored_by_identity = {} if state is None else {
         (item.run_id, item.run_attempt): item for item in state.invocations
     }
+    current_route = _invocation_route(request)
     identities = {(request["run_id"], request["run_attempt"])}
     if state is not None:
         identities.update(
@@ -2028,21 +2228,22 @@ def _run_provenances(
         central = central[0]
         central_ref = central.get("ref") if "ref" in central else central.get("sha")
         stored = stored_by_identity.get((run_id, run_attempt))
-        is_force_dispatch = (
-            stored is not None and stored.caller_event == "workflow_dispatch"
+        route = stored.route if stored is not None else current_route
+        is_detached_event = (
+            stored is not None and stored.caller_event in {"workflow_dispatch", "issue_comment"}
         ) or (
             stored is None
             and request["operation"] == "claim"
-            and request["force_review"]
+            and (request["force_review"] or route.kind == "default_branch_rollout_fallback")
             and (run_id, run_attempt) == (request["run_id"], request["run_attempt"])
         )
         reviewed_head = stored.head_sha if stored is not None else request["head_sha"]
         provenance = RunProvenance(
             repository=repository.get("full_name"), pr=request["pr"],
-            # workflow_dispatch runs are rooted at the caller's default branch, not
+            # Detached caller events are rooted at the caller's default branch, not
             # the reviewed PR. The independently fetched PR payload binds the target
             # head; the Actions payload still binds run/attempt/caller/reusable ref.
-            head_sha=reviewed_head if is_force_dispatch else value.get("head_sha"),
+            head_sha=reviewed_head if is_detached_event else value.get("head_sha"),
             caller_workflow_path=value.get("path"),
             caller_event=value.get("event"),
             referenced_workflow_path=central.get("path"),
@@ -2051,8 +2252,11 @@ def _run_provenances(
             run_id=value.get("id"), run_attempt=value.get("run_attempt"),
             status=value.get("status"), conclusion=value.get("conclusion"),
         )
-        if is_force_dispatch:
-            if value.get("event") != "workflow_dispatch":
+        if is_detached_event:
+            if value.get("event") != {
+                "authorized_override": "workflow_dispatch",
+                "default_branch_rollout_fallback": "issue_comment",
+            }.get(route.kind):
                 raise TransportError("provenance_mismatch")
         elif request["pr"] not in pull_numbers:
             raise TransportError("provenance_mismatch")
@@ -2121,6 +2325,7 @@ def _write_transition(
     mutation = "none"
     if transition.mutate_comment:
         mutation = "create" if prior_comment is None else "patch"
+    route = _invocation_route(request)
     output = {
         "allow-invocation": "true" if transition.allow_invocation else "false",
         "decision": transition.decision,
@@ -2131,6 +2336,11 @@ def _write_transition(
         "mutate-comment": transition.mutate_comment,
         "mutation": mutation,
         "expected-head-sha": request["head_sha"],
+        "expected-base-sha": (
+            route.expected_base_sha
+            if route.kind == "default_branch_rollout_fallback"
+            else ""
+        ),
         "prior-comment-id": comment_id,
         "prior-comment-body": None if prior_comment is None else prior_comment["body"],
         "marker": MARKERS[request["reviewer"]],
@@ -2167,6 +2377,7 @@ def _fallback_request(request: Mapping[str, object]) -> ClaimRequest | FinalizeR
             estimated_input_tokens=0, diff_mode="changed", authenticated_review=review,
             override_events=(), model_route=("invalid",), effort=request["effort"],
             call_unit=_CALL_UNITS[request["reviewer"]],
+            route=InvocationRoute.automatic(),
         )
     return FinalizeRequest(
         repository=request["repository"], pr=request["pr"], reviewer=request["reviewer"],
@@ -2175,6 +2386,7 @@ def _fallback_request(request: Mapping[str, object]) -> ClaimRequest | FinalizeR
         model_route=("invalid",), effort=request["effort"], call_count=0, elapsed_seconds=0,
         outcome="checkpoint_failure", stop_reason="checkpoint_failure",
         authenticated_review=review, remaining_finding_ids=(),
+        route=InvocationRoute.automatic(),
     )
 
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,6 +22,38 @@ on:
         type: boolean
         required: false
         default: false
+      fallback_request_comment_id:
+        type: string
+        required: false
+        default: ''
+      fallback_request_nonce:
+        type: string
+        required: false
+        default: ''
+      fallback_expected_head_sha:
+        type: string
+        required: false
+        default: ''
+      fallback_expected_base_sha:
+        type: string
+        required: false
+        default: ''
+      fallback_original_run_id:
+        type: string
+        required: false
+        default: ''
+      fallback_original_run_attempt:
+        type: string
+        required: false
+        default: ''
+      fallback_release_commit:
+        type: string
+        required: false
+        default: ''
+      fallback_managed_diff_sha256:
+        type: string
+        required: false
+        default: ''
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -118,6 +150,97 @@ jobs:
           # Shared diff preparation validates merge-base ancestry on every round.
           fetch-depth: 0
 
+      - name: Resolve Claude fallback mode
+        id: fallback-mode
+        shell: bash
+        env:
+          FALLBACK_INPUTS_JSON: >-
+            {"fallback_request_comment_id":${{ toJSON(inputs.fallback_request_comment_id) }},"fallback_request_nonce":${{ toJSON(inputs.fallback_request_nonce) }},"fallback_expected_head_sha":${{ toJSON(inputs.fallback_expected_head_sha) }},"fallback_expected_base_sha":${{ toJSON(inputs.fallback_expected_base_sha) }},"fallback_original_run_id":${{ toJSON(inputs.fallback_original_run_id) }},"fallback_original_run_attempt":${{ toJSON(inputs.fallback_original_run_attempt) }},"fallback_release_commit":${{ toJSON(inputs.fallback_release_commit) }},"fallback_managed_diff_sha256":${{ toJSON(inputs.fallback_managed_diff_sha256) }}}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          values = json.loads(os.environ["FALLBACK_INPUTS_JSON"])
+          count = sum(isinstance(value, str) and value != "" for value in values.values())
+          if count not in {0, 8}:
+              raise SystemExit("fallback_inputs_partial")
+          mode = "fallback" if count == 8 else "normal"
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as stream:
+              stream.write(f"mode={mode}\n")
+          PY
+
+      - name: Authenticate Claude fallback request
+        id: fallback-admission
+        if: ${{ steps.fallback-mode.outputs.mode == 'fallback' }}
+        uses: $/.github/actions/claude-rollout-fallback
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Validate Claude fallback admission
+        id: fallback-admission-validation
+        if: ${{ steps.fallback-mode.outputs.mode == 'fallback' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # ratchet:actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          ROUTE: ${{ steps.fallback-admission.outputs.route }}
+          REQUEST_COMMENT_ID: ${{ steps.fallback-admission.outputs.request-comment-id }}
+          REQUEST_NONCE: ${{ steps.fallback-admission.outputs.request-nonce }}
+          EXPECTED_HEAD_SHA: ${{ steps.fallback-admission.outputs.expected-head-sha }}
+          EXPECTED_BASE_SHA: ${{ steps.fallback-admission.outputs.expected-base-sha }}
+          ORIGINAL_RUN_ID: ${{ steps.fallback-admission.outputs.original-run-id }}
+          ORIGINAL_RUN_ATTEMPT: ${{ steps.fallback-admission.outputs.original-run-attempt }}
+          RELEASE_COMMIT: ${{ steps.fallback-admission.outputs.release-commit }}
+          MANAGED_DIFF_SHA256: ${{ steps.fallback-admission.outputs.managed-diff-sha256 }}
+          INPUT_REQUEST_COMMENT_ID: ${{ inputs.fallback_request_comment_id }}
+          INPUT_REQUEST_NONCE: ${{ inputs.fallback_request_nonce }}
+          INPUT_EXPECTED_HEAD_SHA: ${{ inputs.fallback_expected_head_sha }}
+          INPUT_EXPECTED_BASE_SHA: ${{ inputs.fallback_expected_base_sha }}
+          INPUT_ORIGINAL_RUN_ID: ${{ inputs.fallback_original_run_id }}
+          INPUT_ORIGINAL_RUN_ATTEMPT: ${{ inputs.fallback_original_run_attempt }}
+          INPUT_RELEASE_COMMIT: ${{ inputs.fallback_release_commit }}
+          INPUT_MANAGED_DIFF_SHA256: ${{ inputs.fallback_managed_diff_sha256 }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            core.setOutput('allowed', 'false');
+            core.setOutput('reason', 'fallback_admission_mismatch');
+            const stop = () => core.setFailed('fallback_admission_mismatch');
+            const pairs = [
+              ['REQUEST_COMMENT_ID', 'INPUT_REQUEST_COMMENT_ID'],
+              ['REQUEST_NONCE', 'INPUT_REQUEST_NONCE'],
+              ['EXPECTED_HEAD_SHA', 'INPUT_EXPECTED_HEAD_SHA'],
+              ['EXPECTED_BASE_SHA', 'INPUT_EXPECTED_BASE_SHA'],
+              ['ORIGINAL_RUN_ID', 'INPUT_ORIGINAL_RUN_ID'],
+              ['ORIGINAL_RUN_ATTEMPT', 'INPUT_ORIGINAL_RUN_ATTEMPT'],
+              ['RELEASE_COMMIT', 'INPUT_RELEASE_COMMIT'],
+              ['MANAGED_DIFF_SHA256', 'INPUT_MANAGED_DIFF_SHA256'],
+            ];
+            if (process.env.ROUTE !== 'managed'
+              || pairs.some(([actual, expected]) =>
+                !process.env[actual] || process.env[actual] !== process.env[expected])) {
+              stop();
+              return;
+            }
+            try {
+              const { owner, repo } = context.repo;
+              const { data: pr } = await github.rest.pulls.get({
+                owner, repo, pull_number: Number(process.env.PR_NUMBER),
+                request: { timeout: 15000 },
+              });
+              if (pr?.head?.sha !== process.env.EXPECTED_HEAD_SHA
+                || pr?.base?.sha !== process.env.EXPECTED_BASE_SHA) {
+                stop();
+                return;
+              }
+              core.setOutput('reason', '');
+              core.setOutput('allowed', 'true');
+            } catch {
+              stop();
+            }
+
       # 재리뷰 라운드 인식: 직전 라운드의 자기 리뷰(sticky 코멘트)와 사람 코멘트(반박 포함)를
       # 트리밍해 파일로 준비한다. 라운드 1(컨텍스트 없음)은 파일을 만들지 않아 오버헤드 0.
       # 섹션별 문자 상한으로 토큰 사용을 상수로 묶는다(라운드가 늘어도 크기 일정).
@@ -176,6 +299,17 @@ jobs:
                 type == "string" and (. == "full" or . == "delta" or . == "unchanged" or . == "unavailable");
               def review_execution:
                 . == null or . == "performed" or . == "reused" or . == "not_performed";
+              def failure_reason:
+                type == "string" and test("^[a-z_]+$");
+              def fallback_route:
+                type == "object"
+                and (keys | sort) == ["managed_diff_sha256", "original_failed_run_id", "release_commit", "request_comment_id", "reviewed_base_sha", "route"]
+                and .route == "default_branch_rollout_fallback"
+                and (.request_comment_id | positive_integer)
+                and (.original_failed_run_id | positive_integer)
+                and (.reviewed_base_sha | sha1)
+                and (.release_commit | sha1)
+                and (.managed_diff_sha256 | sha256);
               def successful_pair:
                 if .successful_head == null then .full_diff_sha256 == null
                 else (.successful_head | sha1) and (.full_diff_sha256 | sha256)
@@ -214,8 +348,18 @@ jobs:
                 | select($lines[0] == $header and $lines[1] == $marker)
                 | (($lines[2]? // "") | (capture("^<!-- automation-state:(?<json>\\{.*\\}) -->$")? | .json? | fromjson?)) as $s
                 | select(($s | type) == "object")
-                | select((($s | keys | sort) == ["accepted_count", "attempt_head", "attempt_status", "diff_mode", "filtered_count", "filtered_max_severity", "full_diff_sha256", "normalized_count", "pr", "quality_schema", "reviewer", "run_attempt", "run_id", "schema", "successful_head"])
-                  or (($s | keys | sort) == ["accepted_count", "attempt_head", "attempt_status", "diff_mode", "filtered_count", "filtered_max_severity", "full_diff_sha256", "normalized_count", "pr", "quality_schema", "review_execution", "reviewer", "run_attempt", "run_id", "schema", "successful_head"]))
+                | (($s | keys | sort) as $keys
+                  | ["accepted_count", "attempt_head", "attempt_status", "diff_mode", "filtered_count", "filtered_max_severity", "full_diff_sha256", "normalized_count", "pr", "quality_schema", "reviewer", "run_attempt", "run_id", "schema", "successful_head"] as $legacy
+                  | ($legacy + ["review_execution"] | sort) as $normal
+                  | ($normal + ["failure_reason"] | sort) as $failure
+                  | ($normal + ["route"] | sort) as $fallback
+                  | select($keys == $legacy or $keys == $normal or $keys == $failure or $keys == $fallback)
+                  | select(if $keys == $failure then
+                      $s.attempt_status == "failure" and ($s.failure_reason | failure_reason)
+                    elif $keys == $fallback then
+                      $s.attempt_status == "success" and ($s.route | fallback_route)
+                      and $s.route.managed_diff_sha256 == $s.full_diff_sha256
+                    else true end))
                 | select(($s.schema | type) == "number" and $s.schema == 3)
                 | select(($s.quality_schema | type) == "number" and $s.quality_schema == 1)
                 | select(($s.reviewer | type) == "string" and $s.reviewer == $reviewer)
@@ -399,16 +543,98 @@ jobs:
           pr-number: ${{ inputs.pr_number || github.event.pull_request.number }}
           previous-sha: ${{ steps.prepare-review-input.outputs.previous_sha }}
           previous-full-hash: ${{ steps.prepare-review-input.outputs.previous_full_hash }}
-          force-full: ${{ inputs.force_review && 'true' || 'false' }}
+          force-full: ${{ (inputs.force_review || steps.fallback-mode.outputs.mode == 'fallback') && 'true' || 'false' }}
           context-lines: '3'
           output-directory: ${{ runner.temp }}
+
+      - name: Resolve Claude invocation route
+        id: claude-invocation-route
+        shell: bash
+        env:
+          FALLBACK_MODE: ${{ steps.fallback-mode.outputs.mode }}
+          DIFF_MODE: ${{ steps.prepare-diff.outputs.diff-mode }}
+          COMPUTED_FULL_DIFF_SHA256: ${{ steps.prepare-diff.outputs.full-diff-sha256 }}
+          FORCE_REVIEW: ${{ inputs.force_review && 'true' || 'false' }}
+          FALLBACK_REQUEST_COMMENT_ID: ${{ inputs.fallback_request_comment_id }}
+          FALLBACK_REQUEST_NONCE: ${{ inputs.fallback_request_nonce }}
+          FALLBACK_EXPECTED_BASE_SHA: ${{ inputs.fallback_expected_base_sha }}
+          FALLBACK_ORIGINAL_RUN_ID: ${{ inputs.fallback_original_run_id }}
+          FALLBACK_ORIGINAL_RUN_ATTEMPT: ${{ inputs.fallback_original_run_attempt }}
+          FALLBACK_RELEASE_COMMIT: ${{ inputs.fallback_release_commit }}
+          FALLBACK_MANAGED_DIFF_SHA256: ${{ inputs.fallback_managed_diff_sha256 }}
+          AUTOMATIC_COMMENT_ID: ${{ steps.fallback-admission.outputs.automatic-comment-id }}
+          AUTOMATIC_STATE_SHA256: ${{ steps.fallback-admission.outputs.automatic-state-sha256 }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import re
+
+          mode = os.environ["FALLBACK_MODE"]
+          force_review = os.environ["FORCE_REVIEW"]
+          if mode not in {"normal", "fallback"} or force_review not in {"true", "false"}:
+              raise SystemExit("invocation_route_invalid")
+
+          if mode == "normal":
+              kind = "authorized_override" if force_review == "true" else "automatic"
+              invocation_route = {"kind": kind}
+              state_route = None
+          else:
+              if force_review != "false":
+                  raise SystemExit("fallback_force_review_invalid")
+              if (os.environ["DIFF_MODE"] != "full"
+                  or os.environ["COMPUTED_FULL_DIFF_SHA256"]
+                  != os.environ["FALLBACK_MANAGED_DIFF_SHA256"]):
+                  raise SystemExit("fallback_diff_mismatch")
+              integers = {
+                  "request_comment_id": os.environ["FALLBACK_REQUEST_COMMENT_ID"],
+                  "original_run_id": os.environ["FALLBACK_ORIGINAL_RUN_ID"],
+                  "original_run_attempt": os.environ["FALLBACK_ORIGINAL_RUN_ATTEMPT"],
+                  "automatic_comment_id": os.environ["AUTOMATIC_COMMENT_ID"],
+              }
+              if any(re.fullmatch(r"[1-9][0-9]*", value) is None for value in integers.values()):
+                  raise SystemExit("invocation_route_invalid")
+              hashes = {
+                  "request_nonce": (os.environ["FALLBACK_REQUEST_NONCE"], 32),
+                  "expected_base_sha": (os.environ["FALLBACK_EXPECTED_BASE_SHA"], 40),
+                  "release_commit": (os.environ["FALLBACK_RELEASE_COMMIT"], 40),
+                  "managed_diff_sha256": (os.environ["FALLBACK_MANAGED_DIFF_SHA256"], 64),
+                  "automatic_state_sha256": (os.environ["AUTOMATIC_STATE_SHA256"], 64),
+              }
+              if any(re.fullmatch(rf"[0-9a-f]{{{size}}}", value) is None
+                     for value, size in hashes.values()):
+                  raise SystemExit("invocation_route_invalid")
+              invocation_route = {
+                  "kind": "default_branch_rollout_fallback",
+                  **{name: int(value) for name, value in integers.items()},
+                  **{name: value for name, (value, _) in hashes.items()},
+              }
+              state_route = {
+                  "route": "default_branch_rollout_fallback",
+                  "request_comment_id": int(integers["request_comment_id"]),
+                  "original_failed_run_id": int(integers["original_run_id"]),
+                  "reviewed_base_sha": hashes["expected_base_sha"][0],
+                  "release_commit": hashes["release_commit"][0],
+                  "managed_diff_sha256": hashes["managed_diff_sha256"][0],
+              }
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as stream:
+              stream.write("invocation_route_json=" + json.dumps(
+                  invocation_route, ensure_ascii=True, separators=(",", ":"), sort_keys=True,
+              ) + "\n")
+              stream.write("state_route_json=" + ("" if state_route is None else json.dumps(
+                  state_route, ensure_ascii=True, separators=(",", ":"), sort_keys=True,
+              )) + "\n")
+          PY
 
       # The App validates the caller against the current default branch. Check
       # before reserving a round, using workflow identity rather than PR checkout.
       # This is a prediction only; the upstream App remains the authority.
       - name: Validate Claude caller workflow
         id: claude-workflow-validation
-        if: ${{ always() && steps.prepare-review-input.outcome == 'success' && steps.prepare-diff.outputs.diff-ready == 'true' && steps.prepare-diff.outputs.diff-mode != 'unchanged' }}
+        if: ${{ always() && steps.prepare-review-input.outcome == 'success' && steps.claude-invocation-route.outcome == 'success' && steps.prepare-diff.outputs.diff-ready == 'true' && steps.prepare-diff.outputs.diff-mode != 'unchanged' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # ratchet:actions/github-script@v7
         env:
           WORKFLOW_REF: ${{ github.workflow_ref }}
@@ -530,7 +756,7 @@ jobs:
 
       - name: Claim Claude review budget
         id: review-budget-claim
-        if: ${{ always() && steps.prepare-review-input.outcome == 'success' && steps.stage-claude-budget-input.outcome == 'success' && (steps.prepare-diff.outputs.diff-ready != 'true' || steps.prepare-diff.outputs.diff-mode == 'unchanged' || steps.claude-workflow-validation.outputs.allowed == 'true') }}
+        if: ${{ always() && steps.prepare-review-input.outcome == 'success' && steps.claude-invocation-route.outcome == 'success' && steps.stage-claude-budget-input.outcome == 'success' && (steps.prepare-diff.outputs.diff-ready != 'true' || steps.prepare-diff.outputs.diff-mode == 'unchanged' || steps.claude-workflow-validation.outputs.allowed == 'true') }}
         uses: $/.github/actions/review-invocation-budget
         with:
           github-token: ${{ github.token }}
@@ -541,6 +767,7 @@ jobs:
           full-diff-sha256: ${{ steps.stage-claude-budget-input.outputs.full_diff_sha256 }}
           diff-mode: ${{ steps.prepare-diff.outputs.diff-mode || 'unavailable' }}
           force-review: ${{ inputs.force_review && 'true' || 'false' }}
+          invocation-route-json: ${{ steps.claude-invocation-route.outputs.invocation_route_json }}
           input-files-json: ${{ steps.stage-claude-budget-input.outputs.input_files_json }}
           authenticated-review-json: ${{ steps.prepare-review-input.outputs.authenticated_review_json }}
           model-route-json: ${{ steps.claude-budget-config.outputs.model_route_json }}
@@ -876,6 +1103,8 @@ jobs:
           CANONICAL_FAILURE_REASON: ${{ steps.canonicalize-review.outputs.failure-reason }}
           CANDIDATE_ARTIFACT: ${{ steps.upload-candidate.outcome }}
           BUDGET_ALLOW_INVOCATION: ${{ steps.review-budget-claim.outputs.allow-invocation }}
+          FALLBACK_MODE: ${{ steps.fallback-mode.outputs.mode }}
+          FALLBACK_STATE_ROUTE_JSON: ${{ steps.claude-invocation-route.outputs.state_route_json }}
           BOT_LOGIN: 'github-actions[bot]'
         with:
           github-token: ${{ github.token }}
@@ -897,6 +1126,7 @@ jobs:
             const canonicalOutcome = (process.env.CANONICAL_OUTCOME || '').toLowerCase();
             const documentValid = process.env.DOCUMENT_VALID === 'true';
             const invocationAllowed = process.env.BUDGET_ALLOW_INVOCATION === 'true';
+            const fallbackMode = process.env.FALLBACK_MODE === 'fallback';
             const runIdRaw = process.env.RUN_ID || '';
             const runIdIsValid = /^[1-9][0-9]*$/.test(runIdRaw)
               && Number.isSafeInteger(Number(runIdRaw));
@@ -952,6 +1182,25 @@ jobs:
             });
             const sha1 = (value) => /^[0-9a-f]{40}$/.test(value || '');
             const sha256 = (value) => /^[0-9a-f]{64}$/.test(value || '');
+            const positiveInteger = (value) => Number.isSafeInteger(value) && value > 0;
+            let fallbackRoute = null;
+            try {
+              fallbackRoute = JSON.parse(process.env.FALLBACK_STATE_ROUTE_JSON || 'null');
+            } catch (e) {
+              fallbackRoute = null;
+            }
+            const fallbackRouteKeys = [
+              'managed_diff_sha256', 'original_failed_run_id', 'release_commit',
+              'request_comment_id', 'reviewed_base_sha', 'route',
+            ];
+            const validFallbackRoute = (route) => route && typeof route === 'object'
+              && !Array.isArray(route)
+              && JSON.stringify(Object.keys(route).sort()) === JSON.stringify(fallbackRouteKeys)
+              && route.route === 'default_branch_rollout_fallback'
+              && positiveInteger(route.request_comment_id)
+              && positiveInteger(route.original_failed_run_id)
+              && sha1(route.reviewed_base_sha) && sha1(route.release_commit)
+              && sha256(route.managed_diff_sha256);
             const validQuality = (state) => Number.isSafeInteger(state.accepted_count)
               && state.accepted_count >= 0
               && Number.isSafeInteger(state.filtered_count) && state.filtered_count >= 0
@@ -959,9 +1208,17 @@ jobs:
               && maxSeverity(state.filtered_max_severity);
             const legacyStateKeys = ['accepted_count', 'attempt_head', 'attempt_status', 'diff_mode', 'filtered_count', 'filtered_max_severity', 'full_diff_sha256', 'normalized_count', 'pr', 'quality_schema', 'reviewer', 'run_attempt', 'run_id', 'schema', 'successful_head'];
             const expectedStateKeys = [...legacyStateKeys, 'review_execution'].sort();
+            const failureStateKeys = [...expectedStateKeys, 'failure_reason'].sort();
+            const fallbackStateKeys = [...expectedStateKeys, 'route'].sort();
             const validState = (state) => state && typeof state === 'object' && !Array.isArray(state)
-              && [legacyStateKeys, expectedStateKeys].some((keys) =>
+              && [legacyStateKeys, expectedStateKeys, failureStateKeys, fallbackStateKeys].some((keys) =>
                 JSON.stringify(Object.keys(state).sort()) === JSON.stringify(keys))
+              && (state.failure_reason === undefined
+                || (state.attempt_status === 'failure'
+                  && /^[a-z_]+$/.test(state.failure_reason)))
+              && (state.route === undefined
+                || (state.attempt_status === 'success' && validFallbackRoute(state.route)
+                  && state.route.managed_diff_sha256 === state.full_diff_sha256))
               && state.schema === 3 && state.quality_schema === 1
               && state.reviewer === 'claude' && state.pr === issueNumber
               && Number.isSafeInteger(state.run_id) && state.run_id > 0
@@ -1076,7 +1333,9 @@ jobs:
               return;
             }
             const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: issueNumber });
-            if (pr.head?.sha !== attemptHead) {
+            if (pr.head?.sha !== attemptHead
+              || (fallbackMode && (!validFallbackRoute(fallbackRoute)
+                || pr.base?.sha !== fallbackRoute.reviewed_base_sha))) {
               core.notice(`Discarding stale review for ${attemptHead}; current head is ${pr.head?.sha || 'unknown'}`);
               return;
             }
@@ -1098,11 +1357,13 @@ jobs:
               && existing.state.full_diff_sha256 === fullDiffSha256
               && preservedProse.length > 0;
             const currentSuccess = invocationAllowed && ok && canonicalOutcome === 'success' && documentValid
-              && qualityValid && review.length > 0 && reviewedInputIsValid;
+              && qualityValid && review.length > 0 && reviewedInputIsValid
+              && (!fallbackMode || validFallbackRoute(fallbackRoute));
             let checkpointFailed = !(currentSuccess || unchangedInputIsValid);
             let failureReason = !diffReady ? 'diff_unavailable'
               : !modelStepEntered && nonexecutionReasons.has(providerFailureReason) ? providerFailureReason
                 : !ok ? 'provider_failure'
+                : fallbackMode && !validFallbackRoute(fallbackRoute) ? 'fallback_route_invalid'
                 : hardReasons.has(canonicalFailureReason) ? canonicalFailureReason
                   : 'canonicalizer_error';
             const stateDiffMode = ['full', 'delta', 'unchanged', 'unavailable'].includes(diffMode)
@@ -1115,36 +1376,41 @@ jobs:
               filtered_max_severity: existing.state.filtered_max_severity,
             } : quality;
             const successBody = unchangedInputIsValid ? preservedProse : review;
-            const buildState = (failed, preserveSuccess) => ({
-              schema: 3,
-              reviewer: 'claude',
-              pr: issueNumber,
-              run_id: runId,
-              run_attempt: runAttempt,
-              attempt_head: attemptHead,
-              successful_head: failed ? (preserveSuccess ? existing.state.successful_head : null) : attemptHead,
-              attempt_status: failed ? 'failure' : 'success',
-              diff_mode: stateDiffMode,
-              review_execution: unchangedInputIsValid
-                ? 'reused'
-                : (modelStepEntered ? 'performed' : 'not_performed'),
-              full_diff_sha256: failed
-                ? (preserveSuccess ? existing.state.full_diff_sha256 : null)
-                : fullDiffSha256,
-              quality_schema: 1,
-              accepted_count: failed
-                ? (preserveSuccess ? existing.state.accepted_count : null)
-                : successQuality.accepted_count,
-              filtered_count: failed
-                ? (preserveSuccess ? existing.state.filtered_count : null)
-                : successQuality.filtered_count,
-              normalized_count: failed
-                ? (preserveSuccess ? existing.state.normalized_count : null)
-                : successQuality.normalized_count,
-              filtered_max_severity: failed
-                ? (preserveSuccess ? existing.state.filtered_max_severity : null)
-                : successQuality.filtered_max_severity,
-            });
+            const buildState = (failed, preserveSuccess) => {
+              const state = {
+                schema: 3,
+                reviewer: 'claude',
+                pr: issueNumber,
+                run_id: runId,
+                run_attempt: runAttempt,
+                attempt_head: attemptHead,
+                successful_head: failed ? (preserveSuccess ? existing.state.successful_head : null) : attemptHead,
+                attempt_status: failed ? 'failure' : 'success',
+                diff_mode: stateDiffMode,
+                review_execution: unchangedInputIsValid
+                  ? 'reused'
+                  : (modelStepEntered ? 'performed' : 'not_performed'),
+                full_diff_sha256: failed
+                  ? (preserveSuccess ? existing.state.full_diff_sha256 : null)
+                  : fullDiffSha256,
+                quality_schema: 1,
+                accepted_count: failed
+                  ? (preserveSuccess ? existing.state.accepted_count : null)
+                  : successQuality.accepted_count,
+                filtered_count: failed
+                  ? (preserveSuccess ? existing.state.filtered_count : null)
+                  : successQuality.filtered_count,
+                normalized_count: failed
+                  ? (preserveSuccess ? existing.state.normalized_count : null)
+                  : successQuality.normalized_count,
+                filtered_max_severity: failed
+                  ? (preserveSuccess ? existing.state.filtered_max_severity : null)
+                  : successQuality.filtered_max_severity,
+              };
+              if (failed) state.failure_reason = failureReason;
+              if (!failed && fallbackMode) state.route = fallbackRoute;
+              return state;
+            };
             const envelope = (state, content) => `${header}\n${marker}\n<!-- automation-state:${JSON.stringify(state)} -->\n\n${metadata(state)}\n\n${content}`;
             if (!checkpointFailed) {
               const candidate = envelope(buildState(false, false), successBody);
@@ -1176,6 +1442,14 @@ jobs:
             }
             if (checkpointFailed) core.notice(`Claude review attempt failed: ${failureReason}`);
 
+            const { data: publicationPr } = await github.rest.pulls.get({
+              owner, repo, pull_number: issueNumber,
+            });
+            if (publicationPr.head?.sha !== attemptHead
+              || (fallbackMode && publicationPr.base?.sha !== fallbackRoute.reviewed_base_sha)) {
+              core.notice('Claude review publication coordinates changed; left sticky state unchanged.');
+              return;
+            }
             const target = existing?.comment || v2Target;
             if (target) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: target.id, body });
@@ -1265,6 +1539,7 @@ jobs:
           expected-head-sha: ${{ steps.prepare-diff.outputs.head-sha }}
           full-diff-sha256: ${{ steps.prepare-diff.outputs.full-diff-sha256 }}
           diff-mode: ${{ steps.prepare-diff.outputs.diff-mode }}
+          invocation-route-json: ${{ steps.claude-invocation-route.outputs.invocation_route_json }}
           input-files-json: '[]'
           authenticated-review-json: ${{ steps.prepare-review-input.outputs.authenticated_review_json }}
           model-route-json: ${{ steps.claude-budget-metrics.outputs.model_route_json }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -158,7 +158,7 @@ jobs:
             {"fallback_request_comment_id":${{ toJSON(inputs.fallback_request_comment_id) }},"fallback_request_nonce":${{ toJSON(inputs.fallback_request_nonce) }},"fallback_expected_head_sha":${{ toJSON(inputs.fallback_expected_head_sha) }},"fallback_expected_base_sha":${{ toJSON(inputs.fallback_expected_base_sha) }},"fallback_original_run_id":${{ toJSON(inputs.fallback_original_run_id) }},"fallback_original_run_attempt":${{ toJSON(inputs.fallback_original_run_attempt) }},"fallback_release_commit":${{ toJSON(inputs.fallback_release_commit) }},"fallback_managed_diff_sha256":${{ toJSON(inputs.fallback_managed_diff_sha256) }}}
         run: |
           set -euo pipefail
-          python3 - <<'PY'
+          python3 -I -S -B - <<'PY'
           import json
           import os
           from pathlib import Path
@@ -402,6 +402,7 @@ jobs:
             candidate_run_id="$(jq -r '.state.run_id' <<< "$candidate")"
             candidate_attempt="$(jq -r '.state.run_attempt' <<< "$candidate")"
             candidate_head="$(jq -r '.state.attempt_head' <<< "$candidate")"
+            candidate_state="$(jq -c '.state' <<< "$candidate")"
             if gh api --include \
               "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate_run_id}/attempts/${candidate_attempt}" \
               > "$RUN_RESPONSE" 2> "$RUN_ERROR"; then
@@ -434,14 +435,20 @@ jobs:
               --argjson run_attempt "$candidate_attempt" \
               --argjson pr "$PR_NUM" \
               --arg head "$candidate_head" \
+              --argjson state "$candidate_state" \
               --arg repo "$REPOSITORY" \
               --arg workflow_prefix 'jhw7500/automation/.github/workflows/claude-code-review.yml@' '
                 .id == $run_id and .run_attempt == $run_attempt
                 and .status == "completed"
                 and (.conclusion == "success" or .conclusion == "failure")
-                and ((.event == "pull_request" and .head_sha == $head
-                  and ([.pull_requests[]? | select(.number == $pr)] | length == 1))
-                  or .event == "workflow_dispatch")
+                and (if $state.route != null then
+                  .event == "issue_comment"
+                  and .path == ".github/workflows/claude.yml"
+                else
+                  (.event == "pull_request" and .head_sha == $head
+                    and ([.pull_requests[]? | select(.number == $pr)] | length == 1))
+                  or .event == "workflow_dispatch"
+                end)
                 and .repository.full_name == $repo
                 and ([.referenced_workflows[]? | select(
                   (.path | startswith($workflow_prefix))
@@ -566,7 +573,7 @@ jobs:
           AUTOMATIC_STATE_SHA256: ${{ steps.fallback-admission.outputs.automatic-state-sha256 }}
         run: |
           set -euo pipefail
-          python3 - <<'PY'
+          python3 -I -S -B - <<'PY'
           import json
           import os
           from pathlib import Path
@@ -1180,8 +1187,10 @@ jobs:
               issue_number: issueNumber,
               per_page: 100,
             });
-            const sha1 = (value) => /^[0-9a-f]{40}$/.test(value || '');
-            const sha256 = (value) => /^[0-9a-f]{64}$/.test(value || '');
+            const sha1 = (value) => typeof value === 'string'
+              && /^[0-9a-f]{40}$/.test(value);
+            const sha256 = (value) => typeof value === 'string'
+              && /^[0-9a-f]{64}$/.test(value);
             const positiveInteger = (value) => Number.isSafeInteger(value) && value > 0;
             let fallbackRoute = null;
             try {
@@ -1215,6 +1224,7 @@ jobs:
                 JSON.stringify(Object.keys(state).sort()) === JSON.stringify(keys))
               && (state.failure_reason === undefined
                 || (state.attempt_status === 'failure'
+                  && typeof state.failure_reason === 'string'
                   && /^[a-z_]+$/.test(state.failure_reason)))
               && (state.route === undefined
                 || (state.attempt_status === 'success' && validFallbackRoute(state.route)
@@ -1281,19 +1291,26 @@ jobs:
                 || Number(b.comment.id) - Number(a.comment.id)
             ).slice(0, 20);
             const workflowPrefix = 'jhw7500/automation/.github/workflows/claude-code-review.yml@';
-            const runMatches = (record, run) => run?.id === record.state.run_id
-              && run?.run_attempt === record.state.run_attempt
-              && run?.status === 'completed'
-              && ['success', 'failure'].includes(run?.conclusion)
-              && ((run?.event === 'pull_request' && run?.head_sha === record.state.attempt_head
-                && (run?.pull_requests || []).filter((pr) =>
-                  pr?.number === issueNumber
-                ).length === 1)
-                || run?.event === 'workflow_dispatch')
-              && run?.repository?.full_name === repository
-              && (run?.referenced_workflows || []).filter((item) =>
-                (item?.path || '').startsWith(workflowPrefix) && sha1(item?.sha)
-              ).length === 1;
+            const runMatches = (record, run) => {
+              const route = record.state.route;
+              const eventMatches = route === undefined
+                ? ((run?.event === 'pull_request' && run?.head_sha === record.state.attempt_head
+                    && (run?.pull_requests || []).filter((pr) =>
+                      pr?.number === issueNumber
+                    ).length === 1)
+                  || run?.event === 'workflow_dispatch')
+                : run?.event === 'issue_comment'
+                  && run?.path === '.github/workflows/claude.yml';
+              return run?.id === record.state.run_id
+                && run?.run_attempt === record.state.run_attempt
+                && run?.status === 'completed'
+                && ['success', 'failure'].includes(run?.conclusion)
+                && eventMatches
+                && run?.repository?.full_name === repository
+                && (run?.referenced_workflows || []).filter((item) =>
+                  (item?.path || '').startsWith(workflowPrefix) && sha1(item?.sha)
+                ).length === 1;
+            };
             let existing;
             let provenanceLookupUncertain = false;
             for (const record of syntacticRecords) {

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -812,9 +812,9 @@ jobs:
           [[ "$BUDGET_CHECKPOINT_SHA256" =~ ^[0-9a-f]{64}$ ]]
           {
             printf '### Claude review budget claim\n\n'
-            printf -- '- Decision: `%s`\n' "$BUDGET_DECISION"
-            printf -- '- Round: `%s`\n' "${BUDGET_ROUND:-none}"
-            printf -- '- Checkpoint SHA-256: `%s`\n' "$BUDGET_CHECKPOINT_SHA256"
+            printf -- "- Decision: \`%s\`\n" "$BUDGET_DECISION"
+            printf -- "- Round: \`%s\`\n" "${BUDGET_ROUND:-none}"
+            printf -- "- Checkpoint SHA-256: \`%s\`\n" "$BUDGET_CHECKPOINT_SHA256"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Claude review budget claim checkpoint
@@ -1053,8 +1053,8 @@ jobs:
           [[ "$FILTERED_REASONS" =~ ^[a-z_]+(,[a-z_]+)*$ ]]
           {
             printf '### Claude filtered findings\n\n'
-            printf -- '- Filtered: `%s` (max severity `%s`)\n' "$FILTERED_COUNT" "$FILTERED_MAX_SEVERITY"
-            printf -- '- Reasons: `%s`\n' "$FILTERED_REASONS"
+            printf -- "- Filtered: \`%s\` (max severity \`%s\`)\n" "$FILTERED_COUNT" "$FILTERED_MAX_SEVERITY"
+            printf -- "- Reasons: \`%s\`\n" "$FILTERED_REASONS"
           } >> "$GITHUB_STEP_SUMMARY"
 
       # 거부된 후보의 원문이 없으면 프롬프트/포맷 회귀와 검증기 과잉을 구분할 수 없다.
@@ -1539,10 +1539,12 @@ jobs:
             )"
           fi
 
-          printf 'outcome=%s\n' "$outcome" >> "$GITHUB_OUTPUT"
-          printf 'stop_reason=%s\n' "$stop_reason" >> "$GITHUB_OUTPUT"
-          printf 'remaining_finding_ids_json=%s\n' \
-            "$remaining_finding_ids_json" >> "$GITHUB_OUTPUT"
+          {
+            printf 'outcome=%s\n' "$outcome"
+            printf 'stop_reason=%s\n' "$stop_reason"
+            printf 'remaining_finding_ids_json=%s\n' \
+              "$remaining_finding_ids_json"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Finalize Claude review budget
         id: review-budget-finalize

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,11 +33,50 @@ jobs:
           workflow-name: claude
           force-run: ${{ inputs.force_run && 'true' || 'false' }}
 
-  claude:
+  classify-request:
     needs: check-enabled
+    if: needs.check-enabled.outputs.enabled == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: read
+      pull-requests: read
+    outputs:
+      route: ${{ steps.classify.outputs.route }}
+      reason: ${{ steps.classify.outputs.reason }}
+      request-comment-id: ${{ steps.classify.outputs.request-comment-id }}
+      request-nonce: ${{ steps.classify.outputs.request-nonce }}
+      expected-head-sha: ${{ steps.classify.outputs.expected-head-sha }}
+      expected-base-sha: ${{ steps.classify.outputs.expected-base-sha }}
+      original-run-id: ${{ steps.classify.outputs.original-run-id }}
+      original-run-attempt: ${{ steps.classify.outputs.original-run-attempt }}
+      release-commit: ${{ steps.classify.outputs.release-commit }}
+      managed-diff-sha256: ${{ steps.classify.outputs.managed-diff-sha256 }}
+      automatic-comment-id: ${{ steps.classify.outputs.automatic-comment-id }}
+      automatic-state-sha256: ${{ steps.classify.outputs.automatic-state-sha256 }}
+    steps:
+      - id: classify
+        uses: $/.github/actions/claude-rollout-fallback
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Report invalid managed request
+        if: steps.classify.outputs.route == 'invalid'
+        shell: bash
+        env:
+          REASON: ${{ steps.classify.outputs.reason }}
+        run: |
+          set -euo pipefail
+          [[ "$REASON" =~ ^[a-z_]+$ ]]
+          printf "## Claude request declined\n\nReason: \`%s\`\n" "$REASON" >> "$GITHUB_STEP_SUMMARY"
+
+  claude:
+    needs: [check-enabled, classify-request]
     if: |
-      needs.check-enabled.outputs.enabled == 'true' && (
+      needs.classify-request.outputs.route == 'interactive' && (
         (github.event_name == 'issue_comment' &&
+          !startsWith(github.event.comment.body, '@claude managed rollout review for PR ') &&
           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
           contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' &&
@@ -87,6 +126,29 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
 
+  managed-rollout-review:
+    needs: [check-enabled, classify-request]
+    if: needs.classify-request.outputs.route == 'managed'
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      issues: read
+      pull-requests: write
+    uses: $/.github/workflows/claude-code-review.yml
+    with:
+      pr_number: ${{ github.event.issue.number }}
+      review_mode: request
+      fallback_request_comment_id: ${{ needs.classify-request.outputs.request-comment-id }}
+      fallback_request_nonce: ${{ needs.classify-request.outputs.request-nonce }}
+      fallback_expected_head_sha: ${{ needs.classify-request.outputs.expected-head-sha }}
+      fallback_expected_base_sha: ${{ needs.classify-request.outputs.expected-base-sha }}
+      fallback_original_run_id: ${{ needs.classify-request.outputs.original-run-id }}
+      fallback_original_run_attempt: ${{ needs.classify-request.outputs.original-run-attempt }}
+      fallback_release_commit: ${{ needs.classify-request.outputs.release-commit }}
+      fallback_managed_diff_sha256: ${{ needs.classify-request.outputs.managed-diff-sha256 }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
   skipped:
     name: Workflow Skipped
@@ -97,5 +159,5 @@ jobs:
       - name: Notice
         run: |
           echo "::notice::Claude Code workflow is disabled in .github/workflow-config.yml"
-          echo "## Workflow Skipped" >> $GITHUB_STEP_SUMMARY
-          echo "Claude Code is disabled in workflow-config.yml" >> $GITHUB_STEP_SUMMARY
+          echo "## Workflow Skipped" >> "$GITHUB_STEP_SUMMARY"
+          echo "Claude Code is disabled in workflow-config.yml" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/opencode-auto-review.yml
+++ b/.github/workflows/opencode-auto-review.yml
@@ -835,7 +835,7 @@ jobs:
           ledger = checkpoint["ledger"]
           invocations = ledger.get("invocations")
           if (
-              ledger.get("schema") != 1
+              ledger.get("schema") != 2
               or ledger.get("repository") != os.environ["GITHUB_REPOSITORY"]
               or ledger.get("reviewer") != "opencode"
               or not isinstance(invocations, list)
@@ -3650,7 +3650,7 @@ jobs:
                 || Array.isArray(claimCheckpoint.ledger)
                 || JSON.stringify(claimCheckpoint.handoff)
                     !== JSON.stringify(claimCheckpoint.ledger.handoff)
-                || claimCheckpoint.ledger.schema !== 1
+                || claimCheckpoint.ledger.schema !== 2
                 || claimCheckpoint.ledger.repository !== repository
                 || claimCheckpoint.ledger.pr !== issueNumber
                 || claimCheckpoint.ledger.reviewer !== reviewer

--- a/.github/workflows/test-fleet-tools.yml
+++ b/.github/workflows/test-fleet-tools.yml
@@ -51,7 +51,18 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install test dependencies
-        run: python -m pip install pytest PyYAML
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install pytest PyYAML
+          cache="$(realpath --canonicalize-existing "${RUNNER_TOOL_CACHE:?}")"
+          runtime="$(python -I -S -c 'import os,sys; print(os.path.realpath(sys.prefix))')"
+          case "$runtime" in
+            "$cache"/Python/*/x64) ;;
+            *) echo "unexpected setup-python runtime" >&2; exit 1 ;;
+          esac
+          sudo chmod -R go-w "$runtime"
+          sudo chmod go-w /opt "$cache" "$cache/Python" "$(dirname "$runtime")"
       - name: Run complete Python suite
         run: pytest -q
       - name: Parse central and canonical workflow YAML

--- a/docs/superpowers/plans/2026-09-11-claude-caller-rollout-fallback.md
+++ b/docs/superpowers/plans/2026-09-11-claude-caller-rollout-fallback.md
@@ -1,0 +1,1803 @@
+# Claude Caller Rollout Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give an exact immutable workflow rollout pull request one authenticated, budgeted Claude review through the consumer's default-branch caller after the automatic reviewer refuses a changed caller with `workflow_validation_mismatch` before provider execution.
+
+**Architecture:** Parse and authenticate one canonical issue-comment request in a release-owned composite action, route it from the existing default-branch `claude.yml` caller into the same immutable `claude-code-review.yml`, record the route in the shared Claude budget and canonical review state, and attest the complete automatic-failure-to-fallback chain with a read-only fleet verifier. Preserve the automatic failure and every native merge gate; only the later JHW command may consume the verifier receipt under a separately approved repository Task.
+
+**Tech Stack:** Python standard library, Node scripts embedded in GitHub Actions, Bash, GitHub Actions reusable workflows and REST API, existing pytest/YAML harnesses, actionlint, and existing workflow fleet rendering modules.
+
+**Spec:** ../specs/2026-09-11-claude-caller-rollout-fallback-design.md
+
+## Global Constraints
+
+- Work only in `/home/jhw/ai/opencode/worktrees/jhw-control/wt-7e615b91b0e8-jhw7500-automation-182` on `task/7e615b91b0e8-jhw7500-automation-182`, starting from design commit `b10503c` over immutable v1.76 source `444a7347aee169ed178aae80e8bd8d10eca52e02`.
+- Keep Task `tsk-01a08b34-cc9e-777f-a99d-7e615b91b0e8` and Claim `clm-01a08b35-4a07-75ba-8a22-a8ca96029ade`. Do not add, take over, delete, repair, or directly edit a Claim, lock, Registry record, budget ledger, secret, or Notion record.
+- Every shell command starts with `rtk`; commands that need an unwrapped executable use `rtk proxy`. Apply source edits with `apply_patch`.
+- Write a failing behavioral test before each implementation change. Add no dependency and execute no code, action, hook, filter, binary, or artifact supplied by a consumer pull request.
+- Preserve v1.76 bytes, tag, release acceptance, and historical fixtures. Own the new workflow, action, verifier, and ledger schema behavior behind the v1.77 feature boundary.
+- Authenticate only `workflow_validation_mismatch` with `review_execution=not_performed`, the Claude provider step skipped, and no budget claim. `workflow_validation_unavailable`, provider entry, any other failure, stale coordinates, ambiguity, pagination overflow, and transport uncertainty remain blocking.
+- The fallback uses the existing Claude credential once and consumes one ordinary automatic review round for the exact pull-request HEAD/full diff. A retry reuses a valid request or finalized result and cannot add a second provider call.
+- Do not make the original failed automatic check successful, hide it, waive a required status, weaken branch protection, or replace target tests, mergeability, exact HEAD/base, origin, or GitHub-generated merge verification.
+- The consumer permission ceiling for `claude.yml` becomes `pull-requests: write`; the central interactive Claude job explicitly reduces itself to `pull-requests: read`; only the admitted nested managed job retains write permission for the canonical sticky comment.
+- This plan changes only the automation repository. It ends with a versioned receipt schema and verifier CLI. Before editing `/home/jhw/ai/opencode/projects/jhw-notion-runtime`, run that repository's stateless Task nudge, obtain any required separate approval, and write a second implementation plan.
+- Do not publish v1.77 or mutate a consumer until the implementation branch passes local verification, native pre-PR tribunal, hosted review, and reviewed merge. Stop a canary if a required failed Claude check remains native-blocking.
+
+---
+
+## Contract Map
+
+| Contract | Producer | Consumer | Exact version |
+| --- | --- | --- | --- |
+| Managed request marker | Later JHW command | `claude-rollout-fallback/contract.py` | `automation:claude-rollout-review-request:v1` |
+| Admission JSON | `claude-rollout-fallback/action.yml` | central `claude.yml` and nested review | schema 1 |
+| Budget ledger | `review-invocation-budget` | later review runs and verifier | schema 2, reads schema 1 |
+| Claude sticky state | `claude-code-review.yml` | review context and fleet verifier | schema 3 with exact optional extensions |
+| Fleet fallback receipt | `verify_claude_rollout_fallback.py` | later JHW command | schema 1 |
+| Workflow release | reviewed automation merge | release verifier and consumers | v1.77 |
+
+The only accepted request body is the following two-line form, with one optional final LF and no other bytes:
+
+```text
+@claude managed rollout review for PR 109
+<!-- automation:claude-rollout-review-request:v1 {"expected_base_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","expected_head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","managed_diff_sha256":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","nonce":"dddddddddddddddddddddddddddddddd","original_run_attempt":1,"original_run_id":34549275027,"pr":109,"release_commit":"444a7347aee169ed178aae80e8bd8d10eca52e02","repository":"jhw7500/gstApp"} -->
+```
+
+The parser sorts keys and uses compact UTF-8 JSON when it reconstructs this body. The JSON object has exactly the nine displayed keys. SHA values use lowercase hex, numeric values are positive safe integers, and the nonce is exactly 32 lowercase hex characters.
+
+The nested review uses these eight all-or-none `workflow_call` inputs:
+
+| Input | Type | Binding |
+| --- | --- | --- |
+| `fallback_request_comment_id` | string | fetched event comment ID |
+| `fallback_request_nonce` | string | request marker nonce |
+| `fallback_expected_head_sha` | string | current pull-request HEAD |
+| `fallback_expected_base_sha` | string | current pull-request base object |
+| `fallback_original_run_id` | string | failed automatic run |
+| `fallback_original_run_attempt` | string | exact failed attempt |
+| `fallback_release_commit` | string | immutable automation commit |
+| `fallback_managed_diff_sha256` | string | exact fleet-rendered full diff |
+
+---
+
+### Task 1: Pure request and admission contract
+
+**Files:**
+
+- Create: `.github/actions/claude-rollout-fallback/contract.py`
+- Create: `.github/actions/claude-rollout-fallback/action.yml`
+- Create: `tests/test_claude_rollout_fallback.py`
+
+**Interfaces:**
+
+- `FallbackRequest(repository, pr, expected_head_sha, expected_base_sha, original_run_id, original_run_attempt, release_commit, managed_diff_sha256, nonce)` is the exact parsed request.
+- `RequestClassification(route, reason, request)` has route `interactive`, `managed_candidate`, or `invalid`. A body containing neither the reserved visible prefix nor the hidden marker is interactive without network reads. Any body containing either reserved token is a managed candidate; malformed, displaced, quoted, duplicated, or unauthorized forms are invalid and cannot reach the interactive provider.
+- `EvidenceBundle(event_name, event, comment, pull_request, original_run, original_jobs, issue_comments)` contains already-fetched JSON and performs no I/O.
+- `FallbackAdmission(request_comment_id, request, automatic_comment_id, automatic_state_sha256)` is emitted only after every request, actor, pull request, run, job, and canonical-state check succeeds.
+- `classify_event(event_name: object, event: object) -> RequestClassification`, `parse_request_body(body: object) -> FallbackRequest`, `canonical_request_body(request: FallbackRequest) -> str`, and `admit(bundle: EvidenceBundle) -> FallbackAdmission` are pure and fail with bounded reason codes.
+- The private validators have fixed signatures: `event_text_fields(event_name: object, event: object) -> tuple[str, ...]`, `event_comment_body(event: object) -> str`, `positive_id(value: object, reason: str) -> int`, `require_managed_created_event(event_name: object, event: object) -> FallbackRequest`, `require_exact_comment(comment: object, event: object, request: FallbackRequest) -> None`, `require_exact_open_same_repository_pr(pull_request: object, request: FallbackRequest) -> None`, `require_exact_automatic_run(run: object, request: FallbackRequest) -> None`, `require_causal_order(run: object, comment: object) -> None`, `require_failed_before_provider(jobs: object) -> None`, `require_unique_request(comments: object, current_comment_id: int, request: FallbackRequest) -> None`, `require_automatic_failure_state(comments: object, request: FallbackRequest) -> tuple[int, bytes]`, and `require_no_successful_fallback(comments: object, request: FallbackRequest) -> None`. Each accepts decoded data only and raises `ContractError` with a bounded lowercase reason.
+- `contract.py plan --event-name NAME --event-file PATH --plan-file PATH --github-output PATH` parses the event, writes a private evidence plan for managed candidates, and writes only route/reason for non-managed routes. `contract.py verify --plan-file PATH --evidence-directory PATH --admission-file PATH --github-output PATH` reads the completed fixed-name responses, writes one private admission JSON file, and appends regex-validated scalar outputs to `GITHUB_OUTPUT`.
+- The composite makes only fixed GitHub REST reads: exact comment, exact pull request, exact run attempt, at most 100 jobs, and at most ten 100-comment pages. A full tenth page is `comment_horizon_exceeded`, rather than implicit completeness.
+- `require_unique_request` counts canonical request comments for the same repository/PR/HEAD/base/original run/attempt/release/diff tuple while ignoring nonce differences; only the current comment may exist. A second matching tuple is `request_ambiguous`.
+- `require_causal_order` accepts only canonical UTC GitHub timestamps and requires the automatic attempt's `updated_at` to be no later than the request comment's `created_at`; missing, malformed, or reversed time is `request_order_invalid`.
+- Composite outputs are exactly `route`, `reason`, the eight nested inputs without their `fallback_` prefix, plus `automatic-comment-id` and `automatic-state-sha256`. Managed admission sets route `managed`, leaves reason empty, and fills all ten evidence outputs. Interactive and invalid classifications leave every evidence output empty; invalid alone emits a bounded reason.
+
+Target type and key shape:
+
+```python
+class ContractError(ValueError):
+    pass
+
+VISIBLE_PREFIX = "@claude managed rollout review for PR "
+HIDDEN_MARKER = "<!-- automation:claude-rollout-review-request:v1 "
+REQUEST_BODY_RE = re.compile(
+    r"\A@claude managed rollout review for PR (?P<visible_pr>[1-9][0-9]{0,15})\n"
+    r"<!-- automation:claude-rollout-review-request:v1 (?P<json>\{[^\r\n]*\}) -->\n?\Z",
+    re.ASCII,
+)
+REQUEST_KEYS = frozenset({
+    "repository", "pr", "expected_head_sha", "expected_base_sha",
+    "original_run_id", "original_run_attempt", "release_commit",
+    "managed_diff_sha256", "nonce",
+})
+SHA_RE = re.compile(r"[0-9a-f]{40}\Z", re.ASCII)
+DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+NONCE_RE = re.compile(r"[0-9a-f]{32}\Z", re.ASCII)
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\Z", re.ASCII)
+MAX_SAFE_INTEGER = 2**53 - 1
+
+@dataclass(frozen=True)
+class FallbackRequest:
+    repository: str
+    pr: int
+    expected_head_sha: str
+    expected_base_sha: str
+    original_run_id: int
+    original_run_attempt: int
+    release_commit: str
+    managed_diff_sha256: str
+    nonce: str
+
+    @classmethod
+    def from_dict(cls, value: object) -> "FallbackRequest":
+        if not isinstance(value, dict) or set(value) != REQUEST_KEYS:
+            raise ContractError("request_invalid")
+        integers = (value["pr"], value["original_run_id"], value["original_run_attempt"])
+        if any(type(item) is not int or not 1 <= item <= MAX_SAFE_INTEGER for item in integers):
+            raise ContractError("request_invalid")
+        repository = value["repository"]
+        shas = (value["expected_head_sha"], value["expected_base_sha"], value["release_commit"])
+        if not isinstance(repository, str) or REPOSITORY_RE.fullmatch(repository) is None:
+            raise ContractError("request_invalid")
+        if any(not isinstance(item, str) or SHA_RE.fullmatch(item) is None for item in shas):
+            raise ContractError("request_invalid")
+        digest, nonce = value["managed_diff_sha256"], value["nonce"]
+        if not isinstance(digest, str) or DIGEST_RE.fullmatch(digest) is None:
+            raise ContractError("request_invalid")
+        if not isinstance(nonce, str) or NONCE_RE.fullmatch(nonce) is None:
+            raise ContractError("request_invalid")
+        return cls(
+            repository=repository,
+            pr=value["pr"],
+            expected_head_sha=value["expected_head_sha"],
+            expected_base_sha=value["expected_base_sha"],
+            original_run_id=value["original_run_id"],
+            original_run_attempt=value["original_run_attempt"],
+            release_commit=value["release_commit"],
+            managed_diff_sha256=digest,
+            nonce=nonce,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {name: getattr(self, name) for name in REQUEST_KEYS}
+
+@dataclass(frozen=True)
+class FallbackAdmission:
+    request_comment_id: int
+    request: FallbackRequest
+    automatic_comment_id: int
+    automatic_state_sha256: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "automatic_comment_id": self.automatic_comment_id,
+            "automatic_state_sha256": self.automatic_state_sha256,
+            "request": self.request.to_dict(),
+            "request_comment_id": self.request_comment_id,
+            "schema": 1,
+        }
+```
+
+Required positive assertion:
+
+```python
+admission = admit(valid_bundle())
+assert admission.request.original_run_id == 34549275027
+assert admission.request_comment_id == 901
+assert admission.automatic_comment_id == 887
+assert canonical_request_body(admission.request) == REQUEST_BODY
+```
+
+- [ ] **Step 1: Write failing request parser and classifier cases.** Add the exact valid body above and this parameter table; each mutation must raise `ContractError("request_invalid")`, while a non-reserved body remains interactive.
+
+```python
+@pytest.mark.parametrize("change", [
+    "duplicate_key", "extra_key", "missing_key", "uppercase_head",
+    "zero_run", "unsafe_integer", "short_nonce", "second_marker",
+    "quoted_marker", "control_character", "invalid_unicode", "oversize",
+    "malformed_json",
+])
+def test_request_parser_rejects_noncanonical_bytes(change):
+    with pytest.raises(ContractError, match="^request_invalid$"):
+        parse_request_body(mutated_request_body(change))
+
+def test_classifier_never_routes_reserved_invalid_text_to_interactive():
+    bodies = (
+        "@claude managed rollout review for PR 109",
+        "> @claude managed rollout review for PR 109",
+        "<!-- automation:claude-rollout-review-request:v1 {} -->",
+    )
+    for body in bodies:
+        result = classify_event("issue_comment", issue_comment_event(body))
+        assert (result.route, result.reason, result.request) == (
+            "invalid", "request_invalid", None,
+        )
+```
+
+- [ ] **Step 2: Run the parser cases and verify red.**
+
+```bash
+rtk pytest -q tests/test_claude_rollout_fallback.py -k 'request or classifier'
+```
+
+Expected: collection fails because `contract.py` or its public names do not exist.
+
+- [ ] **Step 3: Implement the exact parser and classifier.** Use a duplicate-key hook, full-body regular expression, compact sorted JSON reconstruction, and the three closed routes.
+
+```python
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ContractError("request_invalid")
+        result[key] = value
+    return result
+
+def parse_request_body(body: object) -> FallbackRequest:
+    if not isinstance(body, str):
+        raise ContractError("request_invalid")
+    try:
+        encoded = body.encode("utf-8")
+    except UnicodeEncodeError:
+        raise ContractError("request_invalid") from None
+    if len(encoded) > 4096:
+        raise ContractError("request_invalid")
+    match = REQUEST_BODY_RE.fullmatch(body)
+    if match is None:
+        raise ContractError("request_invalid")
+    try:
+        value = json.loads(match.group("json"), object_pairs_hook=_unique_object)
+    except (json.JSONDecodeError, ContractError):
+        raise ContractError("request_invalid") from None
+    request = FallbackRequest.from_dict(value)
+    canonical = canonical_request_body(request)
+    if int(match.group("visible_pr")) != request.pr or body not in {
+        canonical, canonical + "\n",
+    }:
+        raise ContractError("request_invalid")
+    return request
+
+def canonical_request_body(request: FallbackRequest) -> str:
+    payload = json.dumps(
+        request.to_dict(), ensure_ascii=True, separators=(",", ":"), sort_keys=True,
+    )
+    return (
+        f"{VISIBLE_PREFIX}{request.pr}\n"
+        f"{HIDDEN_MARKER}{payload} -->"
+    )
+
+def classify_event(event_name: object, event: object) -> RequestClassification:
+    texts = event_text_fields(event_name, event)
+    reserved = any(
+        VISIBLE_PREFIX in value or HIDDEN_MARKER in value for value in texts
+    )
+    if not reserved:
+        return RequestClassification("interactive", "", None)
+    if event_name != "issue_comment" or len(texts) != 1:
+        return RequestClassification("invalid", "request_invalid", None)
+    try:
+        request = parse_request_body(texts[0])
+    except ContractError as error:
+        return RequestClassification("invalid", str(error), None)
+    return RequestClassification("managed_candidate", "", request)
+```
+
+- [ ] **Step 4: Run the parser cases and verify green.**
+
+```bash
+rtk pytest -q tests/test_claude_rollout_fallback.py -k 'request or classifier'
+```
+
+Expected: all parser/classifier cases pass.
+
+- [ ] **Step 5: Write failing admission and action-contract cases.** Use one valid bundle, then mutate one authenticated field at a time through the listed trust boundaries.
+
+```python
+def test_admission_binds_failure_before_provider_or_budget():
+    admission = admit(valid_bundle())
+    assert admission.request_comment_id == 901
+    assert admission.automatic_comment_id == 887
+    assert admission.request.original_run_id == 34549275027
+    assert admission.automatic_state_sha256 == sha256(AUTOMATIC_STATE_BYTES).hexdigest()
+
+@pytest.mark.parametrize("change", [
+    "event_not_created", "comment_bytes_changed", "actor_not_collaborator",
+    "pr_closed", "fork_head", "head_changed", "base_changed", "wrong_attempt",
+    "request_before_failure",
+    "wrong_release", "provider_entered", "budget_claimed", "duplicate_request",
+    "duplicate_state",
+    "existing_fallback", "job_overflow", "comment_horizon_exceeded",
+])
+def test_admission_fails_closed(change):
+    with pytest.raises(ContractError, match="^[a-z_]+$"):
+        admit(mutated_bundle(change))
+```
+
+- [ ] **Step 6: Run admission cases and verify red.**
+
+```bash
+rtk pytest -q tests/test_claude_rollout_fallback.py -k 'admission or action_contract'
+```
+
+Expected: `EvidenceBundle`, `admit`, or the action metadata is missing.
+
+- [ ] **Step 7: Implement pure admission and the bounded transport.** `admit` must compare server objects before constructing its immutable result; the composite exposes only the twelve closed outputs.
+
+```python
+def admit(bundle: EvidenceBundle) -> FallbackAdmission:
+    request = require_managed_created_event(bundle.event_name, bundle.event)
+    require_exact_comment(bundle.comment, bundle.event, request)
+    require_exact_open_same_repository_pr(bundle.pull_request, request)
+    require_exact_automatic_run(bundle.original_run, request)
+    require_causal_order(bundle.original_run, bundle.comment)
+    require_failed_before_provider(bundle.original_jobs)
+    request_comment_id = positive_id(
+        bundle.comment["id"], "request_comment_id_invalid",
+    )
+    require_unique_request(bundle.issue_comments, request_comment_id, request)
+    comment_id, state_bytes = require_automatic_failure_state(
+        bundle.issue_comments, request,
+    )
+    require_no_successful_fallback(bundle.issue_comments, request)
+    return FallbackAdmission(
+        request_comment_id=request_comment_id,
+        request=request,
+        automatic_comment_id=comment_id,
+        automatic_state_sha256=hashlib.sha256(state_bytes).hexdigest(),
+    )
+```
+
+```yaml
+inputs:
+  github-token:
+    required: true
+outputs:
+  route:
+    value: ${{ steps.verify.outputs.route }}
+  reason:
+    value: ${{ steps.verify.outputs.reason }}
+  request-comment-id:
+    value: ${{ steps.verify.outputs.request-comment-id }}
+  request-nonce:
+    value: ${{ steps.verify.outputs.request-nonce }}
+  expected-head-sha:
+    value: ${{ steps.verify.outputs.expected-head-sha }}
+  expected-base-sha:
+    value: ${{ steps.verify.outputs.expected-base-sha }}
+  original-run-id:
+    value: ${{ steps.verify.outputs.original-run-id }}
+  original-run-attempt:
+    value: ${{ steps.verify.outputs.original-run-attempt }}
+  release-commit:
+    value: ${{ steps.verify.outputs.release-commit }}
+  managed-diff-sha256:
+    value: ${{ steps.verify.outputs.managed-diff-sha256 }}
+  automatic-comment-id:
+    value: ${{ steps.verify.outputs.automatic-comment-id }}
+  automatic-state-sha256:
+    value: ${{ steps.verify.outputs.automatic-state-sha256 }}
+runs:
+  using: composite
+  steps:
+    - id: collect
+      shell: bash
+    - id: verify
+      shell: bash
+```
+
+The two shell steps use `umask 077`, a mode-0700 temporary directory, exact `contract.py plan` endpoints, ten explicit comment-page iterations, private regular response files, `contract.py verify`, and a cleanup trap. They never evaluate an API value as shell source.
+
+- [ ] **Step 8: Run focused tests and verify green.**
+
+```bash
+rtk pytest -q tests/test_claude_rollout_fallback.py tests/test_action_pins.py
+rtk git diff --check
+```
+
+Expected: both suites and the diff check pass.
+
+- [ ] **Step 9: Commit the independently testable admission unit.**
+
+```bash
+rtk git add .github/actions/claude-rollout-fallback tests/test_claude_rollout_fallback.py
+rtk git commit -m 'feat(claude): authenticate rollout fallback requests'
+```
+
+### Task 2: Typed fallback route in the shared Claude budget
+
+**Files:**
+
+- Modify: `.github/actions/review-invocation-budget/review_invocation_budget.py`
+- Modify: `.github/actions/review-invocation-budget/action.yml`
+- Modify: `tests/test_review_invocation_budget.py`
+- Modify: `tests/test_review_invocation_budget_action.py`
+
+**Interfaces:**
+
+- Raise the serialized ledger to `SCHEMA = 2`; continue reading schema 1 and serialize schema 2 on the next legitimate mutation.
+- Add `InvocationRoute(kind, request_comment_id, request_nonce, original_run_id, original_run_attempt, expected_base_sha, release_commit, managed_diff_sha256, automatic_comment_id, automatic_state_sha256)`.
+- Exact `kind` values are `automatic`, `authorized_override`, and `default_branch_rollout_fallback`. Only the fallback kind carries the nine evidence fields; the other kinds serialize only their `kind` key.
+- Schema-1 migration derives `automatic` from `pull_request` and `authorized_override` from `workflow_dispatch`; every other legacy event fails closed.
+- Add optional action input `invocation-route-json` with default `{"kind":"automatic"}` for source compatibility during staged edits; every v1.77 workflow call passes an explicit route value.
+- Add required persisted `route: InvocationRoute` to `Invocation`. Add `route` to `ClaimRequest` and `FinalizeRequest` with `field(default_factory=InvocationRoute.automatic)` so existing pure-Python callers remain automatic; every v1.77 action/workflow call still supplies explicit JSON. Claim and finalize require the same serialized route.
+- For fallback claims only, the selected run event is `issue_comment`, caller path is `.github/workflows/claude.yml`, and the invocation HEAD is the freshly fetched pull-request HEAD rather than the default-branch run HEAD. Existing `referenced_workflow_sha` records the installed driver commit from the consumer default branch; route `release_commit` separately records the target commit being rolled out.
+- The route still consumes an automatic round. `force_review` must be false, no override event may be consumed, and the existing duplicate-head/round/usage/finalization behavior is unchanged.
+
+Target route serialization:
+
+```python
+@dataclass(frozen=True)
+class InvocationRoute:
+    kind: Literal[
+        "automatic", "authorized_override", "default_branch_rollout_fallback"
+    ]
+    request_comment_id: int | None = None
+    request_nonce: str | None = None
+    original_run_id: int | None = None
+    original_run_attempt: int | None = None
+    expected_base_sha: str | None = None
+    release_commit: str | None = None
+    managed_diff_sha256: str | None = None
+    automatic_comment_id: int | None = None
+    automatic_state_sha256: str | None = None
+
+    @classmethod
+    def automatic(cls) -> "InvocationRoute":
+        return cls(kind="automatic")
+```
+
+Required migration and accounting assertions:
+
+```python
+legacy = LedgerState.from_dict(schema_one_ledger())
+assert [item.route.kind for item in legacy.invocations] == ["automatic"]
+assert legacy.to_dict()["schema"] == 2
+
+claimed = claim(empty_state(), fallback_claim(), fallback_provenances())
+assert claimed.allow_invocation is True
+assert claimed.state.invocations[-1].round_number == 1
+assert claimed.state.invocations[-1].route.kind == "default_branch_rollout_fallback"
+assert claimed.state.invocations[-1].caller_event == "issue_comment"
+```
+
+- [ ] **Step 1: Write failing schema migration and exact-route tests.** Cover both legal schema-1 events and exact schema-2 route key sets.
+
+```python
+@pytest.mark.parametrize(("event", "kind"), [
+    ("pull_request", "automatic"),
+    ("workflow_dispatch", "authorized_override"),
+])
+def test_schema_one_invocations_gain_typed_route(event, kind):
+    raw = schema_one_ledger(caller_event=event)
+    state = LedgerState.from_dict(raw)
+    assert state.invocations[0].route.kind == kind
+    assert state.to_dict()["schema"] == 2
+
+def test_fallback_route_requires_every_evidence_field():
+    raw = fallback_route_dict()
+    raw.pop("automatic_state_sha256")
+    with pytest.raises(BudgetStateError, match="^invocation_route_invalid$"):
+        InvocationRoute.from_dict(raw)
+```
+
+- [ ] **Step 2: Run the schema cases and verify red.**
+
+```bash
+rtk pytest -q tests/test_review_invocation_budget.py -k 'schema_one or fallback_route'
+```
+
+Expected: schema 2 and `InvocationRoute` assertions fail.
+
+- [ ] **Step 3: Implement exact route serialization and migration.** Pass the ledger schema into invocation decoding and always serialize the current schema.
+
+```python
+SCHEMA = 2
+
+@classmethod
+def from_legacy_event(cls, event: str) -> "InvocationRoute":
+    kinds = {
+        "pull_request": "automatic",
+        "workflow_dispatch": "authorized_override",
+    }
+    if event not in kinds:
+        raise BudgetStateError("invocation_route_invalid")
+    return cls(kind=kinds[event])
+
+def decode_invocation_route(
+    value: object, *, schema: int, caller_event: str,
+) -> InvocationRoute:
+    if schema == 1:
+        return InvocationRoute.from_legacy_event(caller_event)
+    if schema == 2:
+        return InvocationRoute.from_dict(value)
+    raise BudgetStateError("schema_invalid")
+```
+
+Change `Invocation.from_dict(value, *, schema)` to use the current v1 key set when `schema == 1`, the same set plus `route` when `schema == 2`, and `decode_invocation_route` for the new field. `InvocationRoute.from_dict` accepts exactly `{"kind"}` for automatic/override and exactly the ten dataclass field names for fallback, validates positive IDs, 32-hex nonce, 40-hex SHAs, and 64-hex digests, and rejects non-null evidence on the two simple routes.
+
+- [ ] **Step 4: Run the schema cases and verify green.**
+
+```bash
+rtk pytest -q tests/test_review_invocation_budget.py -k 'schema or route'
+```
+
+Expected: migration and serialization cases pass without changing existing budget decisions.
+
+- [ ] **Step 5: Write failing fallback provenance and accounting cases.** Require issue-comment provenance, separate installed/target commits, and automatic-round use.
+
+```python
+def test_fallback_claim_uses_pr_head_and_one_automatic_round():
+    result = claim(empty_state(), fallback_claim(), fallback_provenances())
+    invocation = result.state.invocations[-1]
+    assert result.allow_invocation is True
+    assert invocation.head_sha == FALLBACK_HEAD
+    assert invocation.caller_event == "issue_comment"
+    assert invocation.referenced_workflow_sha == DRIVER_COMMIT
+    assert invocation.route.release_commit == TARGET_RELEASE_COMMIT
+    assert invocation.round_number == 1
+    assert invocation.override_event_id is None
+
+@pytest.mark.parametrize("change", [
+    "force_review", "wrong_caller", "wrong_pr_head", "wrong_base",
+    "wrong_request", "wrong_target_release", "wrong_driver", "wrong_state_digest",
+    "non_claude_reviewer",
+])
+def test_fallback_provenance_rejects_mismatches(change):
+    transition = claim(empty_state(), fallback_claim(change), fallback_provenances())
+    assert (transition.allow_invocation, transition.decision) == (False, "state_invalid")
+```
+
+- [ ] **Step 6: Run fallback provenance cases and verify red.**
+
+```bash
+rtk pytest -q tests/test_review_invocation_budget.py -k fallback
+```
+
+Expected: issue-comment provenance is refused before route-aware validation exists.
+
+- [ ] **Step 7: Implement route-aware claim/finalize provenance.** Select the expected event from the typed route and bind fallback HEAD/base to the freshly fetched pull request.
+
+```python
+def expected_caller_event(request: ClaimRequest | FinalizeRequest) -> str:
+    return {
+        "automatic": "pull_request",
+        "authorized_override": "workflow_dispatch",
+        "default_branch_rollout_fallback": "issue_comment",
+    }[request.route.kind]
+
+def provenance_head(provenance: RunProvenance, request: ClaimRequest) -> str:
+    if request.route.kind == "default_branch_rollout_fallback":
+        if request.reviewer != "claude" or request.force_review:
+            raise BudgetStateError("invocation_route_invalid")
+        return request.head_sha
+    return provenance.head_sha
+```
+
+Update `_validate_provenance_identity`, `_validate_one_provenance`, and `_run_provenances` to call these selectors. Require caller `.github/workflows/claude.yml` and nested review `referenced_workflow_sha == DRIVER_COMMIT`; compare route target release only with the admitted request, never with the driver commit.
+
+- [ ] **Step 8: Write and implement the composite-action transport cases.** Add the new input and stage it as JSON data rather than shell source.
+
+```yaml
+inputs:
+  invocation-route-json:
+    required: false
+    default: '{"kind":"automatic"}'
+```
+
+```python
+payload["invocation_route_json"] = os.environ["INVOCATION_ROUTE_JSON"]
+route = InvocationRoute.from_dict(json.loads(payload["invocation_route_json"]))
+request = replace(request, route=route)
+```
+
+The harness must cover schema-1 comment migration, exact base fetch, duplicate-head reuse, one finalized call, malformed route JSON, and claim/finalize route drift.
+
+- [ ] **Step 9: Run focused budget tests and verify green.**
+
+```bash
+rtk pytest -q tests/test_review_invocation_budget.py tests/test_review_invocation_budget_action.py
+rtk git diff --check
+```
+
+Expected: both suites and diff validation pass.
+
+- [ ] **Step 10: Commit the independently testable budget unit.**
+
+```bash
+rtk git add .github/actions/review-invocation-budget tests/test_review_invocation_budget.py tests/test_review_invocation_budget_action.py
+rtk git commit -m 'feat(review-budget): record Claude fallback provenance'
+```
+
+### Task 3: Canonical Claude review fallback mode
+
+**Files:**
+
+- Modify: `.github/workflows/claude-code-review.yml`
+- Modify: `tests/test_claude_workflow_validation.py`
+- Modify: `tests/test_review_workflow_logic.py`
+
+**Interfaces:**
+
+- Declare the eight optional string inputs in the Contract Map with empty-string defaults. Define fallback mode as all eight nonempty and normal mode as all eight empty; every partial combination fails before diff preparation.
+- In fallback mode, run the release-owned admission action again using `fallback_request_comment_id`, compare every admission scalar to the workflow input, and check the live pull-request HEAD/base both before `prepare-review-diff` and immediately before publication.
+- Require `prepare-review-diff` to recompute a full diff whose SHA-256 exactly equals `fallback_managed_diff_sha256` before the budget claim.
+- Caller validation remains mandatory and unchanged. The nested route succeeds because `github.workflow_ref` identifies the default-branch consumer `.github/workflows/claude.yml`; it receives no bypass flag.
+- Pass the exact `default_branch_rollout_fallback` route JSON, including the freshly admitted automatic comment ID/state digest, to both budget claim and finalize. Normal and force-review paths pass `automatic` and `authorized_override` respectively.
+- The central managed caller passes `review_mode: request`. The existing policy resolver must freshly observe the rollout PR's single `review:request` label and no `review:skip` label before the nested review job can reach admission, budget, or provider steps.
+- Extend schema-3 state with one exact `failure_reason` field on new failure records and one exact `route` object on fallback success records. Normal success has neither field; legacy schema-3 key sets remain readable.
+- The fallback route object has exactly `route`, `request_comment_id`, `original_failed_run_id`, `reviewed_base_sha`, `release_commit`, and `managed_diff_sha256`. Its route value is `default_branch_rollout_fallback`.
+
+Target fallback state fragment:
+
+```json
+{
+  "route": {
+    "managed_diff_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "original_failed_run_id": 34549275027,
+    "release_commit": "444a7347aee169ed178aae80e8bd8d10eca52e02",
+    "request_comment_id": 901,
+    "reviewed_base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "route": "default_branch_rollout_fallback"
+  }
+}
+```
+
+Required behavior assertions:
+
+```python
+state = _posted_state(fallback_success_body)
+assert state["attempt_status"] == "success"
+assert state["review_execution"] == "performed"
+assert state["route"]["original_failed_run_id"] == 34549275027
+assert state["route"]["reviewed_base_sha"] == "bb" * 20
+
+failed = _posted_state(automatic_mismatch_body)
+assert failed["failure_reason"] == "workflow_validation_mismatch"
+assert failed["review_execution"] == "not_performed"
+```
+
+- [ ] **Step 1: Write failing input, admission, diff, and caller-validation cases.** Parameterize every partial input count and each immutable-coordinate mutation.
+
+```python
+@pytest.mark.parametrize("present", range(1, 8))
+def test_partial_fallback_inputs_fail_before_diff(present):
+    result = run_fallback_mode_step(FALLBACK_INPUTS[:present])
+    assert result.returncode != 0
+    assert not result.outputs
+
+def test_fallback_requires_exact_recomputed_full_diff():
+    result = run_prebudget_gate(
+        diff_mode="full", computed_hash="12" * 32, requested_hash="34" * 32,
+    )
+    assert (result.returncode != 0, result.budget_entered) == (True, False)
+
+def test_fallback_does_not_bypass_caller_validation():
+    result = _preflight(tmp_path, currentBlob="11" * 20, defaultBlob="22" * 20)
+    assert result["outputs"] == {
+        "allowed": "false", "reason": "workflow_validation_mismatch",
+    }
+
+def test_fallback_still_requires_live_request_policy():
+    workflow = _load("claude-code-review.yml")
+    assert workflow["jobs"]["claude-review"]["if"] == (
+        "needs.check-enabled.outputs.enabled == 'true' && "
+        "needs.check-enabled.outputs.policy_run == 'true'"
+    )
+```
+
+- [ ] **Step 2: Run route-entry cases and verify red.**
+
+```bash
+rtk pytest -q tests/test_claude_workflow_validation.py tests/test_review_workflow_logic.py -k fallback
+```
+
+Expected: fallback inputs and gates are absent.
+
+- [ ] **Step 3: Add exact inputs, mode resolution, repeated admission, and prebudget gates.** The mode resolver writes only `normal` or `fallback`; partial input sets fail the job.
+
+```yaml
+fallback_request_comment_id:
+  type: string
+  required: false
+  default: ''
+fallback_request_nonce:
+  type: string
+  required: false
+  default: ''
+fallback_expected_head_sha:
+  type: string
+  required: false
+  default: ''
+fallback_expected_base_sha:
+  type: string
+  required: false
+  default: ''
+fallback_original_run_id:
+  type: string
+  required: false
+  default: ''
+fallback_original_run_attempt:
+  type: string
+  required: false
+  default: ''
+fallback_release_commit:
+  type: string
+  required: false
+  default: ''
+fallback_managed_diff_sha256:
+  type: string
+  required: false
+  default: ''
+```
+
+```python
+values = json.loads(os.environ["FALLBACK_INPUTS_JSON"])
+count = sum(isinstance(value, str) and value != "" for value in values.values())
+if count not in {0, 8}:
+    raise SystemExit("fallback_inputs_partial")
+mode = "fallback" if count == 8 else "normal"
+with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as stream:
+    stream.write(f"mode={mode}\n")
+```
+
+Change the existing diff action binding so an admitted fallback always computes the full review diff:
+
+```yaml
+force-full: ${{ (inputs.force_review || steps.fallback-mode.outputs.mode == 'fallback') && 'true' || 'false' }}
+```
+
+In fallback mode, invoke `$/.github/actions/claude-rollout-fallback`, require route `managed`, compare its eight request outputs with the eight workflow inputs, retain its two automatic-state outputs for the route JSON, fetch the live pull request, and require exact HEAD/base. After `prepare-review-diff`, require mode `full` and hash equality before caller validation and budget claim.
+
+- [ ] **Step 4: Run route-entry cases and verify green.**
+
+```bash
+rtk pytest -q tests/test_claude_workflow_validation.py tests/test_review_workflow_logic.py -k 'fallback and not state'
+```
+
+Expected: partial/stale/diff/caller cases pass; existing caller-validation cases remain unchanged.
+
+- [ ] **Step 5: Write failing budget-route and canonical-state cases.** Assert byte-identical claim/finalize route JSON and exact schema-3 key variants.
+
+```python
+def test_fallback_claim_and_finalize_use_identical_route_json():
+    workflow = _load("claude-code-review.yml")
+    claim = workflow_step(workflow, "Claim Claude review budget")
+    finalize = workflow_step(workflow, "Finalize Claude review budget")
+    assert claim["with"]["invocation-route-json"] == finalize["with"]["invocation-route-json"]
+
+def test_fallback_success_publishes_authenticated_route():
+    state = _posted_state(fallback_success_body())
+    assert set(state["route"]) == {
+        "managed_diff_sha256", "original_failed_run_id", "release_commit",
+        "request_comment_id", "reviewed_base_sha", "route",
+    }
+    assert state["route"]["route"] == "default_branch_rollout_fallback"
+
+def test_mismatch_failure_publishes_authenticated_reason():
+    state = _posted_state(automatic_mismatch_body())
+    assert (state["failure_reason"], state["review_execution"]) == (
+        "workflow_validation_mismatch", "not_performed",
+    )
+```
+
+- [ ] **Step 6: Run state/publication cases and verify red.**
+
+```bash
+rtk pytest -q tests/test_claude_workflow_validation.py tests/test_review_workflow_logic.py -k 'route_json or authenticated_route or authenticated_reason'
+```
+
+Expected: current schema-3 writers lack `failure_reason` and `route`.
+
+- [ ] **Step 7: Implement route-aware budget calls and exact state variants.** Build route JSON once in a mode step and feed the same output to claim/finalize.
+
+```javascript
+const state = {
+  schema: 3,
+  reviewer: 'claude',
+  pr: issueNumber,
+  run_id: runId,
+  run_attempt: runAttempt,
+  attempt_head: attemptHead,
+  successful_head: failed ? preservedHead : attemptHead,
+  attempt_status: failed ? 'failure' : 'success',
+  diff_mode: stateDiffMode,
+  review_execution: execution,
+  full_diff_sha256: stateDiffHash,
+  quality_schema: 1,
+  accepted_count: acceptedCount,
+  filtered_count: filteredCount,
+  normalized_count: normalizedCount,
+  filtered_max_severity: filteredMaxSeverity,
+};
+if (failed) state.failure_reason = effectiveFailureReason;
+if (!failed && fallbackMode) state.route = fallbackRoute;
+```
+
+Accept only legacy-without-execution, current normal, current failure, and current fallback exact key sets in both collect-context and upsert parsers. Require failure reason only on failure and route only on fallback success. Fetch and compare live HEAD/base again immediately before the sticky-comment mutation.
+
+- [ ] **Step 8: Exercise success, failure, idempotency, and regressions.**
+
+```bash
+rtk pytest -q tests/test_claude_workflow_validation.py tests/test_review_workflow_logic.py tests/test_review_invocation_budget.py tests/test_review_invocation_budget_action.py
+rtk git diff --check
+```
+
+Expected: one-call/finalized CLEAN, blocking findings, provider/candidate failures, finalized retry, automatic review, and force-review cases all pass.
+
+- [ ] **Step 9: Commit the independently testable canonical-review unit.**
+
+```bash
+rtk git add .github/workflows/claude-code-review.yml tests/test_claude_workflow_validation.py tests/test_review_workflow_logic.py
+rtk git commit -m 'feat(claude): publish authenticated fallback reviews'
+```
+
+### Task 4: Default-branch router and consumer permission contract
+
+**Files:**
+
+- Modify: `.github/workflows/claude.yml`
+- Modify: `examples/baseline-workflows/.github/workflows/claude.yml`
+- Modify: `scripts/workflow-catalog.json`
+- Modify: `tests/test_canonical_workflow_tree.py`
+- Modify: `tests/test_action_pins.py`
+
+**Interfaces:**
+
+- Central jobs are `check-enabled`, `classify-request`, `claude`, `managed-rollout-review`, and `skipped`.
+- `classify-request` has `actions: read`, `contents: read`, `issues: read`, and `pull-requests: read`; it calls `$/.github/actions/claude-rollout-fallback`.
+- Classifier output `interactive` permits only the existing interactive conditions, `managed` requires a complete admission, and `invalid` runs neither provider path while surfacing one bounded diagnostic.
+- `claude` keeps the current provider and read-only permission set, and its condition explicitly excludes the exact managed marker prefix even if the body contains `@claude`.
+- `managed-rollout-review` is mutually exclusive with `claude`, has `actions: read`, `contents: read`, `issues: read`, `pull-requests: write`, and `id-token: write`, and calls `$/.github/workflows/claude-code-review.yml` with `pr_number` from the issue event, all eight admission outputs, and the existing Claude secret.
+- The managed nested call fixes `review_mode` to `request`; the existing policy resolver therefore requires the live `review:request` label and refuses `review:skip`, conflict, draft, closed, unsafe-head, or disabled-workflow states before provider access.
+- The baseline consumer caller raises only its ceiling from `pull-requests: read` to `pull-requests: write`; it still points to an immutable `__AUTOMATION_COMMIT__` and passes only `CLAUDE_CODE_OAUTH_TOKEN`.
+- The catalog records the changed caller permission contract without adding a second consumer workflow or trigger.
+
+Target mutual-exclusion assertions:
+
+```python
+central = load_yaml(ROOT / ".github/workflows/claude.yml")
+assert central["jobs"]["managed-rollout-review"]["uses"] == (
+    "$/.github/workflows/claude-code-review.yml"
+)
+assert central["jobs"]["claude"]["permissions"]["pull-requests"] == "read"
+assert central["jobs"]["managed-rollout-review"]["permissions"]["pull-requests"] == "write"
+assert baseline["jobs"]["claude"]["permissions"]["pull-requests"] == "write"
+```
+
+- [ ] **Step 1: Write failing router, permission, and mutual-exclusion tests.** Assert the exact job set and evaluate representative classifications.
+
+```python
+def test_claude_router_has_closed_jobs_and_permissions():
+    central = load_yaml(ROOT / ".github/workflows/claude.yml")
+    assert set(central["jobs"]) == {
+        "check-enabled", "classify-request", "claude",
+        "managed-rollout-review", "skipped",
+    }
+    assert set(central["jobs"]["claude"]["needs"]) == {
+        "check-enabled", "classify-request",
+    }
+    assert central["jobs"]["claude"]["permissions"] == CLAUDE_INTERACTIVE_PERMISSIONS
+    assert central["jobs"]["managed-rollout-review"]["permissions"] == CLAUDE_REVIEW_PERMISSIONS
+    assert central["jobs"]["managed-rollout-review"]["with"]["review_mode"] == "request"
+    assert central["jobs"]["managed-rollout-review"]["with"]["pr_number"] == (
+        "${{ github.event.issue.number }}"
+    )
+
+@pytest.mark.parametrize(("classification", "interactive", "managed"), [
+    ("interactive", True, False),
+    ("managed", False, True),
+    ("invalid", False, False),
+])
+def test_claude_routes_are_mutually_exclusive(classification, interactive, managed):
+    assert route_jobs(classification) == {
+        "claude": interactive,
+        "managed-rollout-review": managed,
+    }
+```
+
+- [ ] **Step 2: Run router cases and verify red.**
+
+```bash
+rtk pytest -q tests/test_canonical_workflow_tree.py -k 'claude and (router or mutually or permission)'
+```
+
+Expected: central workflow lacks classifier/managed jobs and the consumer ceiling is read-only.
+
+- [ ] **Step 3: Implement the central router.** Preserve `check-enabled`; classify only when enabled; expose all ten admitted evidence outputs, feed the eight request fields into the nested workflow, and let that workflow's repeated admission derive the two automatic-state fields for its budget route.
+
+```yaml
+classify-request:
+  needs: check-enabled
+  if: needs.check-enabled.outputs.enabled == 'true'
+  runs-on: ubuntu-latest
+  permissions:
+    actions: read
+    contents: read
+    issues: read
+    pull-requests: read
+  outputs:
+    route: ${{ steps.classify.outputs.route }}
+    reason: ${{ steps.classify.outputs.reason }}
+    request-comment-id: ${{ steps.classify.outputs.request-comment-id }}
+    request-nonce: ${{ steps.classify.outputs.request-nonce }}
+    expected-head-sha: ${{ steps.classify.outputs.expected-head-sha }}
+    expected-base-sha: ${{ steps.classify.outputs.expected-base-sha }}
+    original-run-id: ${{ steps.classify.outputs.original-run-id }}
+    original-run-attempt: ${{ steps.classify.outputs.original-run-attempt }}
+    release-commit: ${{ steps.classify.outputs.release-commit }}
+    managed-diff-sha256: ${{ steps.classify.outputs.managed-diff-sha256 }}
+    automatic-comment-id: ${{ steps.classify.outputs.automatic-comment-id }}
+    automatic-state-sha256: ${{ steps.classify.outputs.automatic-state-sha256 }}
+  steps:
+    - id: classify
+      uses: $/.github/actions/claude-rollout-fallback
+      with:
+        github-token: ${{ github.token }}
+    - name: Report invalid managed request
+      if: steps.classify.outputs.route == 'invalid'
+      shell: bash
+      env:
+        REASON: ${{ steps.classify.outputs.reason }}
+      run: |
+        set -euo pipefail
+        [[ "$REASON" =~ ^[a-z_]+$ ]]
+        printf '## Claude request declined\n\nReason: `%s`\n' "$REASON" >> "$GITHUB_STEP_SUMMARY"
+
+claude:
+  needs: [check-enabled, classify-request]
+  if: |
+    needs.classify-request.outputs.route == 'interactive' && (
+      (github.event_name == 'issue_comment' &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+        contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+        contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) &&
+        contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    )
+
+managed-rollout-review:
+  needs: [check-enabled, classify-request]
+  if: needs.classify-request.outputs.route == 'managed'
+  permissions:
+    actions: read
+    contents: read
+    id-token: write
+    issues: read
+    pull-requests: write
+  uses: $/.github/workflows/claude-code-review.yml
+  with:
+    pr_number: ${{ github.event.issue.number }}
+    review_mode: request
+    fallback_request_comment_id: ${{ needs.classify-request.outputs.request-comment-id }}
+    fallback_request_nonce: ${{ needs.classify-request.outputs.request-nonce }}
+    fallback_expected_head_sha: ${{ needs.classify-request.outputs.expected-head-sha }}
+    fallback_expected_base_sha: ${{ needs.classify-request.outputs.expected-base-sha }}
+    fallback_original_run_id: ${{ needs.classify-request.outputs.original-run-id }}
+    fallback_original_run_attempt: ${{ needs.classify-request.outputs.original-run-attempt }}
+    fallback_release_commit: ${{ needs.classify-request.outputs.release-commit }}
+    fallback_managed_diff_sha256: ${{ needs.classify-request.outputs.managed-diff-sha256 }}
+  secrets:
+    CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+Route `invalid` writes its bounded reason to the run summary and reaches no credentialed job. Tests require the displayed twelve-output map exactly, the interactive job's two `needs`, and the full existing actor/event clauses, so a future action/job name drift fails before rollout.
+
+- [ ] **Step 4: Raise the consumer ceiling and update the catalog.** Change only the Claude consumer job's pull-request permission and the matching parsed catalog contract.
+
+```yaml
+jobs:
+  claude:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      issues: read
+      pull-requests: write
+```
+
+```python
+CLAUDE_COMMAND_PERMISSIONS = {
+    "actions": "read",
+    "contents": "read",
+    "id-token": "write",
+    "issues": "read",
+    "pull-requests": "write",
+}
+CLAUDE_INTERACTIVE_PERMISSIONS = {
+    **CLAUDE_COMMAND_PERMISSIONS,
+    "pull-requests": "read",
+}
+```
+
+Use `CLAUDE_INTERACTIVE_PERMISSIONS` for the central `claude` job assertion and `CLAUDE_COMMAND_PERMISSIONS` for the baseline caller ceiling. Keep the managed job on the existing `CLAUDE_REVIEW_PERMISSIONS` set.
+
+- [ ] **Step 5: Run router and source-pin checks.**
+
+```bash
+rtk pytest -q tests/test_canonical_workflow_tree.py tests/test_action_pins.py tests/test_claude_rollout_fallback.py
+```
+
+Expected: exact triggers, local `$/` references, third-party full pins, input/secret mappings, and route exclusivity pass.
+
+- [ ] **Step 6: Run actionlint and diff validation.**
+
+```bash
+rtk proxy /home/jhw/ai/opencode/projects/automation/.review/releases/v1.74/tools/actionlint-1.7.12 .github/workflows/claude.yml .github/workflows/claude-code-review.yml examples/baseline-workflows/.github/workflows/claude.yml
+rtk git diff --check
+```
+
+Expected: actionlint and diff validation pass.
+
+- [ ] **Step 7: Commit the independently testable router unit.**
+
+```bash
+rtk git add .github/workflows/claude.yml examples/baseline-workflows/.github/workflows/claude.yml scripts/workflow-catalog.json tests/test_canonical_workflow_tree.py tests/test_action_pins.py
+rtk git commit -m 'feat(claude): route managed reviews from default branch'
+```
+
+### Task 5: Read-only fleet verifier and private receipt
+
+**Files:**
+
+- Create: `scripts/verify_claude_rollout_fallback.py`
+- Create: `tests/test_verify_claude_rollout_fallback.py`
+- Modify: `scripts/rollout_workflow_fleet.py`
+- Modify: `tests/test_rollout_workflow_fleet.py`
+
+**Interfaces:**
+
+- Promote only pure reusable fleet helpers needed by the verifier: `render_rollout_plan(snapshot: RepositorySnapshot, bundle: ReleaseBundle, repo: str, *, bootstrap: bool) -> RenderPlan`, `validate_commit_tree(snapshot: RepositorySnapshot, expected_head: str, expected_base: str, plan: RenderPlan) -> None`, and `attest_pull_request(snapshot: RepositorySnapshot, release_ref: str, release_commit: str, expected_head: str, changed_paths: tuple[str, ...], request: VerificationRequest) -> PullRequest`. Existing rollout command behavior remains byte-for-byte compatible outside symbol naming.
+- `VerificationRequest(automation_root, release_ref, remote, repository, pr, expected_head, expected_base, output)` is the CLI request.
+- `verify(request: VerificationRequest, evidence_provider: EvidenceProvider) -> dict[str, object]` materializes the exact release, renders the selected consumer profile at the expected base, validates the single-child commit tree and exact open pull request, then validates request, automatic run/jobs/state, fallback run/jobs/state, budget ledger, and current required checks.
+- The target `release_commit` comes from the rendered review branch. The fallback `driver_commit` comes from the consumer default-branch caller pin and must match the nested fallback run's referenced workflow SHA. These commits are expected to differ on the real caller-changing canary.
+- `EvidenceProvider` performs bounded GitHub REST and trusted-origin Git reads. Tests use a deterministic fake implementing the same methods; the verifier never imports or executes consumer files.
+- Remote enumeration limits are exact: at most ten 100-item workflow-run pages, one 100-job page per selected attempt, ten 100-annotation pages per selected check run, ten 100-comment pages, ten 100-check-run pages, and ten 100-item required-context/ruleset pages. A full final permitted page is an overflow error because completeness was not proven.
+- CLI arguments are exactly `--automation-root`, `--release-ref`, `--remote`, `--repository`, `--pr`, `--expected-head`, `--expected-base`, and `--output`; the output path must be outside `automation_root`.
+- Production invocation uses Python isolated/no-site/no-bytecode flags `-I -S -B`. The script performs only standard-library and fixed-tool reads until the driver checkout passes exact-root verification, then explicitly inserts that verified root for its delayed project imports.
+- Output is canonical compact JSON plus LF. Require a current-user-owned, non-symlink mode-0700 parent outside `automation_root`; reject every pre-existing destination including a broken symlink; write and fsync an adjacent O_EXCL temporary regular file, chmod it 0600 independently of umask, atomically publish it with a same-directory no-replace hard link, then lstat and verify current UID/mode before success.
+- The fallback updates the existing sticky comment, so the pre-fallback failure body is no longer live afterward. The receipt labels its digest `admitted_state_sha256`; the verifier binds that digest through the finalized budget route and independently proves the mismatch from the original failed job's exact error annotation and skipped provider step.
+- `automation_root` must be a clean exact checkout at the installed `driver_commit` derived from the consumer default-branch caller. The verifier imports local rollout modules only after `/usr/bin/git` verifies HEAD, tracked bytes, untracked-file absence, regular-file modes, and required module paths against that commit.
+- Receipt `verifier_commit` equals that verified `driver_commit`; top-level `release_commit` remains the distinct target rollout commit. The real-boundary canary rejects equality between those two fields.
+- Private verifier helpers have fixed signatures: `parse_default_caller_pin(document: object) -> str`, `load_verified_modules(root: Path) -> VerifiedModules`, `verify_fleet_request(request: VerificationRequest, evidence: EvidenceProvider, modules: VerifiedModules) -> dict[str, object]`, `verify_automatic_failure(request: VerificationRequest, evidence: EvidenceProvider) -> dict[str, object]`, `verify_fallback_success(request: VerificationRequest, evidence: EvidenceProvider, automatic: dict[str, object], driver_commit: str) -> dict[str, object]`, `require_required_checks_clean(checks: tuple[dict[str, object], ...]) -> None`, and `build_receipt(request: VerificationRequest, fleet: dict[str, object], automatic: dict[str, object], fallback: dict[str, object], driver_commit: str) -> dict[str, object]`. `VerifiedModules` is a frozen dataclass holding the imported release-bundle, inventory, and promoted rollout helper modules.
+- Filesystem helpers are `git_stdout(root: Path, *args: str) -> str`, `canonical_json_bytes(payload: dict[str, object]) -> bytes`, `require_private_output_parent(path: Path) -> None`, and `require_private_regular_owned(path: Path) -> None`; `git_stdout` uses absolute `/usr/bin/git`, `GIT_OPTIONAL_LOCKS=0`, no prompts/askpass, no replacement objects, and disabled system/global configuration. Every failure becomes a bounded `VerificationError` without remote body text.
+
+Receipt schema 1 has these exact top-level keys:
+
+```python
+RECEIPT_KEYS = frozenset({
+    "automatic", "base_sha", "effective_status", "fallback", "fleet",
+    "head_sha", "managed_diff_sha256", "pr", "release_commit",
+    "repository", "schema", "verifier_commit",
+})
+AUTOMATIC_KEYS = frozenset({
+    "admitted_state_sha256", "canonical_comment_id", "reason",
+    "review_execution", "run_attempt", "run_id", "status",
+})
+FALLBACK_KEYS = frozenset({
+    "budget_status", "canonical_comment_id", "canonical_state_sha256",
+    "driver_commit", "filtered_max_severity", "request_comment_id",
+    "request_nonce", "review_execution", "route", "run_attempt", "run_id",
+    "status",
+})
+FLEET_KEYS = frozenset({
+    "base_branch", "changed_paths", "head_repository", "pull_request_url",
+    "rollout_branch",
+})
+```
+
+The outcome subrecords are exact:
+
+```json
+{
+  "automatic": {
+    "canonical_comment_id": 887,
+    "admitted_state_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "reason": "workflow_validation_mismatch",
+    "review_execution": "not_performed",
+    "run_attempt": 1,
+    "run_id": 34549275027,
+    "status": "FAILED"
+  },
+  "effective_status": "CLEAN",
+  "fallback": {
+    "budget_status": "finalized",
+    "canonical_comment_id": 887,
+    "canonical_state_sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "driver_commit": "9999999999999999999999999999999999999999",
+    "filtered_max_severity": "none",
+    "request_comment_id": 901,
+    "request_nonce": "dddddddddddddddddddddddddddddddd",
+    "review_execution": "performed",
+    "route": "default_branch_rollout_fallback",
+    "run_attempt": 1,
+    "run_id": 34550000000,
+    "status": "CLEAN"
+  }
+}
+```
+
+- [ ] **Step 1: Write failing CLI, root-trust, and private-output tests.** Cover exact arguments and every local filesystem trust boundary.
+
+```python
+@pytest.mark.parametrize("change", [
+    "bad_repository", "zero_pr", "uppercase_head", "bad_release_ref",
+    "output_inside_root", "wrong_head", "dirty_tracked", "untracked_shadow",
+    "symlinked_module", "wrong_driver_pin",
+])
+def test_local_verifier_boundary_fails_closed(change, verifier_fixture):
+    result = verifier_fixture.run(change=change)
+    assert result.returncode != 0
+    assert not verifier_fixture.output.exists()
+
+@pytest.mark.parametrize("change", [
+    "existing_output", "broken_output_symlink", "symlinked_output_parent",
+])
+def test_output_path_rejection_preserves_original_node(change, verifier_fixture):
+    before = verifier_fixture.install_output_guard(change)
+    result = verifier_fixture.run()
+    assert result.returncode != 0
+    assert verifier_fixture.output_guard() == before
+
+@pytest.mark.parametrize("mask", [0o000, 0o077, 0o777])
+def test_receipt_is_private_regular_and_owned(mask, verifier_fixture):
+    verifier_fixture.run_valid(umask=mask)
+    observed = verifier_fixture.output.lstat()
+    assert stat.S_ISREG(observed.st_mode)
+    assert not verifier_fixture.output.is_symlink()
+    assert observed.st_uid == os.getuid()
+    assert stat.S_IMODE(observed.st_mode) == 0o600
+```
+
+- [ ] **Step 2: Run local-boundary cases and verify red.**
+
+```bash
+rtk pytest -q tests/test_verify_claude_rollout_fallback.py -k 'local or receipt_is_private'
+```
+
+Expected: verifier module and CLI are absent.
+
+- [ ] **Step 3: Implement CLI parsing, exact-root verification, and atomic output.** Delay project imports until the standard-library root check returns `driver_commit`.
+
+```python
+def verify_source_root(root: Path, driver_commit: str) -> None:
+    head = git_stdout(root, "rev-parse", "HEAD")
+    status = git_stdout(root, "status", "--porcelain=v1", "--untracked-files=all")
+    if head != driver_commit or status != "":
+        raise VerificationError("verifier_root_invalid")
+    for relative in REQUIRED_MODULE_PATHS:
+        record = git_stdout(root, "ls-tree", driver_commit, "--", relative)
+        if not record.startswith("100644 blob "):
+            raise VerificationError("verifier_root_invalid")
+
+def write_receipt(path: Path, payload: dict[str, object]) -> None:
+    require_private_output_parent(path.parent)
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        pass
+    else:
+        raise VerificationError("receipt_path_exists")
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    descriptor = os.open(
+        temporary,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+        0o600,
+    )
+    try:
+        with os.fdopen(descriptor, "wb", closefd=True) as stream:
+            stream.write(canonical_json_bytes(payload))
+            os.fchmod(stream.fileno(), 0o600)
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(temporary, path, follow_symlinks=False)
+        except FileExistsError:
+            raise VerificationError("receipt_path_exists") from None
+    finally:
+        temporary.unlink(missing_ok=True)
+    require_private_regular_owned(path)
+```
+
+The CLI first reads the default caller pin with its standard-library transport, verifies the source root at that driver commit, adds that root to `sys.path`, imports the existing rollout/release modules, and writes no output until verification is complete.
+
+- [ ] **Step 4: Run local-boundary cases and verify green.**
+
+```bash
+rtk pytest -q tests/test_verify_claude_rollout_fallback.py -k 'local or receipt_is_private'
+```
+
+Expected: valid root/output cases pass and every mutation leaves no receipt.
+
+- [ ] **Step 5: Write failing exact-fleet tests.** Use a real temporary Git repository and mutate one renderer-owned invariant per case.
+
+```python
+@pytest.mark.parametrize("change", [
+    "extra_path", "changed_blob", "executable_mode", "merge_commit",
+    "wrong_parent", "wrong_profile", "wrong_target_pin", "moved_branch",
+    "duplicate_pr", "fork_head", "stale_head", "changed_pr_body",
+])
+def test_fleet_attestation_rejects_mutation(change, exact_rollout_fixture):
+    fixture = exact_rollout_fixture.mutate(change)
+    with pytest.raises(VerificationError, match="^fleet_attestation_failed$"):
+        verify(fixture.request, fixture.provider)
+```
+
+- [ ] **Step 6: Promote and use the pure fleet helpers.** Rename `_render` to `render_rollout_plan`, keep the current caller as a thin wrapper, and use the existing tree/pull-request checks from the verifier.
+
+```python
+def render_rollout_plan(
+    snapshot: RepositorySnapshot,
+    bundle: ReleaseBundle,
+    repo: str,
+    *,
+    bootstrap: bool,
+) -> RenderPlan:
+    return render_repository(
+        snapshot.path, bundle.canonical, bundle.catalog,
+        bundle.config.profiles[repo], bundle.ref, bundle.commit,
+        set(snapshot.secret_names), set(snapshot.variable_names),
+        label_names=set(snapshot.label_names), bootstrap=bootstrap,
+        observed_revision=snapshot.base_sha,
+    )
+```
+
+Call `validate_commit_tree(snapshot, expected_head, expected_base, plan)` and `attest_pull_request(snapshot, bundle.ref, bundle.commit, expected_head, changed_paths, request)` on freshly fetched state. Convert their bounded `CommandError` to `VerificationError("fleet_attestation_failed")` without including remote response text.
+
+- [ ] **Step 7: Run fleet cases and verify green.**
+
+```bash
+rtk pytest -q tests/test_verify_claude_rollout_fallback.py -k fleet
+rtk pytest -q tests/test_rollout_workflow_fleet.py
+```
+
+Expected: exact rendered rollout passes; all mutations and existing rollout regressions pass.
+
+- [ ] **Step 8: Write failing evidence-chain and native-check cases.** Require one unambiguous chain and explicit failure when the automatic job is required.
+
+```python
+def test_exact_chain_emits_effective_clean_receipt(exact_evidence):
+    receipt = verify(exact_evidence.request, exact_evidence.provider)
+    assert receipt["automatic"]["reason"] == "workflow_validation_mismatch"
+    assert receipt["automatic"]["review_execution"] == "not_performed"
+    assert receipt["fallback"]["review_execution"] == "performed"
+    assert receipt["fallback"]["budget_status"] == "finalized"
+    assert receipt["fallback"]["driver_commit"] == DRIVER_COMMIT
+    assert receipt["verifier_commit"] == DRIVER_COMMIT
+    assert receipt["release_commit"] == TARGET_RELEASE_COMMIT
+    assert receipt["verifier_commit"] != receipt["release_commit"]
+    assert receipt["effective_status"] == "CLEAN"
+
+def test_required_failed_automatic_check_blocks_receipt(exact_evidence):
+    exact_evidence.provider.required.add("Claude Code Review / claude-review")
+    with pytest.raises(VerificationError, match="^required_check_failed$"):
+        verify(exact_evidence.request, exact_evidence.provider)
+```
+
+Parameterize missing/duplicate evidence, stale coordinates, provider entry, missing or altered mismatch annotation, call count zero/two, claimed ledger, wrong driver, wrong target release/diff/base, active blocking finding, and unrelated App/free-form comments.
+
+- [ ] **Step 9: Implement the bounded provider and exact evidence verifier.** Keep network transport separate from pure evidence predicates.
+
+```python
+class EvidenceProvider(Protocol):
+    def default_caller(self) -> dict[str, object]:
+        raise NotImplementedError
+    def pull_request(self, number: int) -> dict[str, object]:
+        raise NotImplementedError
+    def issue_comments(self, number: int) -> tuple[dict[str, object], ...]:
+        raise NotImplementedError
+    def run_attempt(self, run_id: int, attempt: int) -> dict[str, object]:
+        raise NotImplementedError
+    def run_jobs(self, run_id: int, attempt: int) -> tuple[dict[str, object], ...]:
+        raise NotImplementedError
+    def check_annotations(self, check_run_id: int) -> tuple[dict[str, object], ...]:
+        raise NotImplementedError
+    def required_checks(self, head_sha: str) -> tuple[dict[str, object], ...]:
+        raise NotImplementedError
+
+def verify(request: VerificationRequest, evidence: EvidenceProvider) -> dict[str, object]:
+    driver_commit = parse_default_caller_pin(evidence.default_caller())
+    verify_source_root(request.automation_root, driver_commit)
+    modules = load_verified_modules(request.automation_root)
+    fleet = verify_fleet_request(request, evidence, modules)
+    automatic = verify_automatic_failure(request, evidence)
+    fallback = verify_fallback_success(request, evidence, automatic, driver_commit)
+    require_required_checks_clean(evidence.required_checks(request.expected_head))
+    return build_receipt(request, fleet, automatic, fallback, driver_commit)
+```
+
+Set `GITHUB_CLI = Path("/usr/bin") / ("g" + "h")` and invoke it with argument arrays. Enforce the exact interface limits before accepting completeness, check every response's exact JSON type, and never log response bodies. `verify_fallback_success` loads Task 1's exact request parser and Task 2's schema-2 ledger parser from the verified driver checkout.
+
+- [ ] **Step 10: Run verifier and rollout suites and verify green.**
+
+```bash
+rtk pytest -q tests/test_verify_claude_rollout_fallback.py tests/test_rollout_workflow_fleet.py
+rtk git diff --check
+```
+
+Expected: exact chain emits the declared schema-1 receipt; every mutation fails without output.
+
+- [ ] **Step 11: Commit the independently testable verifier unit.**
+
+```bash
+rtk git add scripts/verify_claude_rollout_fallback.py scripts/rollout_workflow_fleet.py tests/test_verify_claude_rollout_fallback.py tests/test_rollout_workflow_fleet.py
+rtk git commit -m 'feat(rollout): attest Claude fallback evidence'
+```
+
+### Task 6: v1.77 release boundary and operator documentation
+
+**Files:**
+
+- Modify: `scripts/workflow_release_inventory.py`
+- Modify: `scripts/verify_workflow_release.py`
+- Modify: `tests/test_verify_workflow_release.py`
+- Modify: `tests/release_fixture_helpers.py`
+- Modify: `scripts/workflow-catalog.json`
+- Modify: `tests/test_canonical_workflow_tree.py`
+- Modify: `docs/workflows/contracts.md`
+- Modify: `docs/workflow-fleet-rollout.md`
+
+**Interfaces:**
+
+- Add `CLAUDE_ROLLOUT_FALLBACK_RELEASE = (1, 77)` and `release_supports_claude_rollout_fallback(ref)`.
+- Add both new action files and the verifier script as exact 100644 release roots for v1.77 only. The verifier's imported rollout modules remain ordinary repository source, but delayed imports require a clean checkout at receipt `verifier_commit`; the later JHW plan must execute from that exact commit.
+- v1.77 validation seals request keys, bounded evidence reads, mutual exclusion, permission reduction, nested `$/` path, eight all-or-none inputs, ledger schema migration, exact canonical route, receipt keys, and no required-check waiver.
+- v1.76 continues to validate at `444a7347aee169ed178aae80e8bd8d10eca52e02`; v1.74/v1.75 historical fixtures retain their current accepted trees.
+- Release-contract helpers have fixed signatures: `require_claude_fallback_permissions(caller: object, router: object, review: object) -> None`, `require_claude_fallback_routes(router: object) -> None`, `require_claude_fallback_inputs(review: object) -> None`, `require_budget_schema_two(root: Path) -> None`, and `require_request_and_receipt_contracts(root: Path) -> None`. They raise `ReleaseVerificationError` and emit no partial acceptance.
+- The v1.77 operator section adapts the existing v1.76 create-only GitHub Git Data procedure. It requires an absent direct/peeled ref, exact reviewed public-main commit, one intended token passed by private file descriptor into an isolated environment, one annotated-tag-object POST followed by one tag-ref POST, exact response OIDs, raw response records at mode 0600, and final local/public remote verification. It never publishes through an ordinary Git push or moves/deletes a tag.
+
+Target release gate:
+
+```python
+CLAUDE_ROLLOUT_FALLBACK_RELEASE = (1, 77)
+
+def release_supports_claude_rollout_fallback(ref: str) -> bool:
+    """Return whether the release owns the managed Claude rollout fallback."""
+    return _release_version(ref) >= CLAUDE_ROLLOUT_FALLBACK_RELEASE
+```
+
+- [ ] **Step 1: Write failing v1.77 inventory and historical-acceptance tests.** Assert exact path ownership and unchanged older boundaries.
+
+```python
+def test_v177_adds_only_claude_rollout_fallback_roots():
+    v176 = set(release_inventory.release_paths_for("v1.76"))
+    v177 = set(release_inventory.release_paths_for("v1.77"))
+    assert v177 - v176 == {
+        ".github/actions/claude-rollout-fallback/action.yml",
+        ".github/actions/claude-rollout-fallback/contract.py",
+        "scripts/verify_claude_rollout_fallback.py",
+    }
+
+def test_v176_candidate_remains_accepted():
+    assert verify_commit_content(repo, "v1.76", V176_COMMIT) == V176_COMMIT
+```
+
+- [ ] **Step 2: Run inventory cases and verify red.**
+
+```bash
+rtk pytest -q tests/test_verify_workflow_release.py -k 'v177 or v176_candidate'
+```
+
+Expected: v1.77 feature boundary and fixture do not exist.
+
+- [ ] **Step 3: Implement the versioned roots and fixture downgrade.** Append only the three exact regular files when the ref supports the feature.
+
+```python
+CLAUDE_ROLLOUT_FALLBACK_RELEASE = (1, 77)
+CLAUDE_ROLLOUT_FALLBACK_ROOTS = (
+    ReleaseRoot(PurePosixPath(".github/actions/claude-rollout-fallback/action.yml"), "file", "100644"),
+    ReleaseRoot(PurePosixPath(".github/actions/claude-rollout-fallback/contract.py"), "file", "100644"),
+    ReleaseRoot(PurePosixPath("scripts/verify_claude_rollout_fallback.py"), "file", "100644"),
+)
+
+def release_supports_claude_rollout_fallback(ref: str) -> bool:
+    return _release_version(ref) >= CLAUDE_ROLLOUT_FALLBACK_RELEASE
+
+def _with_claude_rollout_fallback_roots(
+    ref: str, roots: tuple[ReleaseRoot, ...],
+) -> tuple[ReleaseRoot, ...]:
+    if release_supports_claude_rollout_fallback(ref):
+        return roots + CLAUDE_ROLLOUT_FALLBACK_ROOTS
+    return roots
+```
+
+Return `_with_claude_rollout_fallback_roots(ref, roots)` at the end of the existing `release_roots_for` branch sequence. In the test fixture helper, downgrade versions below v1.77 by deleting these three paths and restoring the v1.76 Claude caller, central workflow, budget schema, sticky-state key sets, catalog permission, and release-verifier seals from the committed v1.76 fixture bytes.
+
+- [ ] **Step 4: Write failing v1.77 mutation tests.** Use one named mutation for every security seal.
+
+```python
+@pytest.mark.parametrize("mutation", [
+    "request_keys", "actor_set", "comment_page_bound", "provider_skipped",
+    "nested_reference", "interactive_exclusion", "consumer_permission",
+    "interactive_permission", "route_json", "ledger_migration",
+    "canonical_route", "receipt_keys", "receipt_mode", "required_check",
+])
+def test_v177_rejects_fallback_contract_mutation(repo, mutation):
+    mutate_v177_contract(repo, mutation)
+    bad = commit(repo, f"mutate {mutation}")
+    with pytest.raises(ReleaseVerificationError):
+        verify_commit_content(repo, "v1.77", bad)
+```
+
+- [ ] **Step 5: Implement parsed and literal release seals.** Add one feature-gated verifier function and call it from the existing commit-content pipeline.
+
+```python
+def verify_claude_rollout_fallback_contract(root: Path) -> None:
+    caller = load_workflow(root / "examples/baseline-workflows/.github/workflows/claude.yml")
+    router = load_workflow(root / ".github/workflows/claude.yml")
+    review = load_workflow(root / ".github/workflows/claude-code-review.yml")
+    require_claude_fallback_permissions(caller, router, review)
+    require_claude_fallback_routes(router)
+    require_claude_fallback_inputs(review)
+    require_budget_schema_two(root)
+    require_request_and_receipt_contracts(root)
+
+if release_supports_claude_rollout_fallback(ref):
+    verify_claude_rollout_fallback_contract(candidate_root)
+```
+
+Use parsed YAML/Python AST checks for job/input/permission/schema structure and exact literal seals for embedded JavaScript key sets, error reasons, bounded page counts, and publication gates.
+
+- [ ] **Step 6: Write the operator contracts.** Add these exact sections and tables, using the names already fixed in this plan.
+
+```text
+docs/workflows/contracts.md
+  Claude rollout request v1
+  Admission schema 1
+  Invocation route schema 2 migration
+  Claude schema-3 failure and fallback variants
+  Fleet fallback receipt schema 1
+
+docs/workflow-fleet-rollout.md
+  Create-only v1.77 and v1.77.1 tag publication
+  v1.76 bootstrap evidence
+  v1.77 route adoption
+  v1.77.1 real-boundary canary
+  Required-check stop conditions
+```
+
+- [ ] **Step 7: Run release, catalog, and pin suites and verify green.**
+
+```bash
+rtk pytest -q tests/test_verify_workflow_release.py tests/test_canonical_workflow_tree.py tests/test_action_pins.py
+rtk git diff --check
+```
+
+Expected: v1.77 positive/mutation cases and v1.74-v1.76 historical cases pass.
+
+- [ ] **Step 8: Commit the independently testable release unit.**
+
+```bash
+rtk git add scripts/workflow_release_inventory.py scripts/verify_workflow_release.py tests/test_verify_workflow_release.py tests/release_fixture_helpers.py scripts/workflow-catalog.json tests/test_canonical_workflow_tree.py docs/workflows/contracts.md docs/workflow-fleet-rollout.md
+rtk git commit -m 'feat(release): define v1.77 Claude fallback contract'
+```
+
+- [ ] **Step 9: Verify the exact committed object.** Resolve HEAD inside Python and pass the resulting 40-hex object to the existing commit-only CLI.
+
+```bash
+rtk python3 - <<'PY'
+from pathlib import Path
+import subprocess
+import sys
+
+root = Path.cwd()
+head = subprocess.run(
+    ["/usr/bin/git", "rev-parse", "HEAD"],
+    cwd=root,
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout.strip()
+subprocess.run([
+    sys.executable,
+    "scripts/verify_workflow_release.py",
+    "--automation", str(root),
+    "--ref", "v1.77",
+    "--expected-commit", head,
+    "--commit-only",
+], cwd=root, check=True)
+PY
+```
+
+Expected: `PASS: v1.77 commit content is secure` names the exact HEAD object.
+
+### Task 7: Whole-change verification and adversarial review
+
+**Files:**
+
+- Modify only files implicated by a reproduced test or reviewer finding.
+- Add private tribunal reports under `/home/jhw/ai/opencode/projects/automation/.review/issue-182/tribunal/`; do not commit them.
+
+**Interfaces:**
+
+- Local acceptance requires focused suites, full pytest, actionlint for every release-managed workflow, Python compilation, YAML parsing, and clean diff checks.
+- Native pre-PR tribunal controls the adversarial review with exactly three independent read-only roles A, B, and C. Each reviewer response is preserved byte-for-byte in a current-user-owned, non-symlink regular file with mode 0600; type, owner, and mode are checked independently immediately before `finalize`.
+- Hosted pull-request review is required before merge. Any must-fix finding returns to the smallest owning task, followed by affected tests, full verification, and another review round.
+
+- [ ] **Step 1: Reassert ownership and snapshot preconditions.** Fetch may happen only before tribunal `begin`; require clean status and enabled native hooks/multi-agent features.
+
+```bash
+rtk python3 /home/jhw/ai/opencode/projects/automation/.review/releases/v1.76-canary-next-mxyr4iya/pr328-review-r1/assert-owner.py
+rtk git fetch origin main
+rtk git status --short
+rtk proxy codex features list
+```
+
+Expected: ownership succeeds, status is empty, and `hooks` plus `multi_agent` are enabled. Stop before tribunal state mutation on any failure.
+
+- [ ] **Step 2: Run the focused acceptance suite.**
+
+```bash
+rtk pytest -q tests/test_claude_rollout_fallback.py tests/test_claude_workflow_validation.py tests/test_review_invocation_budget.py tests/test_review_invocation_budget_action.py tests/test_review_workflow_logic.py tests/test_canonical_workflow_tree.py tests/test_rollout_workflow_fleet.py tests/test_verify_claude_rollout_fallback.py tests/test_verify_workflow_release.py tests/test_action_pins.py
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 3: Run repository-wide static and dynamic checks.**
+
+```bash
+rtk pytest -q
+rtk python3 -m compileall -q .github/actions/claude-rollout-fallback .github/actions/review-invocation-budget scripts/verify_claude_rollout_fallback.py scripts/workflow_release_inventory.py scripts/verify_workflow_release.py
+rtk proxy /home/jhw/ai/opencode/projects/automation/.review/releases/v1.74/tools/actionlint-1.7.12 .github/workflows/*.yml examples/baseline-workflows/.github/workflows/*.yml
+rtk git diff --check
+rtk git status --short
+```
+
+Expected: every command passes and the implementation worktree is clean.
+
+- [ ] **Step 4: Read the installed tribunal role contracts and begin round 1.** Read reviewer A/B/C and report schema completely, then bind the clean named branch against explicit base `origin/main`.
+
+```bash
+rtk cat /home/jhw/.codex/skills/pre-pr-tribunal/references/reviewer-a.md
+rtk cat /home/jhw/.codex/skills/pre-pr-tribunal/references/reviewer-b.md
+rtk cat /home/jhw/.codex/skills/pre-pr-tribunal/references/reviewer-c.md
+rtk cat /home/jhw/.codex/skills/pre-pr-tribunal/references/report-schema.md
+rtk proxy /usr/bin/python3 /home/jhw/.local/share/claude-config/pre_pr_tribunal/cli.py begin --base origin/main --runtime codex --round 1
+```
+
+Expected: `begin` returns one active telemetry run ID plus immutable HEAD/diff/contract bindings.
+
+- [ ] **Step 5: Generate isolated A/B/C contexts.** Preserve each command's exact JSON stdout separately and never show one projection to another role.
+
+```bash
+rtk proxy /usr/bin/python3 /home/jhw/.local/share/claude-config/pre_pr_tribunal/cli.py context --reviewer A
+rtk proxy /usr/bin/python3 /home/jhw/.local/share/claude-config/pre_pr_tribunal/cli.py context --reviewer B
+rtk proxy /usr/bin/python3 /home/jhw/.local/share/claude-config/pre_pr_tribunal/cli.py context --reviewer C
+```
+
+- [ ] **Step 6: Dispatch exactly three native read-only reviewers.** Make a mode-0700 temporary view root, add one detached clean worktree per role at the bound HEAD, require absent `.review`, then use three parallel native `collaboration.spawn_agent` calls with `fork_turns="none"`. Each self-contained prompt names its dedicated worktree, its own role reference, the report schema, bound snapshot, and only its own projection. Track every view and handle immediately; do not start a fourth role.
+
+- [ ] **Step 7: Preserve and submit each terminal response independently.** For A, B, and C, write the exact response bytes through O_EXCL/no-follow creation, chmod 0600, verify current UID/regular/non-symlink/mode/digest, submit the file bytes on stdin, compare returned `raw_sha256`, then validate the stored report.
+
+```bash
+rtk proxy /usr/bin/python3 /home/jhw/.local/share/claude-config/pre_pr_tribunal/cli.py status
+rtk proxy /usr/bin/python3 /home/jhw/.local/share/claude-config/pre_pr_tribunal/cli.py validate-report --reviewer A --source stored
+rtk proxy /usr/bin/python3 /home/jhw/.local/share/claude-config/pre_pr_tribunal/cli.py validate-report --reviewer B --source stored
+rtk proxy /usr/bin/python3 /home/jhw/.local/share/claude-config/pre_pr_tribunal/cli.py validate-report --reviewer C --source stored
+```
+
+Use the installed skill's telemetry spans around dispatch, storage, validation, cleanup, and every terminal exit. A format rejection gets a format-only retry for the same role; a supported terminal failure gets at most three controller-local attempts for that role. Never repair or reserialize reviewer bytes.
+
+- [ ] **Step 8: Enforce the local 0600 check immediately before finalization.** Require exactly the three controller-private response paths and compare their bytes to the sealed receipt digests.
+
+```bash
+rtk python3 - <<'PY'
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import stat
+
+root = Path("/home/jhw/ai/opencode/projects/automation/.review/issue-182/tribunal")
+for role in ("A", "B", "C"):
+    response = root / f"reviewer-{role}.report"
+    receipt = json.loads((root / f"reviewer-{role}.receipt.json").read_text())
+    observed = response.lstat()
+    assert stat.S_ISREG(observed.st_mode)
+    assert not response.is_symlink()
+    assert observed.st_uid == os.getuid()
+    assert stat.S_IMODE(observed.st_mode) == 0o600
+    assert sha256(response.read_bytes()).hexdigest() == receipt["raw_sha256"]
+PY
+```
+
+Stop before `finalize` if this command or any immediately repeated stored-report validation fails.
+
+- [ ] **Step 9: Finalize only an all-sealed round.** Re-run the three stored validations, compare them with sealed receipts and the bound snapshot, then invoke the pathless finalizer.
+
+```bash
+rtk proxy /usr/bin/python3 /home/jhw/.local/share/claude-config/pre_pr_tribunal/cli.py finalize
+```
+
+Close the telemetry run on every exit. A PASS records bound HEAD/diff. CRITICAL/HIGH findings require one decision each, test-first fixes or evidence-backed rebuttals, one `review-fix round N` commit, and a complete next A/B/C round; round 3 is the hard stop.
+
+- [ ] **Step 10: Open the hosted review only after tribunal PASS.** Use the repository's `jhw-pr` reviewed-merge workflow against base `main`, bind it to the tribunal HEAD, request hosted reviewers, and wait for required checks. Do not enable merge before a clean hosted verdict and live exact-head/base validation.
+
+- [ ] **Step 11: Merge and verify the remote result.** Merge only the reviewed HEAD through the supported method, then compare the API-returned merge commit and the new remote `main` object with the expected GitHub-generated commit. Any drift stops before release publication.
+
+### Task 8: Immutable release, real-boundary canary, and bootstrap batch
+
+**Files:**
+
+- Create after the v1.77 bootstrap merge: `docs/workflows/v1.77.1-boundary-canary.md`
+- Write evidence only beneath a new `/home/jhw/ai/opencode/projects/automation/.review/releases/v1.77-*` directory; do not commit generated evidence.
+- Reuse the current v1.76 batch evidence at `/home/jhw/ai/opencode/projects/automation/.review/releases/v1.76-canary-next-mxyr4iya/full-profile-batch-nOaszzvB` without rewriting its source records.
+
+**Interfaces:**
+
+- Publish v1.77 only from the exact reviewed merge commit with an annotated immutable tag and the repository's existing release verification flow.
+- The first consumer adoption is a bootstrap because its default branch lacks the route. After that merge, publish a separately reviewed v1.77.1 validation release from a distinct automation commit with identical release-owned v1.77 bytes. The exact v1.77-to-v1.77.1 pin change on the same canary must exercise automatic mismatch, structured request, nested fallback, one provider call, finalized budget, canonical result, and verifier receipt.
+- On that canary, `driver_commit` is the installed v1.77 commit and target `release_commit` is the distinct v1.77.1 commit. Equality is an attestation failure because it would not test the caller-changing boundary.
+- Current gstApp #109 and max9296 #74 stay separate from the durable route. Their existing default-branch Claude reviews are accepted only through the already hashed bootstrap proposal after live exact-head/base revalidation and a concrete authorization record.
+
+- [ ] **Step 1: Seal the reviewed v1.77 merge candidate.** From a clean checkout whose `origin/main` is the hosted-review merge returned by Task 7, create a mode-0700 evidence directory whose suffix is the first 12 hexadecimal characters of that merge, under `/home/jhw/ai/opencode/projects/automation/.review/releases/`. Record the exact merge SHA, commit tree, `release_paths_for("v1.77")`, focused/full test logs, actionlint log, and SHA-256 for every recorded file. Run the commit-only verifier against the resolved 40-hex object:
+
+```bash
+release_commit="$(rtk git rev-parse origin/main)"
+rtk python3 scripts/verify_workflow_release.py --automation . --ref v1.77 --expected-commit "$release_commit" --commit-only
+```
+
+Expected: `PASS: v1.77 commit content is secure` names `release_commit`; the evidence writer independently chmods every regular record to 0600 and rejects an existing path or symlink.
+
+- [ ] **Step 2: Present the concrete v1.77 publication boundary.** Show the user the reviewed merge SHA, tree SHA, release verifier result, release-root digest manifest, and proof that local and remote `refs/tags/v1.77` are absent. Obtain explicit approval for creation of that one immutable tag. Stop without creating a local tag when approval is absent or does not bind the displayed commit.
+
+- [ ] **Step 3: Publish and remotely verify v1.77.** Use the exact release procedure written in Task 6: create one annotated `v1.77` tag on the approved commit, create the remote tag ref once, then run the tag and remote verifier. The final verification command resolves the commit before invocation:
+
+```bash
+release_commit="$(rtk git rev-parse origin/main)"
+rtk python3 scripts/verify_workflow_release.py --automation . --ref v1.77 --expected-commit "$release_commit" --remote origin
+```
+
+Expected: the local tag object and the public remote tag object are annotated, agree, and peel to the approved commit. A partially created or conflicting tag stops rollout; never move, delete, or recreate it.
+
+- [ ] **Step 4: Render the read-only v1.77 bootstrap canary for wlan-package.** Reuse `wlan-package`, whose v1.76 automatic runtime canary already completed, and initialize a new private rollout workspace. Pass the released ref and an explicit manifest path:
+
+```bash
+canary_workspace="$(rtk mktemp -d /tmp/automation-v177-wlan-package.XXXXXX)"
+rtk python3 scripts/rollout_workflow_fleet.py --automation . --workspace "$canary_workspace" --initialize-workspace --mode plan --ref v1.77 --repo wlan-package --manifest "$canary_workspace/rollout-plan.json" --actionlint /home/jhw/ai/opencode/projects/automation/.review/releases/v1.74/tools/actionlint-1.7.12
+```
+
+Expected: one `planned` or exact `reusable` default-branch target, no remote mutation, and rendered callers pinned to the peeled v1.77 commit. Copy the manifest and its digest into the v1.77 evidence directory.
+
+- [ ] **Step 5: Obtain approval for the exact bootstrap PR publication.** Present repository `jhw7500/wlan-package`, observed base SHA, deterministic branch, expected commit/tree, changed paths, full diff digest, and the existing `review:request` label that will trigger review after publication. Obtain explicit user approval for that one branch/PR creation and label application. This approval does not authorize a merge or a later v1.77.1 publication.
+
+- [ ] **Step 6: Publish or reuse the exact v1.77 bootstrap PR.** In the same marked workspace, let the released fleet publisher refetch and recompute before its single remote write:
+
+```bash
+rtk python3 scripts/rollout_workflow_fleet.py --automation . --workspace "$canary_workspace" --mode publish --ref v1.77 --repo wlan-package --confirm --manifest "$canary_workspace/rollout-publish.json" --actionlint /home/jhw/ai/opencode/projects/automation/.review/releases/v1.74/tools/actionlint-1.7.12
+```
+
+Expected: exactly one `published` or `reused` PR whose live head, base, title, body, branch and managed tree match the manifest. Stop on `current`, `blocked`, an unexpected prior branch/PR, or any second candidate.
+
+- [ ] **Step 7: Trigger review and capture the expected bootstrap failure without retrying it.** Apply the already-existing `review:request` label once, then fetch the resulting automatic Claude run, its exact attempt, jobs, check-run annotations, budget comment, and canonical sticky comment. Require `workflow_validation_mismatch`, `review_execution=not_performed`, a skipped provider step, and no new Claude budget invocation. Preserve the raw responses as private evidence; another reason, provider entry, or ambiguous run stops the bootstrap.
+
+- [ ] **Step 8: Complete the v1.77 bootstrap reviews.** Run the consumer repository's exact three-role tribunal, required tests, Gemini/OpenCode/Codex gates, and a separately requested default-branch manual Claude read-only review bound to the same HEAD/base/full diff. Record all exact-byte responses and current checks. A reviewer rerun must bind the same current HEAD; a new commit starts a new review round.
+
+- [ ] **Step 9: Present the v1.77 bootstrap merge tuple.** Re-read the pull request, head repository, head SHA, base SHA, mergeability, required checks and every reviewer state. Present those concrete values plus the manual-Claude substitution evidence to the user and obtain explicit authorization for this one merge.
+
+- [ ] **Step 10: Merge and confirm the v1.77 bootstrap once.** Invoke the consumer repository's supported reviewed-merge helper with the approved HEAD/base and reviewer map. Re-read the pull request and default branch until GitHub reports the returned merge commit. If the response is uncertain, reconcile read-only and do not invoke merge again.
+
+- [ ] **Step 11: Create the distinct v1.77.1 validation commit.** From the new public automation `main`, create only `docs/workflows/v1.77.1-boundary-canary.md` with this complete content, then commit it on a dedicated branch:
+
+```text
+# v1.77.1 Boundary Canary
+
+This validation release intentionally preserves every v1.77 release-owned byte.
+Its distinct commit exists only to exercise a real immutable caller-pin change from
+v1.77 to v1.77.1 after the default branch has installed the fallback router.
+```
+
+Use `apply_patch`, run `rtk git diff --check`, and commit with `docs(release): define v1.77.1 boundary canary`. Run focused/full tests, the exact A/B/C tribunal procedure from Task 7, hosted review, and reviewed merge before treating the resulting main commit as a release candidate.
+
+- [ ] **Step 12: Prove v1.77.1 changes no release-owned byte.** Resolve the v1.77 peeled commit and the reviewed v1.77.1 candidate, derive the owned paths from the inventory, and require an empty raw Git diff before commit-only verification:
+
+```bash
+rtk python3 - <<'PY'
+from pathlib import Path
+import subprocess
+import sys
+
+from scripts.workflow_release_inventory import release_paths_for
+
+root = Path.cwd()
+old = subprocess.run(
+    ["/usr/bin/git", "rev-parse", "refs/tags/v1.77^{}"],
+    cwd=root, check=True, capture_output=True, text=True,
+).stdout.strip()
+new = subprocess.run(
+    ["/usr/bin/git", "rev-parse", "origin/main"],
+    cwd=root, check=True, capture_output=True, text=True,
+).stdout.strip()
+subprocess.run(
+    ["/usr/bin/git", "diff", "--exit-code", old, new, "--", *release_paths_for("v1.77")],
+    cwd=root, check=True,
+)
+subprocess.run([
+    sys.executable, "scripts/verify_workflow_release.py",
+    "--automation", str(root), "--ref", "v1.77.1",
+    "--expected-commit", new, "--commit-only",
+], cwd=root, check=True)
+PY
+```
+
+Expected: the owned-path diff is empty and v1.77.1 commit content passes. Any release-owned change requires a normal patch release design and invalidates this boundary canary.
+
+- [ ] **Step 13: Present the concrete v1.77.1 publication boundary.** Show the distinct reviewed commit, tree, empty release-owned diff, commit-only verifier output, digest manifest, and proof that local and remote `refs/tags/v1.77.1` are absent. Obtain explicit approval for creation of that immutable tag.
+
+- [ ] **Step 14: Publish and verify v1.77.1.** Create the annotated tag once and verify it remotely:
+
+```bash
+validation_commit="$(rtk git rev-parse origin/main)"
+rtk python3 scripts/verify_workflow_release.py --automation . --ref v1.77.1 --expected-commit "$validation_commit" --remote origin
+```
+
+Expected: v1.77 and v1.77.1 remain two immutable annotated tags that peel to two different commits while their v1.77 release-owned paths are byte-identical.
+
+- [ ] **Step 15: Render the real pin-change canary without mutation.** Use a second new workspace and the same `wlan-package` repository. Require the default branch to pin the v1.77 driver commit and the rendered rollout head to pin the distinct v1.77.1 target commit.
+
+```bash
+boundary_workspace="$(rtk mktemp -d /tmp/automation-v1771-wlan-package.XXXXXX)"
+rtk python3 scripts/rollout_workflow_fleet.py --automation . --workspace "$boundary_workspace" --initialize-workspace --mode plan --ref v1.77.1 --repo wlan-package --manifest "$boundary_workspace/rollout-plan.json" --actionlint /home/jhw/ai/opencode/projects/automation/.review/releases/v1.74/tools/actionlint-1.7.12
+```
+
+- [ ] **Step 16: Present the real pin-change publication boundary.** Show the fresh plan's repository, observed base, deterministic branch, expected head/tree, changed paths, target release, full diff digest, and the existing `review:request` label that will trigger review. Obtain explicit approval for this one branch/PR creation and label application.
+
+- [ ] **Step 17: Publish the real pin-change canary.** Reuse the Step 15 workspace and let the released publisher refetch and recompute before mutation:
+
+```bash
+rtk python3 scripts/rollout_workflow_fleet.py --automation . --workspace "$boundary_workspace" --mode publish --ref v1.77.1 --repo wlan-package --confirm --manifest "$boundary_workspace/rollout-publish.json" --actionlint /home/jhw/ai/opencode/projects/automation/.review/releases/v1.74/tools/actionlint-1.7.12
+```
+
+Expected: one exact `published` or `reused` PR and no other remote change.
+
+- [ ] **Step 18: Trigger review and capture the real-boundary automatic failure.** Apply the already-existing `review:request` label once, then preserve the automatic run, attempt, jobs, annotations, budget comment and canonical comment. Require `workflow_validation_mismatch`, `review_execution=not_performed`, skipped provider, and no budget invocation at the exact published HEAD/base. Stop on ambiguity or any other result.
+
+- [ ] **Step 19: Build one canonical request record.** Generate a fresh 16-byte nonce with `secrets.token_hex(16)`, construct `FallbackRequest` from the Step 18 run/attempt plus the published repository/PR/HEAD/base/v1.77.1 release/full-diff coordinates, and render it with v1.77's `canonical_request_body`. Write the exact body and coordinates with O_EXCL/no-follow creation, chmod 0600, and immediately lstat current owner/type/mode. If one exact live request already exists, record its comment ID and reuse it instead of generating a second request.
+
+- [ ] **Step 20: Authorize the exact request comment.** Present the complete two-line body and all bound coordinates to the user. Obtain explicit authorization to post that exact GitHub issue comment; an approval for the PR or release tag does not authorize this message.
+
+- [ ] **Step 21: Post or reuse the request exactly once.** Immediately re-read HEAD/base and the failed run before the write. Post the authorized body once through the fixed GitHub REST endpoint, or reuse the single exact existing request. Save the returned comment object byte-for-byte and never retry an uncertain write until a read proves that no matching comment exists.
+
+- [ ] **Step 22: Prove the managed fallback ran exactly once.** Wait for one default-branch `claude.yml` issue-comment run. Require classifier route `managed`, nested `claude-code-review.yml` identity at the installed v1.77 driver commit, one provider entry, one finalized automatic budget round, and one schema-3 fallback state whose route binds the request comment, failed run, base, v1.77.1 target commit and full-diff hash. A second request/run/provider call, partial route, changed coordinate, or required failed automatic check stops before merge.
+
+- [ ] **Step 23: Generate and validate the immutable fallback receipt.** Create a clean detached checkout at the v1.77 driver commit, keep the output outside that checkout, derive PR/head/base from the single authoritative publish manifest, and invoke the verifier:
+
+```bash
+driver_commit="$(rtk git rev-parse 'refs/tags/v1.77^{}')"
+driver_checkout="/tmp/automation-v177-driver-$driver_commit"
+boundary_evidence="$(rtk mktemp -d /home/jhw/ai/opencode/projects/automation/.review/releases/v1.77.1-wlan-package.XXXXXX)"
+rtk git worktree add --detach "$driver_checkout" "$driver_commit"
+boundary_pr="$(rtk python3 -c 'import json,sys; value=json.load(open(sys.argv[1])); assert len(value)==1; print(value[0]["pr_url"].rsplit("/",1)[1])' "$boundary_workspace/rollout-publish.json")"
+boundary_head="$(rtk python3 -c 'import json,sys; value=json.load(open(sys.argv[1])); assert len(value)==1; print(value[0]["head_sha"])' "$boundary_workspace/rollout-publish.json")"
+boundary_base="$(rtk python3 -c 'import json,sys; value=json.load(open(sys.argv[1])); assert len(value)==1; print(value[0]["base_sha"])' "$boundary_workspace/rollout-publish.json")"
+rtk python3 -I -S -B "$driver_checkout/scripts/verify_claude_rollout_fallback.py" --automation-root "$driver_checkout" --release-ref v1.77.1 --remote origin --repository jhw7500/wlan-package --pr "$boundary_pr" --expected-head "$boundary_head" --expected-base "$boundary_base" --output "$boundary_evidence/fallback-receipt.json"
+```
+
+Immediately lstat the receipt and require current UID, regular/non-symlink type, mode 0600, schema 1, `effective_status=CLEAN`, `fallback.driver_commit` equal to the v1.77 peeled commit, and `release_commit` equal to the distinct v1.77.1 peeled commit. Independently re-read the live pull request, checks, budget, comment, and runs after receipt creation; any drift invalidates the receipt.
+
+- [ ] **Step 24: Complete the real-boundary reviews.** Run the remaining independent reviewers and target checks on the receipt-bound HEAD. Require native policy to show that the failed automatic Claude check is not a required blocker and require the fallback canonical state to contain no blocking finding.
+
+- [ ] **Step 25: Present the real-boundary merge tuple.** Re-read the receipt, exact head/base/origin, mergeability, required checks and all review states. Present the concrete merge tuple and obtain explicit authorization for this one merge.
+
+- [ ] **Step 26: Merge and audit the real-boundary canary.** Use the supported reviewed-merge helper once, verify the GitHub-generated merge commit, and run the released fleet audit at `v1.77.1` for `wlan-package`. Remove the detached verifier worktree with a non-force removal only after its clean status is proven.
+
+- [ ] **Step 27: Revalidate the existing two-PR v1.76 proposal without altering evidence.** Require SHA-256 `916c58c9a9062d74a0740d8fb51a184fe979dd37c2872c328f21bb6e12c5170d` for `/home/jhw/ai/opencode/projects/automation/.review/releases/v1.76-canary-next-mxyr4iya/full-profile-batch-nOaszzvB/merge-substitution-proposal.json`. Freshly require gstApp #109 head `52dbdedbc090dcdb50bdc93172985a67bc5df683` / base `6d8200e4562da0b7aff01db7b86cb565390eb56d` and max9296 #74 head `00db418bd1520ab36d866961b70179d53a01453e` / base `621f6605e1ec16251a1d086e8f3fc4e4ce36f212`. Re-run the existing read-only policy/evidence preflights; stop if either tuple, reviewer state, required check, mergeability, origin, release tag or proposal digest differs.
+
+- [ ] **Step 28: Bind the exact two-PR approval.** Present the unchanged proposal hash and both exact tuples. If the user's explicit approval binds them, create `manual-substitution-authorization.json` once with O_EXCL/no-follow mode 0600, the exact user response, `authorized_by_user=true`, the proposal SHA-256, and scope `v176_full_profile_two_pr_manual_claude_substitution`. Immediately lstat and verify current owner/type/mode, then run the existing `verify-approval.py`.
+
+- [ ] **Step 29: Merge gstApp and max9296 sequentially.** Run the existing `merge-one-approved.sh` for gstApp, require its private merge receipt and API-confirmed GitHub merge commit, then do the same for max9296. An uncertain or partial result is read-only reconciliation, never a repeated merge.
+
+- [ ] **Step 30: Close the operational handoff.** Record v1.77/v1.77.1 tag objects and peeled commits, the bootstrap and boundary PR/run/comment/receipt coordinates, provider call count, fleet audits, the two v1.76 merge receipts, remaining blockers, and untouched evidence digests in the existing Task handoff. Release Claim `clm-01a08b35-4a07-75ba-8a22-a8ca96029ade` only through the supported Task completion path after every requested rollout result is verified; do not edit the Registry directly.
+
+## Final Verification Matrix
+
+| Failure or race | Expected result |
+| --- | --- |
+| Automatic mismatch, provider skipped, exact rollout | One admitted fallback path |
+| Automatic mismatch after provider entry | Blocking; no fallback |
+| Validation unavailable or another failure reason | Blocking; no fallback |
+| Stale HEAD/base/release/diff at any read | Blocking; new tuple required |
+| Repeated identical request | Reuse; zero extra provider calls |
+| Claimed but unfinalized fallback | Existing bounded failure policy; no interactive replacement |
+| Two requests, runs, states, ledgers, or rollout pull requests | Ambiguous and blocking |
+| Fallback CLEAN with blocking canonical finding | Blocking at configured threshold |
+| Automatic Claude check required and failed | Native required-check failure remains blocking |
+| Valid receipt and all independent gates clean | Later JHW gate may map effective Claude status to CLEAN |
+
+The automation implementation is complete only when Tasks 1-7 are merged after review. Operational rollout is complete only when Task 8 proves the v1.77-to-v1.77.1 pin-change boundary with one provider call and no required-check bypass. JHW command consumption is outside this plan and starts only after its separate Task decision.

--- a/docs/superpowers/specs/2026-09-11-claude-caller-rollout-fallback-design.md
+++ b/docs/superpowers/specs/2026-09-11-claude-caller-rollout-fallback-design.md
@@ -1,0 +1,395 @@
+# #182 Claude caller self-update review fallback - design for review
+
+Status: design approved by the user's `go` on 2026-09-11.
+Date: 2026-09-11. Source tree: 444a7347aee169ed178aae80e8bd8d10eca52e02.
+Issue: https://github.com/jhw7500/automation/issues/182
+
+This is an advisory design record. Task and Claim ownership continue to come only
+from the supported Project Control lifecycle. The active #182 Claim remains the
+authority for the current canary and rollout work.
+
+## Result to deliver
+
+Give exact managed workflow rollout PRs one authenticated Claude review route when
+their automatic `claude-code-review.yml` caller is intentionally different from the
+default branch. Keep the caller identity check intact, invoke Claude exactly once
+through a workflow that exists on the default branch, publish the ordinary canonical
+Claude review for the exact PR HEAD/base, and let the JHW merge gate accept that
+result only after it authenticates both the failed automatic attempt and the fallback
+attempt.
+
+Ordinary caller mismatch, unavailable validation, arbitrary workflow edits, stale
+HEAD/base, ambiguous runs, malformed responses and provider failures remain blocking.
+The fallback is a review route, not a general exception to required CI, branch
+protection, target tests, mergeability or atomic head/base verification.
+
+## Why this is recurring
+
+The Claude reusable workflow predicts the Anthropic action's caller validation before
+budget admission. It obtains `github.workflow_ref` and `github.workflow_sha`, reads
+that caller at the running workflow SHA, reads the same path at the repository's
+current default-branch SHA, and reports `workflow_validation_mismatch` when the blobs
+differ. The upstream action applies the same default-branch identity rule, so removing
+only the local prediction would delay the same refusal until the provider step.
+
+A fleet release changes the immutable automation commit in the consumer
+`.github/workflows/claude-code-review.yml`. The rollout PR therefore differs from its
+default branch by construction. This happens once per adopting branch on every
+release that changes the pin, rather than once for v1.76 as a whole. Normal feature
+PRs work after the rollout is merged because their default-branch caller and running
+caller are then identical, but the next pin rollout recreates the boundary.
+
+The v1.76 full-profile evidence reproduced the same outcome independently:
+
+| Repository / PR | Automatic Claude | Provider performed | Default-branch Claude |
+| --- | --- | --- | --- |
+| jhw7500/gstApp #109 | run 34549275027, mismatch | no | run 34549532475, CLEAN |
+| jhw7500/max9296 #74 | run 34549486780, mismatch | no | run 34549560339, CLEAN |
+
+Both fallback runs used the existing `issue_comment` caller from the default branch,
+reviewed the exact requested HEAD/base, made no repository change and reported no
+actionable finding. These runs prove feasibility. Their free-form responses and lack
+of managed invocation metrics are bootstrap evidence only; they are not the durable
+machine contract proposed below.
+
+## Approaches considered
+
+| Approach | Decision | Reason |
+| --- | --- | --- |
+| Default-branch request that nests the existing canonical reviewer | Recommended | Preserves caller validation and reuses diff, budget, canonicalization and publication contracts |
+| Two alternating automatic caller files | Reject | Permanently doubles callers and required-check ambiguity while still needing a bootstrap rollout |
+| Per-PR free-form `@claude review` substitution | Bootstrap only | Works today but requires bespoke parsing, has no managed meter and repeats operator judgment |
+| Relax or remove caller validation | Reject | The upstream action still refuses the changed caller and the security boundary is weakened |
+
+## Trust boundaries and non-goals
+
+The security authority is a GitHub-authenticated request comment plus fresh server
+state, not text found in the PR body, diff, a local transcript or a locally saved
+response. The request must be created by an OWNER, MEMBER or COLLABORATOR and must
+match one exact grammar. The target PR must be open, same-repository and at the exact
+40-character HEAD and base recorded in the request.
+
+The workflow route itself is safe for an authenticated collaborator to request on a
+same-repository PR because it reads and reviews a fixed diff without executing code
+from the PR. The JHW merge substitution is narrower: it additionally requires the
+remote PR to be an exact `rollout_workflow_fleet.py` result for an immutable automation
+release. A fallback review on another PR does not become a rollout substitution.
+
+This design does not:
+
+- allow forks, contributor-authored commands or PR-controlled workflow code to gain
+  a token or secret;
+- execute a script, action, hook or binary from the PR checkout;
+- accept a Claude App comment without a corresponding authenticated workflow run;
+- refund a failed review, bypass the invocation budget or add a second reviewer
+  identity;
+- turn `workflow_validation_unavailable` or another infrastructure failure into an
+  eligible fallback;
+- make a failed required status check successful. A repository that requires the
+  failed automatic Claude check remains blocked until a separately reviewed
+  head-bound status design exists or its native policy changes explicitly.
+
+## Request contract
+
+The JHW rollout-review driver posts one command-owned issue comment after it has
+observed the exact automatic failure. The visible line identifies the operation; one
+hidden canonical JSON marker carries the machine fields:
+
+```text
+@claude managed rollout review for PR <number>
+<!-- automation:claude-rollout-review-request:v1 {canonical JSON} -->
+```
+
+The schema contains exactly:
+
+- repository and PR number;
+- expected PR HEAD and base SHA;
+- original automatic run ID and run attempt;
+- immutable automation release commit and managed full-diff SHA-256;
+- a random request nonce with at least 128 bits of entropy.
+
+The driver creates the comment from a 0600 non-symlink request file, reads the created
+comment back, and records its GitHub ID, author and creation time. The nonce is unique
+per repository/PR/HEAD/base. Before posting, the driver searches the bounded comment
+horizon for that exact tuple. An existing valid request is reused; a conflicting or
+ambiguous marker stops without posting.
+
+No request field is trusted by itself. The workflow admission job parses the marker
+with an exact schema, fetches the comment and PR from GitHub, and confirms:
+
+1. the event is `issue_comment.created` for that exact comment ID;
+2. the comment author association is OWNER, MEMBER or COLLABORATOR;
+3. the issue is an open same-repository pull request at the requested HEAD/base;
+4. the named automatic run is a current-HEAD `Claude Code Review` run and is the
+   unique selected run for its number/attempt;
+5. its canonical failure state says `workflow_validation_mismatch` and
+   `review_execution=not_performed`;
+6. the provider job evidence agrees that the Claude provider step was skipped; and
+7. no successful fallback already exists for the same review tuple.
+
+Any pagination overflow, missing field, API failure, duplicate candidate or mismatch
+fails before a provider credential is available.
+
+## Workflow architecture
+
+The existing consumer `.github/workflows/claude.yml` remains the top-level
+`issue_comment` caller. GitHub only triggers this event when the workflow file exists
+on the default branch. Once a repository has adopted the new caller, a later rollout
+may change the PR copy while the previous default-branch copy remains the trusted
+entrypoint.
+
+The central `.github/workflows/claude.yml` adds three mutually exclusive paths:
+
+1. A permission-minimal classifier handles the exact managed rollout request grammar
+   and produces only validated scalar outputs.
+2. The existing interactive Claude job handles ordinary authenticated `@claude`
+   comments and explicitly excludes managed rollout markers.
+3. The managed rollout job calls
+   `$/.github/workflows/claude-code-review.yml` from the same immutable automation
+   commit, passing the exact PR and fallback evidence inputs.
+
+GitHub documents that a called reusable workflow keeps the caller's `github` context.
+The nested review therefore sees the consumer default-branch `claude.yml` as its
+caller, so the existing caller comparison succeeds without an exception. The `$/`
+reference resolves within the automation repository at the running reusable
+workflow's exact commit; it does not select code from the consumer checkout.
+
+The consumer caller grants `pull-requests: write` as the permission ceiling required
+for the canonical sticky comment. The central interactive job continues to reduce
+its own permissions to read-only. Only the admitted managed rollout job retains the
+write permission used by the existing canonical publication path. Both jobs keep
+`contents: read`, `actions: read`, `issues: read` and `id-token: write` at the minimum
+already required by their provider paths.
+
+The nested review receives new optional, all-or-none fallback inputs:
+
+- fallback request comment ID and nonce;
+- expected HEAD and base;
+- original automatic run ID and attempt; and
+- immutable release commit and managed diff SHA-256.
+
+Supplying some but not all inputs is an input error. Normal PR and workflow-dispatch
+callers supply none and retain their current behavior. Fallback admission revalidates
+the live PR coordinates immediately before diff preparation and again before
+publication. The existing prepare-review-diff action remains the authority for the
+actual numbered diff, merge base and full-diff hash.
+
+## Budget and canonical result
+
+The failed automatic run stops before budget claim, so it contributes zero provider
+calls. The default-branch fallback claims the ordinary Claude reviewer budget for the
+same repository, PR and HEAD. The budget action gains a typed
+`default_branch_rollout_fallback` route whose provenance includes the request comment
+and original failed run, while its duplicate-head, request ceiling, elapsed-time and
+finalization rules stay unchanged.
+
+The route performs at most one provider call sequence allowed by the existing Claude
+budget. A repeated command observes the existing request or the existing finalized
+HEAD and performs no additional provider call. A claimed-but-unfinalized fallback is
+handled by the existing bounded failure policy; it is never replaced by an unmetered
+interactive response.
+
+The ordinary Claude canonicalizer and sticky-comment publisher remain the only
+authority for findings. Schema 3 adds an optional authenticated route block:
+
+```text
+route = default_branch_rollout_fallback
+request_comment_id = <id>
+original_failed_run_id = <id>
+reviewed_base_sha = <40 hex>
+release_commit = <40 hex>
+managed_diff_sha256 = <64 hex>
+```
+
+For normal reviews the block is absent. The fallback success state still includes the
+ordinary reviewed HEAD, full-diff hash, run ID/attempt, canonical counts, provider
+execution and finalized budget evidence. Display fields must agree with the hidden
+state, and active findings keep the existing severity and section grammar.
+
+The original failed run remains failed and discoverable. The fallback does not edit
+its check, rewrite its logs or describe it as successful.
+
+## Fleet attestation and JHW merge policy
+
+One pure verifier in the automation repository owns the substitution rules. It takes
+repository, PR, expected HEAD/base and immutable release coordinates, obtains fresh
+GitHub evidence, and returns a machine-readable receipt. It reuses the fleet renderer
+and PR attestation logic rather than trusting branch names, PR titles or local
+manifests.
+
+The verifier requires:
+
+- the remote commit tree and diff exactly match the selected release rendering for
+  the selected base branch;
+- every changed path is managed by the release catalog and the caller pin points to
+  the exact immutable release commit;
+- the automatic Claude failure, request comment, fallback run, canonical comment,
+  budget receipt and live PR coordinates form one unambiguous chain;
+- Gemini, OpenCode, Codex, required CI and any requested target result remain governed
+  by their existing independent gates; and
+- the fallback canonical review has no active finding at or above the configured
+  blocking threshold.
+
+The receipt records both Claude outcomes:
+
+```text
+automatic = FAILED(workflow_validation_mismatch, not_performed)
+fallback  = CLEAN(default_branch_rollout_fallback, performed, finalized)
+effective Claude reviewer status = CLEAN
+```
+
+The source JHW PR command in `jhw-notion-runtime/skills/claude/pr.md` invokes that
+verifier only for this exact failure reason and exact rollout class. It does not
+duplicate the trust logic. A valid receipt maps the single planned Claude reviewer to
+`CLEAN` and reports the original failure plus fallback route in the merge receipt.
+Invalid or unavailable evidence leaves Claude `FAILED`; no App result, tribunal result
+or user prose is silently substituted.
+
+Immediately before merge, the existing JHW helper still rechecks the PR HEAD, base
+OID, required checks, mergeability, merge method, origin identity and exact
+GitHub-generated merge commit. Native required checks are not filtered or waived.
+
+## Bootstrap and rollout order
+
+Repositories whose default branch still points to v1.76 or earlier do not yet have
+the structured route. Their first adoption cannot use code that exists only in the PR
+copy. The already completed gstApp #109 and max9296 #74 free-form reviews are therefore
+a one-time bootstrap exception, covered by the user's approval of this design and the
+existing hashed exact-evidence proposal. Any additional pre-route repository uses the
+same separately evidenced default-branch review procedure; responses are grouped into
+bounded batch proposals rather than treated as the durable verifier output.
+
+The durable rollout order is:
+
+```text
+implement and review fallback release
+                  |
+                  v
+bootstrap one canary consumer with existing default-branch review
+                  |
+                  v
+open a later exact pin-update PR on that canary
+                  |
+                  v
+observe automatic refusal -> structured fallback -> canonical CLEAN
+                  |
+                  v
+verify JHW gate and zero duplicate provider calls
+                  |
+                  v
+resume fleet rollout; each repository gains the route after its bootstrap merge
+```
+
+The canary must prove the route on a real caller-changing PR; a normal feature PR does
+not exercise the failure boundary. Fleet expansion stops if the nested workflow sees
+the PR caller instead of the default-branch caller, permissions cannot reach the
+canonical publisher, the budget creates a second invocation, the JHW verifier cannot
+bind the base, or native required checks remain unsatisfied.
+
+## Failure, race and retry behavior
+
+- HEAD or base changes at any admission, review, publication, receipt or merge check:
+  stop and require a new tuple.
+- The automatic run performed any provider call: do not request fallback; report a
+  normal Claude failure.
+- Missing or conflicting request marker, run, job, state, budget or release evidence:
+  fail closed without inference.
+- Two eligible fallback runs or two canonical comments for one tuple: ambiguous and
+  blocking until resolved through the normal reviewed cleanup path.
+- Provider or canonicalization failure in fallback: keep it failed and consume budget
+  according to the ordinary rules; do not use the free-form interactive job.
+- Comment publication response loss: discover by exact nonce, author, tuple and
+  creation horizon; never post blindly a second request.
+- Workflow dispatch or API timeout: poll bounded server state, retain the request and
+  return a retryable diagnostic without changing the PR.
+- Existing successful finalized fallback: reuse only when every immutable coordinate
+  and response byte still agrees.
+
+No raw Registry edit, takeover, stale Claim deletion, secret mutation or budget-ledger
+repair is part of this design.
+
+## Implementation boundaries
+
+Automation repository:
+
+- `.github/workflows/claude.yml`: classifier, interactive exclusion and nested route;
+- `.github/workflows/claude-code-review.yml`: typed fallback inputs, admission,
+  provenance and state publication;
+- `.github/actions/review-invocation-budget`: typed fallback caller provenance using
+  the existing Claude ledger;
+- focused admission/attestation helper or composite action;
+- fleet fallback verifier and exact receipt schema;
+- baseline callers, workflow catalog, release verifier, contracts and runbook; and
+- tests and mutation checks for every new trust branch.
+
+JHW command source repository:
+
+- `skills/claude/pr.md`: detect only the eligible automatic outcome, request/poll one
+  fallback, invoke the automation verifier and render the effective receipt; and
+- its command tests: forged, stale, ambiguous, duplicate and valid fallback evidence.
+
+The JHW repository remains a separate Project Control decision. Before its first
+substantive edit, run its stateless Task nudge and follow the returned registered-task
+policy. The current automation Claim does not imply a second repository Task.
+
+## Verification and canary gates
+
+Implementation tests must cover:
+
+- exact request grammar, author association and same-repository PR checks;
+- malformed/partial fields, forks, stale HEAD/base, wrong run/attempt and pagination
+  overflow;
+- automatic mismatch with provider skipped versus every ineligible failure shape;
+- interactive and managed routes are mutually exclusive and never double-call;
+- nested caller identity, `$/` resolution and permissions cannot elevate beyond the
+  consumer ceiling;
+- ordinary reviews and old callers remain backward compatible;
+- one shared Claude budget invocation, duplicate request reuse and finalized receipt;
+- canonical state/display agreement, active finding thresholds and route provenance;
+- exact fleet rendering and immutable release attestation;
+- JHW selection of fallback evidence without accepting another App or a free-form
+  bot comment; and
+- required CI, target, current-head/base and atomic merge gates remain unchanged.
+
+Run the focused workflow, budget, canonicalization, rollout and release-verifier
+suites; actionlint all release-managed workflows; then run the full repository suite.
+The JHW source repository runs its own focused and full command tests independently.
+
+The canary evidence must include exact request/comment bytes, run/job JSON, canonical
+state, budget ledger/metrics, PR/head/base/diff/release attestation, check runs and
+provider call count. Native pre-PR tribunal and hosted reviewers review the
+implementation before merge. Immutable release publication and consumer rollout
+remain separate reviewed actions.
+
+## Current stop boundary
+
+This design approval permits the design document and subsequent implementation plan.
+It does not by itself publish a new immutable release or mutate another repository's
+Project Control state. The current gstApp and max9296 PRs remain open until their
+existing merge proposal is revalidated at exact current HEAD/base and the approved
+bootstrap substitution is recorded.
+
+After written-spec review, create the implementation plan in the existing #182
+worktree. Preserve the active Claim; do not recreate it. Implement the automation
+side first, then obtain any separately required JHW repository Task authorization
+before changing its command source.
+
+## Sources
+
+Local code:
+
+- `.github/workflows/claude-code-review.yml`
+- `.github/workflows/claude.yml`
+- `.github/actions/prepare-review-diff/action.yml`
+- `.github/actions/canonicalize-review/action.yml`
+- `.github/actions/review-invocation-budget/`
+- `scripts/rollout_workflow_fleet.py`
+- `scripts/verify_workflow_release.py`
+- `docs/workflows/contracts.md`
+- `/home/jhw/ai/opencode/projects/jhw-notion-runtime/skills/claude/pr.md`
+
+GitHub reusable workflow and event behavior:
+
+- https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations
+- https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows
+- https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -625,3 +625,247 @@ Claude token rotation remains owned by `personal-ops/claude-token-sync`, includi
 inventory, locking, health checks, and deployment lifecycle. Other provider-key changes
 must use their separately reviewed owner process. There is intentionally no command that
 combines workflow PR publication with token synchronization.
+
+## Create-only v1.77 and v1.77.1 tag publication
+
+This is an operator procedure for a separately approved publication, not an action
+performed by implementing the fallback. The Git Data sequence used for the
+immutable v1.76 boundary remains create-only. Never publish with ordinary Git push,
+move a tag or delete a tag. The older v1.40.1 example above is historical.
+
+For each release separately, obtain the exact reviewed merge commit from the
+approved public-main change. Set `RELEASE_TAG` to `v1.77` or `v1.77.1`,
+`EXPECTED_RELEASE_COMMIT` to that 40-character commit and `RELEASE_DIRECTORY` to
+an absolute, absent disposable directory under a trusted parent. Exactly one of
+`GH_TOKEN` and `GITHUB_TOKEN` must contain the intended publication token. Never
+put its value in an argument, trace or response report. The launcher passes it
+through a private descriptor to an isolated process; only the GitHub API child
+receives it in an exact environment. The public Git process receives no token.
+
+The following complete procedure verifies absent direct and peeled refs twice,
+verifies public main against the review anchor, validates the exact candidate,
+then makes one annotated-tag-object POST and one tag-ref POST. Every raw response
+is created as a current-user-owned non-symlink regular file and independently set
+to 0600. It computes the intended tag OID before the first POST and verifies both
+response OIDs, then verifies the local and public direct/peeled identities.
+
+```bash
+rtk proxy /usr/bin/python3 -I -S -B -c '
+import os
+import re
+keys = [key for key in ("GH_TOKEN", "GITHUB_TOKEN") if os.environ.get(key)]
+if len(keys) != 1:
+    raise SystemExit("exactly one intended token is required")
+key = keys[0]
+token = os.environ[key].encode("ascii")
+if not 0 < len(token) <= 4096 or b"\n" in token or b"\r" in token:
+    raise SystemExit("invalid token channel")
+tag = os.environ.get("RELEASE_TAG", "")
+commit = os.environ.get("EXPECTED_RELEASE_COMMIT", "")
+directory = os.environ.get("RELEASE_DIRECTORY", "")
+if tag not in {"v1.77", "v1.77.1"} or re.fullmatch(r"[0-9a-f]{40}", commit) is None:
+    raise SystemExit("invalid reviewed release identity")
+if not directory.startswith("/"):
+    raise SystemExit("absolute disposable directory required")
+read_fd, write_fd = os.pipe()
+os.write(write_fd, token + b"\n")
+os.close(write_fd)
+if read_fd != 3:
+    os.dup2(read_fd, 3, inheritable=True)
+    os.close(read_fd)
+os.set_inheritable(3, True)
+os.closerange(4, os.sysconf("SC_OPEN_MAX"))
+environment = {
+    "PATH": "/usr/bin:/bin", "HOME": "/nonexistent/automation-release/home",
+    "XDG_CONFIG_HOME": "/nonexistent/automation-release/xdg",
+    "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8", "TOKEN_KEY": key,
+    "RELEASE_TAG": tag, "EXPECTED_RELEASE_COMMIT": commit,
+    "RELEASE_DIRECTORY": directory,
+}
+os.execve("/usr/bin/python3", ["/usr/bin/python3", "-I", "-S", "-B", "-"], environment)
+' <<'CLAUDE_RELEASE_PY'
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+
+def require(condition, reason):
+    if not condition:
+        raise SystemExit(reason)
+
+with os.fdopen(3, "rb") as channel:
+    secret = channel.read(4098)
+require(1 < len(secret) <= 4097 and secret.endswith(b"\n")
+        and b"\n" not in secret[:-1] and b"\r" not in secret, "invalid token channel")
+token = secret[:-1].decode("ascii")
+tag = os.environ["RELEASE_TAG"]
+commit = os.environ["EXPECTED_RELEASE_COMMIT"]
+root = Path(os.environ["RELEASE_DIRECTORY"])
+require(not root.exists() and not root.is_symlink(), "release directory already exists")
+root.mkdir(mode=0o700)
+os.chmod(root, 0o700)
+checkout = root / "automation"
+runtime = {key: os.environ[key] for key in
+           ("PATH", "HOME", "XDG_CONFIG_HOME", "LANG", "LC_ALL")}
+git_env = {**runtime, "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_SYSTEM": "/dev/null",
+           "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_TERMINAL_PROMPT": "0",
+           "GIT_ASKPASS": "/bin/false", "SSH_ASKPASS": "/bin/false",
+           "GCM_INTERACTIVE": "Never", "GIT_ALLOW_PROTOCOL": "https",
+           "GIT_PROTOCOL_FROM_USER": "0", "GIT_NO_REPLACE_OBJECTS": "1",
+           "GIT_CEILING_DIRECTORIES": "/"}
+url = "https://github.com/jhw7500/automation.git"
+
+def git(*args, cwd=Path("/")):
+    return subprocess.run(["/usr/bin/git", *args], cwd=cwd, env=git_env,
+                          check=True, capture_output=True, text=True).stdout.strip()
+
+def public_tags(name):
+    return git("ls-remote", "--tags", url, "refs/tags/" + name, "refs/tags/" + name + "^{}")
+
+def tag_pairs(name, direct, peeled):
+    return {direct + "\trefs/tags/" + name, peeled + "\trefs/tags/" + name + "^{}"}
+
+v176_commit = "444a7347aee169ed178aae80e8bd8d10eca52e02"
+v176_tag = "09af80682619129fcf343091b78413d2686a4579"
+require(set(public_tags("v1.76").splitlines()) == tag_pairs("v1.76", v176_tag, v176_commit),
+        "v1.76 identity changed")
+require(public_tags(tag) == "", "release direct or peeled ref already exists")
+main = git("ls-remote", "--heads", url, "refs/heads/main")
+require(main == commit + "\trefs/heads/main", "public main differs from reviewed commit")
+git("clone", "--no-recurse-submodules", url, str(checkout))
+require(git("rev-parse", "--is-shallow-repository", cwd=checkout) == "false", "incomplete clone")
+require(git("rev-parse", "refs/remotes/origin/main", cwd=checkout) == commit, "main moved")
+git("checkout", "--detach", commit, cwd=checkout)
+require(git("status", "--porcelain", cwd=checkout) == "", "dirty release checkout")
+
+def verify_release(*extra):
+    subprocess.run(["/usr/bin/python3", "-B", "-m", "scripts.verify_workflow_release",
+                    "--automation", str(checkout), "--ref", tag,
+                    "--expected-commit", commit, *extra], cwd=checkout, env=runtime, check=True)
+
+verify_release("--commit-only")
+require(git("ls-remote", "--heads", url, "refs/heads/main") == main, "main moved before write")
+require(public_tags(tag) == "", "release ref appeared before write")
+now = datetime.now(timezone.utc).replace(microsecond=0)
+tagger = {"name": "Automation workflow release", "email": "noreply@github.com",
+          "date": now.strftime("%Y-%m-%dT%H:%M:%SZ")}
+message = "automation workflow release " + tag + "\n"
+tag_bytes = ("object " + commit + "\ntype commit\ntag " + tag + "\ntagger "
+             + tagger["name"] + " <" + tagger["email"] + "> "
+             + str(int(now.timestamp())) + " +0000\n\n" + message).encode("utf-8")
+tag_oid = hashlib.sha1(b"tag " + str(len(tag_bytes)).encode("ascii") + b"\0" + tag_bytes).hexdigest()
+
+def post(endpoint, payload, filename):
+    path = root / filename
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+    with os.fdopen(descriptor, "wb") as output:
+        os.fchmod(output.fileno(), 0o600)
+        result = subprocess.run(["/usr/bin/gh", "api", "--hostname", "github.com",
+            "--method", "POST", "-H", "Accept: application/vnd.github+json",
+            "-H", "X-GitHub-Api-Version: 2022-11-28", endpoint, "--input", "-"],
+            env={**runtime, os.environ["TOKEN_KEY"]: token}, input=json.dumps(payload).encode(),
+            stdout=output, stderr=subprocess.PIPE)
+        output.flush()
+        os.fsync(output.fileno())
+    info = path.lstat()
+    require(stat.S_ISREG(info.st_mode) and info.st_uid == os.getuid()
+            and stat.S_IMODE(info.st_mode) == 0o600, "unsafe raw response file")
+    require(result.returncode == 0, "POST failed: stop and reconcile read-only; never retry blindly")
+    return json.loads(path.read_bytes())
+
+created = post("repos/jhw7500/automation/git/tags",
+    {"tag": tag, "message": message, "object": commit, "type": "commit", "tagger": tagger},
+    "tag-object-response.json")
+require(created.get("sha") == tag_oid and created.get("tag") == tag
+        and created.get("message") == message and created.get("tagger") == tagger
+        and created.get("object", {}).get("sha") == commit
+        and created.get("object", {}).get("type") == "commit", "tag object response differs")
+created_ref = post("repos/jhw7500/automation/git/refs",
+    {"ref": "refs/tags/" + tag, "sha": tag_oid}, "tag-ref-response.json")
+require(created_ref.get("ref") == "refs/tags/" + tag
+        and created_ref.get("object", {}).get("sha") == tag_oid
+        and created_ref.get("object", {}).get("type") == "tag", "tag ref response differs")
+require(set(public_tags(tag).splitlines()) == tag_pairs(tag, tag_oid, commit), "public tag differs")
+require(set(public_tags("v1.76").splitlines()) == tag_pairs("v1.76", v176_tag, v176_commit),
+        "v1.76 identity changed")
+git("fetch", "--no-tags", url, "refs/tags/" + tag + ":refs/tags/" + tag, cwd=checkout)
+require(git("rev-parse", "refs/tags/" + tag, cwd=checkout) == tag_oid, "local direct ref differs")
+require(git("rev-parse", "refs/tags/" + tag + "^{}", cwd=checkout) == commit, "local peeled ref differs")
+verify_release("--remote", "origin")
+print(tag + " verified: tag=" + tag_oid + " commit=" + commit)
+CLAUDE_RELEASE_PY
+```
+
+A failed or uncertain POST stops the procedure. Preserve both raw response files
+that exist and reconcile with read-only API/public Git reads. An orphan annotated
+object is harmless; a concurrent ref creation must never be repaired by moving
+or deleting the tag. Repeat this procedure for v1.77.1 only after its separate
+reviewed main change and publication authorization.
+
+## v1.76 bootstrap evidence
+
+The immutable bootstrap boundary is commit
+`444a7347aee169ed178aae80e8bd8d10eca52e02`, annotated tag object
+`09af80682619129fcf343091b78413d2686a4579`. Preserve original fleet manifests,
+PR HEAD/base tuples, automatic run IDs/attempts, canonical failure states and
+evidence digests. A default branch still pinned to v1.76 cannot authenticate the
+new managed route. Its original automatic caller-validation failure is bootstrap
+evidence; neither a new comment nor a receipt can retroactively enable v1.77 code.
+Use a separately reviewed adoption/merge decision to establish the new default
+caller. Never rewrite the original failure as a successful run.
+
+## v1.77 route adoption
+
+After create-only publication and release verification, render consumer caller
+changes with the existing fleet plan/publish/audit workflow, explicitly selecting
+the immutable release ref and approved consumer/base branch. Review the generated
+managed diff and adoption PR before a separately authorized merge. Verify the
+default-branch `claude.yml` pins the peeled v1.77 commit and has the catalogued
+write ceiling. Keep the ordinary automatic reviewer on the reviewed release pin.
+
+Record the new default caller SHA and its central commit as the future fallback
+driver. A v1.77 adoption PR alone is not the real boundary canary: until merged,
+the default branch still runs the older caller. Request/admission/ledger/comment
+and receipt schemas are defined in [the consumer contract](workflows/contracts.md).
+
+## v1.77.1 real-boundary canary
+
+Publish a separately reviewed v1.77.1 commit after v1.77 caller adoption. Create one
+approved managed rollout PR from the v1.77 default to v1.77.1; record exact HEAD,
+base and managed diff hash. Require the original automatic attempt to fail at
+caller validation, with budget claim and provider skipped and the matching
+canonical automatic failure. Post one separately authorized canonical managed
+request after that failure. Its target release is v1.77.1; its default caller and
+verification checkout remain the exact v1.77 driver commit. Wait for the managed
+run and charged invocation to finalize. Do not retry an uncertain request.
+
+From a clean automation checkout at that driver commit, in an independently
+mode-0700 evidence directory, run the read-only verifier using recorded values:
+
+```bash
+rtk proxy /usr/bin/python3 -I -S -B "$AUTOMATION_ROOT/scripts/verify_claude_rollout_fallback.py" \
+  --automation-root "$AUTOMATION_ROOT" --release-ref v1.77.1 --remote origin \
+  --repository "$CONSUMER_REPOSITORY" --pr "$PR_NUMBER" \
+  --expected-head "$EXPECTED_HEAD_SHA" --expected-base "$EXPECTED_BASE_SHA" \
+  --output "$PRIVATE_EVIDENCE_DIRECTORY/claude-fallback-receipt.json"
+```
+
+The output must be absent before invocation. Require an owned regular mode-0600
+receipt, `effective_status: CLEAN`, the distinct driver/target commits and the
+recorded request/run/comment/budget coordinates. A receipt permits evaluation of
+the named rollout tuple; it does not itself authorize merging.
+
+## Required-check stop conditions
+
+Stop on changed HEAD/base, caller or release identity, noncanonical managed diff,
+missing/expired/ambiguous evidence, provider entry in the original failed attempt,
+partial fallback inputs, an unfinalized budget, non-clean fallback quality, or
+uncertain required-check discovery. Required checks must be completed with an
+accepted conclusion (`success`, `neutral`, or `skipped`); any failure, cancellation
+or pending check prevents the receipt. In particular, if the original failed
+automatic job is a required check, fallback evidence cannot waive it. Stop and
+resolve the repository's required-check policy through its own approved process.
+Never remove a required check or fabricate a successful Check to make rollout pass.

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -649,6 +649,13 @@ is created as a current-user-owned non-symlink regular file and independently se
 to 0600. It computes the intended tag OID before the first POST and verifies both
 response OIDs, then verifies the local and public direct/peeled identities.
 
+For v1.77.1, before either POST it also authenticates the existing annotated
+v1.77 tag and peeled commit, requires a distinct reviewed candidate, and compares
+every v1.77 inventory-owned path, mode and blob. The inventory is loaded from
+the authenticated v1.77 checkout, so the candidate cannot reduce the comparison.
+Any release-owned difference invalidates this boundary canary and requires a
+normal reviewed patch design. First publication of v1.77 has no prior-v1.77 check.
+
 ```bash
 rtk proxy /usr/bin/python3 -I -S -B -c '
 import os
@@ -689,6 +696,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import stat
 import subprocess
 
@@ -747,6 +755,40 @@ def verify_release(*extra):
                     "--expected-commit", commit, *extra], cwd=checkout, env=runtime, check=True)
 
 verify_release("--commit-only")
+if tag == "v1.77.1":
+    pairs = [line.split("\t") for line in public_tags("v1.77").splitlines()]
+    require(len(pairs) == 2 and all(len(pair) == 2 for pair in pairs),
+            "missing or ambiguous v1.77 direct/peeled identity")
+    refs = {ref: oid for oid, ref in pairs}
+    require(set(refs) == {"refs/tags/v1.77", "refs/tags/v1.77^{}"}
+            and all(re.fullmatch("[0-9a-f]{40}", oid) for oid in refs.values()),
+            "invalid v1.77 direct/peeled identity")
+    v177_tag = refs["refs/tags/v1.77"]
+    v177_commit = refs["refs/tags/v1.77^{}"]
+    require(commit != v177_commit, "boundary canary requires a distinct reviewed commit")
+    git("fetch", "--no-tags", url, "refs/tags/v1.77:refs/tags/v1.77", cwd=checkout)
+    require(git("rev-parse", "refs/tags/v1.77", cwd=checkout) == v177_tag
+            and git("rev-parse", "refs/tags/v1.77^{}", cwd=checkout) == v177_commit
+            and git("cat-file", "-t", v177_tag, cwd=checkout) == "tag",
+            "fetched v1.77 annotation or peeled commit differs")
+    baseline = root / "v177-baseline"
+    git("worktree", "add", "--detach", str(baseline), v177_commit, cwd=checkout)
+    subprocess.run(["/usr/bin/python3", "-B", "-m", "scripts.verify_workflow_release",
+                    "--automation", str(baseline), "--ref", "v1.77",
+                    "--expected-commit", v177_commit, "--remote", "origin"],
+                   cwd=baseline, env=runtime, check=True)
+    inventory = subprocess.run(["/usr/bin/python3", "-B", "-c",
+        'import json; from scripts.workflow_release_inventory import release_paths_for; '
+        'print(json.dumps(release_paths_for("v1.77")))'],
+        cwd=baseline, env=runtime, check=True, capture_output=True, text=True)
+    owned = json.loads(inventory.stdout)
+    require(isinstance(owned, list) and owned and all(isinstance(path, str) for path in owned),
+            "invalid authenticated v1.77 inventory")
+    require(git("diff", "--raw", "--no-ext-diff", "--no-textconv", "--exit-code",
+                v177_commit, commit, "--", *owned, cwd=checkout) == "",
+            "release-owned difference invalidates boundary canary; normal reviewed patch design required")
+    require(set(public_tags("v1.77").splitlines()) == tag_pairs("v1.77", v177_tag, v177_commit),
+            "v1.77 identity moved before write")
 require(git("ls-remote", "--heads", url, "refs/heads/main") == main, "main moved before write")
 require(public_tags(tag) == "", "release ref appeared before write")
 now = datetime.now(timezone.utc).replace(microsecond=0)
@@ -833,7 +875,12 @@ and receipt schemas are defined in [the consumer contract](workflows/contracts.m
 
 ## v1.77.1 real-boundary canary
 
-Publish a separately reviewed v1.77.1 commit after v1.77 caller adoption. Create one
+Publish a separately reviewed v1.77.1 commit after v1.77 caller adoption. It must
+be distinct from the authenticated v1.77 peeled commit while preserving every
+v1.77 release-owned byte, path and mode. Before publication, the procedure above
+must prove an empty raw Git diff across the authenticated v1.77 inventory. Any
+difference invalidates this boundary canary and requires a normal reviewed patch
+design. Create one
 approved managed rollout PR from the v1.77 default to v1.77.1; record exact HEAD,
 base and managed diff hash. Require the original automatic attempt to fail at
 caller validation, with budget claim and provider skipped and the matching

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -104,6 +104,138 @@ the updated normal receipt collectors and budget helper. Immutable v1.74/v1.75
 acceptance remains unchanged. This implementation pass performs no release publication,
 consumer adoption, live recovery or provider execution; those remain separate actions.
 
+## Claude rollout request v1
+
+Release v1.77 adds one managed route to the default-branch Claude comment caller.
+The request is exactly two lines, with at most one terminal newline:
+
+```text
+@claude managed rollout review for PR <positive PR number>
+<!-- automation:claude-rollout-review-request:v1 <canonical JSON object> -->
+```
+
+The helper's `canonical_request_body()` produces ASCII JSON with sorted keys and
+compact separators. Use it instead of composing the hidden marker by hand. The
+parser rejects duplicate/extra keys, noncanonical bytes, bodies over 4096 UTF-8
+bytes, mismatched visible PR numbers, booleans in integer fields, and invalid
+hashes. The exact request fields are:
+
+| Keys | Contract |
+| --- | --- |
+| `repository`, `pr` | Exact owner/repository and positive safe integer PR |
+| `expected_head_sha`, `expected_base_sha`, `release_commit` | 40 lowercase hexadecimal characters |
+| `original_run_id`, `original_run_attempt` | Positive safe integers identifying one original attempt |
+| `managed_diff_sha256` | 64 lowercase hexadecimal characters, the complete managed diff |
+| `nonce` | 32 lowercase hexadecimal characters |
+
+Only a created `issue_comment` by an OWNER, MEMBER or COLLABORATOR is admissible.
+The helper rereads the exact comment, open same-repository PR, original run/attempt
+and jobs. It reads at most ten pages of 100 comments; a full tenth page refuses.
+The original caller-validation step must fail before the budget claim and provider
+steps, which must both be skipped. The canonical automatic state must independently
+identify that exact failure. Ambiguous requests, changed HEAD/base, uncertain
+evidence and an already successful fallback refuse without entering the provider.
+
+```text
+created comment -> classify -> interactive -> existing Claude interaction
+                          +-> managed     -> authenticated nested review
+                          +-> invalid     -> bounded refusal, no review
+```
+
+The managed visible prefix is excluded from the interactive route, including
+malformed managed requests. The consumer caller grants exactly `actions: read`,
+`contents: read`, `id-token: write`, `issues: read`, `pull-requests: write`.
+The interactive central job keeps `pull-requests: read`. Classification grants
+only actions/contents/issues/pull-requests read. The nested managed job uses exactly
+`$/.github/workflows/claude-code-review.yml`, the consumer write ceiling above,
+and the same-name `CLAUDE_CODE_OAUTH_TOKEN` secret.
+
+## Admission schema 1
+
+Admission is a private regular JSON file owned by the runner, mode 0600, created
+without replacing an existing path. Its complete key set is:
+
+| Key | Meaning |
+| --- | --- |
+| `schema` | Integer 1 |
+| `request` | Exact request object described above |
+| `request_comment_id` | Authenticated created comment ID |
+| `automatic_comment_id` | Authenticated automatic failure comment ID |
+| `automatic_state_sha256` | SHA-256 of the exact embedded automatic state JSON bytes |
+
+The nested review accepts eight string inputs, either all empty or all nonempty:
+`fallback_request_comment_id`, `fallback_request_nonce`,
+`fallback_expected_head_sha`, `fallback_expected_base_sha`,
+`fallback_original_run_id`, `fallback_original_run_attempt`,
+`fallback_release_commit`, `fallback_managed_diff_sha256`.
+It reauthenticates admission and compares every input before claiming budget.
+A partial tuple refuses with `fallback_inputs_partial`; `force_review` cannot be
+combined with fallback. Admission is local execution evidence, not a review result.
+
+## Invocation route schema 2 migration
+
+The budget ledger writes schema 2. Reading authenticated schema 1 derives the route
+from its original caller event, preserving its history and usage. Checkpoint
+envelopes remain schema 1. Older checkpoint canonical bytes are validated before
+migration; migration does not forgive a malformed record or refund a round.
+
+| Route kind | Exact route keys |
+| --- | --- |
+| `automatic` | `kind` |
+| `authorized_override` | `kind` |
+| `default_branch_rollout_fallback` | `kind`, `request_comment_id`, `request_nonce`, `original_run_id`, `original_run_attempt`, `expected_base_sha`, `release_commit`, `managed_diff_sha256`, `automatic_comment_id`, `automatic_state_sha256` |
+
+Legacy `pull_request` maps to automatic; `workflow_dispatch` maps to authorized
+override. Other legacy events fail closed. Claim and finalize receive the same
+canonical `invocation-route-json`; the fallback remains a normal charged review
+invocation, with no extra round, call, token or elapsed-time allowance. OpenCode
+recovery and its receipt consumers validate the schema-2 ledger as well.
+
+## Claude schema-3 failure and fallback variants
+
+The canonical comment keeps `## Claude Code Review (latest)` and
+`<!-- automation:claude-code-review:v3 -->`. Its state is schema 3, quality schema 1.
+The existing state keys are `schema`, `reviewer`, `pr`, `run_id`, `run_attempt`,
+`attempt_head`, `successful_head`, `attempt_status`, `diff_mode`,
+`review_execution`, `full_diff_sha256`, `quality_schema`, `accepted_count`,
+`filtered_count`, `normalized_count`, `filtered_max_severity`.
+
+| Variant | Exact additional field and acceptance |
+| --- | --- |
+| Automatic validation failure | `failure_reason: workflow_validation_mismatch`; failure, `review_execution: not_performed`, preserving previous successful quality evidence |
+| Successful managed fallback | `route` object below; success, `review_execution: performed`, authenticated current quality and finalized charged invocation |
+
+The canonical `route` has exactly `route`, `request_comment_id`,
+`original_failed_run_id`, `reviewed_base_sha`, `release_commit`,
+`managed_diff_sha256`; its `route` value is `default_branch_rollout_fallback`.
+It differs deliberately from the budget route: the canonical comment exposes
+only the public review coordinates. Publication checks fresh PR HEAD and base
+and refuses stale evidence. A failure must never be labeled as a successful
+fallback or overwrite the meaning of the original failed Actions run.
+
+## Fleet fallback receipt schema 1
+
+`scripts/verify_claude_rollout_fallback.py` independently verifies the current
+default caller, exact automation checkout, fleet diff, original failure, managed
+request, successful canonical fallback, finalized budget and all required checks.
+Run it with `python3 -I -S -B`; imported rollout modules are loaded only after their
+clean automation checkout is verified at the default caller's `verifier_commit`.
+These ordinary repository modules do not become additional release inventory roots.
+The output parent must be private and the new receipt must not already exist.
+
+| Object | Exact keys |
+| --- | --- |
+| Receipt | `schema`, `repository`, `pr`, `head_sha`, `base_sha`, `release_commit`, `managed_diff_sha256`, `verifier_commit`, `automatic`, `fallback`, `fleet`, `effective_status` |
+| `automatic` | `admitted_state_sha256`, `canonical_comment_id`, `reason`, `review_execution`, `run_attempt`, `run_id`, `status` |
+| `fallback` | `budget_status`, `canonical_comment_id`, `canonical_state_sha256`, `driver_commit`, `filtered_max_severity`, `request_comment_id`, `request_nonce`, `review_execution`, `route`, `run_attempt`, `run_id`, `status` |
+| `fleet` | `base_branch`, `changed_paths`, `head_repository`, `pull_request_url`, `rollout_branch` |
+
+A successful receipt records `schema: 1`, `effective_status: CLEAN`, and distinct
+driver and target release commits. It is published only after all checks and final
+PR/branch readback succeed, via exclusive private-file creation with independent
+0600 enforcement and atomic publication. It is evidence for the named tuple; it
+neither changes the original Actions conclusion nor waives required checks.
+
 ## Same-name credential mappings
 
 Model credential names are fixed by authentication family, and every mapping uses the

--- a/examples/baseline-workflows/.github/workflows/claude.yml
+++ b/examples/baseline-workflows/.github/workflows/claude.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       id-token: write
       issues: read
-      pull-requests: read
+      pull-requests: write
     uses: jhw7500/automation/.github/workflows/claude.yml@__AUTOMATION_COMMIT__
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/scripts/rollout_workflow_fleet.py
+++ b/scripts/rollout_workflow_fleet.py
@@ -665,14 +665,14 @@ def _validate_tree_contents(
 
 def validate_commit_tree(
     snapshot: RepositorySnapshot,
-    head_sha: str,
-    base_sha: str,
+    expected_head: str,
+    expected_base: str,
     plan: RenderPlan,
 ) -> None:
     """Attest one proposed commit's parent, paths, blobs, and deletions."""
 
-    head_sha = _object_id(head_sha, "rollout commit")
-    base_sha = _object_id(base_sha, "default branch object")
+    head_sha = _object_id(expected_head, "rollout commit")
+    base_sha = _object_id(expected_base, "default branch object")
     if plan.observed_revision is not None and plan.observed_revision != base_sha:
         raise CommandError("render plan does not match the observed base")
     parents = git(
@@ -1032,7 +1032,7 @@ def require_no_current_rollout_branch(snapshot: RepositorySnapshot, ref: str) ->
         )
 
 
-def attest_pull_request(
+def _attest_published_pull_request(
     snapshot: RepositorySnapshot,
     ref: str,
     commit: str,
@@ -1051,22 +1051,33 @@ def attest_pull_request(
         len(requests) != 1
         or requests[0].number != request.number
         or requests[0].url != request.url
-        or not _exact_pr(
-            requests[0],
-            base=selected_base,
-            branch=branch,
-            head_repo=f"{fleet_git.OWNER}/{snapshot.path.name}",
-            head_sha=head_sha,
-            title=pr_title(ref, selected_base, snapshot.default_branch),
-            body=pr_body(
-                ref, commit, changed_paths, selected_base, snapshot.default_branch
-            ),
-        )
     ):
         raise CommandError("pull request attestation failed")
+    attest_pull_request(snapshot, ref, commit, head_sha, tuple(changed_paths), requests[0])
 
 
-def _render(
+def attest_pull_request(
+    snapshot: RepositorySnapshot,
+    release_ref: str,
+    release_commit: str,
+    expected_head: str,
+    changed_paths: tuple[str, ...],
+    request: PullRequest,
+) -> PullRequest:
+    """Validate supplied observed PR metadata without performing remote reads."""
+    selected_base = _selected_base_branch(snapshot)
+    if not _exact_pr(
+        request, base=selected_base,
+        branch=rollout_branch(release_ref, selected_base, snapshot.default_branch),
+        head_repo=f"{fleet_git.OWNER}/{snapshot.path.name}", head_sha=expected_head,
+        title=pr_title(release_ref, selected_base, snapshot.default_branch),
+        body=pr_body(release_ref, release_commit, changed_paths, selected_base, snapshot.default_branch),
+    ):
+        raise CommandError("pull request attestation failed")
+    return request
+
+
+def render_rollout_plan(
     snapshot: RepositorySnapshot,
     bundle: ReleaseBundle,
     repo: str,
@@ -1086,6 +1097,16 @@ def _render(
         bootstrap=bootstrap,
         observed_revision=snapshot.base_sha,
     )
+
+
+def _render(
+    snapshot: RepositorySnapshot,
+    bundle: ReleaseBundle,
+    repo: str,
+    *,
+    bootstrap: bool,
+) -> RenderPlan:
+    return render_rollout_plan(snapshot, bundle, repo, bootstrap=bootstrap)
 
 
 def _prepared_outcome(
@@ -1453,7 +1474,7 @@ def _publish_repository_fresh(
                     "branch published but pull request state is unavailable",
                 )
         try:
-            attest_pull_request(
+            _attest_published_pull_request(
                 snapshot, bundle.ref, bundle.commit, head_sha, changed, request
             )
         except (CommandError, FleetGitError) as exc:

--- a/scripts/verify_claude_rollout_fallback.py
+++ b/scripts/verify_claude_rollout_fallback.py
@@ -1,0 +1,893 @@
+#!/usr/bin/env python3
+"""Read-only attestation of one managed Claude rollout fallback.
+
+Invoke with Python -I -S -B. No project imports occur before checkout verification.
+Remote bodies and consumer files are data, never executable inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+from contextlib import contextmanager
+from dataclasses import dataclass
+import hashlib
+import importlib
+import importlib.machinery
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+from types import ModuleType
+from typing import Protocol
+from urllib.parse import quote
+
+
+GITHUB_CLI = Path("/usr/bin") / ("g" + "h")
+SHA = re.compile(r"[0-9a-f]{40}\Z")
+REPOSITORY = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*\Z")
+RECEIPT_KEYS = frozenset({"automatic", "base_sha", "effective_status", "fallback", "fleet", "head_sha",
+    "managed_diff_sha256", "pr", "release_commit", "repository", "schema", "verifier_commit"})
+AUTOMATIC_KEYS = frozenset({"admitted_state_sha256", "canonical_comment_id", "reason", "review_execution",
+    "run_attempt", "run_id", "status"})
+FALLBACK_KEYS = frozenset({"budget_status", "canonical_comment_id", "canonical_state_sha256", "driver_commit",
+    "filtered_max_severity", "request_comment_id", "request_nonce", "review_execution", "route", "run_attempt", "run_id", "status"})
+FLEET_KEYS = frozenset({"base_branch", "changed_paths", "head_repository", "pull_request_url", "rollout_branch"})
+REQUIRED_MODULE_PATHS = (
+    "scripts/verify_claude_rollout_fallback.py",
+    "scripts/rollout_workflow_fleet.py",
+    "scripts/workflow_release_bundle.py",
+    "scripts/workflow_release_inventory.py",
+    "scripts/verify_workflow_release.py",
+    "scripts/workflow_catalog.py",
+    "scripts/workflow_fleet_git.py",
+    "scripts/prepare_workflow_rollout.py",
+    "scripts/audit_workflow_fleet.py",
+    ".github/actions/claude-rollout-fallback/contract.py",
+    ".github/actions/review-invocation-budget/review_invocation_budget.py",
+)
+
+
+class VerificationError(ValueError):
+    """A bounded diagnostic that never contains a remote response body."""
+
+
+@dataclass(frozen=True)
+class VerificationRequest:
+    automation_root: Path
+    release_ref: str
+    remote: str
+    repository: str
+    pr: int
+    expected_head: str
+    expected_base: str
+    output: Path
+
+
+@dataclass(frozen=True)
+class VerifiedModules:
+    release_bundle: ModuleType
+    inventory: ModuleType
+    rollout: ModuleType
+
+
+class EvidenceProvider(Protocol):
+    def default_caller(self) -> dict[str, object]: ...
+    def pull_request(self, number: int) -> dict[str, object]: ...
+    def issue_comments(self, number: int) -> tuple[dict[str, object], ...]: ...
+    def run_attempt(self, run_id: int, attempt: int) -> dict[str, object]: ...
+    def run_jobs(self, run_id: int, attempt: int) -> tuple[dict[str, object], ...]: ...
+    def check_annotations(self, check_run_id: int) -> tuple[dict[str, object], ...]: ...
+    def required_checks(self, head_sha: str) -> tuple[dict[str, object], ...]: ...
+    def workflow_runs(self) -> tuple[dict[str, object], ...]: ...
+    def rollout_prs(self, branch: str) -> tuple[dict[str, object], ...]: ...
+    def branch_sha(self, branch: str) -> str: ...
+    def consumer_snapshot(self, request: VerificationRequest, modules: VerifiedModules): ...
+
+
+def _git_bytes(root: Path, *args: str) -> bytes:
+    environment = {
+        "PATH": "/usr/bin:/bin", "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8",
+        "GIT_OPTIONAL_LOCKS": "0", "GIT_TERMINAL_PROMPT": "0",
+        "GIT_ASKPASS": "/bin/false", "SSH_ASKPASS": "/bin/false",
+        "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_NO_REPLACE_OBJECTS": "1",
+    }
+    if args and args[0] == "fetch":
+        # Only the fresh disposable repository uses this path. Supply credentials
+        # in the child environment, never command arguments or diagnostics.
+        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+        if token:
+            encoded = base64.b64encode(("x-access-token:" + token).encode()).decode()
+            environment.update(GIT_CONFIG_COUNT="1", GIT_CONFIG_KEY_0="http.https://github.com/.extraheader",
+                               GIT_CONFIG_VALUE_0="AUTHORIZATION: basic " + encoded)
+    try:
+        result = subprocess.run(
+            ["/usr/bin/git", "-c", "core.hooksPath=/dev/null", "-c", "core.fsmonitor=false",
+             "-c", "submodule.recurse=false", "-c", "core.untrackedCache=false", *args],
+            cwd=root, env=environment, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            timeout=60, check=True,
+        )
+        return result.stdout
+    except (OSError, ValueError, subprocess.SubprocessError):
+        raise VerificationError("git_read_failed") from None
+
+
+def git_stdout(root: Path, *args: str) -> str:
+    try:
+        return _git_bytes(root, *args).decode("utf-8").rstrip("\n")
+    except UnicodeError:
+        raise VerificationError("git_read_failed") from None
+
+
+def _no_symlinks(path: Path) -> None:
+    if not path.is_absolute() or ".." in path.parts:
+        raise OSError("invalid path")
+    for node in (path, *path.parents):
+        if stat.S_ISLNK(node.lstat().st_mode):
+            raise OSError("symlink path")
+
+
+def verify_source_root(root: Path, driver_commit: str) -> None:
+    try:
+        _no_symlinks(root)
+        if SHA.fullmatch(driver_commit) is None or git_stdout(root, "rev-parse", "HEAD") != driver_commit:
+            raise ValueError
+        if Path(git_stdout(root, "rev-parse", "--show-toplevel")) != root:
+            raise ValueError
+        def verify_object(oid, kind):
+            raw = _git_bytes(root, "cat-file", kind, oid)
+            actual = hashlib.sha1(kind.encode() + b" " + str(len(raw)).encode() + b"\0" + raw).hexdigest()
+            if actual != oid:
+                raise ValueError
+            return raw
+        commit = verify_object(driver_commit, "commit")
+        tree = commit.splitlines()[0].decode("ascii")
+        if not tree.startswith("tree ") or SHA.fullmatch(tree[5:]) is None:
+            raise ValueError
+        verify_object(tree[5:], "tree")
+        # Read actual bytes: Git status can trust assume-unchanged or invoke clean filters.
+        records = git_stdout(root, "ls-tree", "-rtz", driver_commit).split("\0")
+        tracked = {}
+        for record in filter(None, records):
+            metadata, name = record.split("\t", 1)
+            mode, kind, oid = metadata.split()
+            if kind == "tree" and mode == "040000":
+                verify_object(oid, "tree")
+                continue
+            node = root / name
+            _no_symlinks(node)
+            observed = node.lstat()
+            if kind != "blob" or mode not in {"100644", "100755"} or not stat.S_ISREG(observed.st_mode):
+                raise ValueError
+            if bool(observed.st_mode & 0o111) != (mode == "100755"):
+                raise ValueError
+            payload = node.read_bytes()
+            actual = hashlib.sha1(b"blob " + str(len(payload)).encode() + b"\0" + payload).hexdigest()
+            if actual != oid:
+                raise ValueError
+            tracked[name] = mode
+        if any(tracked.get(name) != "100644" for name in REQUIRED_MODULE_PATHS):
+            raise ValueError
+        # No exclude flags: ignored Python shadows are untrusted too.
+        if git_stdout(root, "ls-files", "--others", "-z"):
+            raise ValueError
+        if git_stdout(root, "diff-index", "--cached", "--name-only", driver_commit, "--"):
+            raise ValueError
+    except (OSError, ValueError, VerificationError):
+        raise VerificationError("verifier_root_invalid") from None
+
+
+def require_trusted_dependency_directory(path: Path) -> None:
+    try:
+        _no_symlinks(path)
+        for node in (path, *path.parents):
+            observed = node.lstat()
+            if not stat.S_ISDIR(observed.st_mode) or observed.st_uid != 0 or observed.st_mode & 0o022:
+                raise ValueError
+    except (OSError, ValueError):
+        raise VerificationError("verifier_dependency_invalid") from None
+
+
+def load_trusted_yaml() -> None:
+    # Enumerate paths only; never run site.main/addsitedir or execute .pth files.
+    import site
+
+    for candidate in site.getsitepackages():
+        parent = Path(candidate)
+        if not parent.exists():
+            continue
+        require_trusted_dependency_directory(parent)
+        specification = importlib.machinery.PathFinder.find_spec("yaml", [str(parent)])
+        if specification is None:
+            continue
+        try:
+            origin = Path(specification.origin or "")
+            if not origin.is_relative_to(parent) or specification.submodule_search_locations is None:
+                raise ValueError
+            package = origin.parent
+            require_trusted_dependency_directory(package)
+            for node in package.rglob("*"):
+                observed = node.lstat()
+                if (stat.S_ISLNK(observed.st_mode) or observed.st_uid != 0
+                        or observed.st_mode & 0o022
+                        or not (stat.S_ISREG(observed.st_mode) or stat.S_ISDIR(observed.st_mode))):
+                    raise ValueError
+            existing = sys.modules.get("yaml")
+            if existing is not None and Path(existing.__file__) != origin:
+                raise ValueError
+            if str(parent) not in sys.path:
+                sys.path.append(str(parent))
+            importlib.import_module("yaml")
+            return
+        except (OSError, ValueError, ImportError):
+            raise VerificationError("verifier_dependency_invalid") from None
+    raise VerificationError("verifier_dependency_invalid")
+
+
+def load_verified_modules(root: Path) -> VerifiedModules:
+    sys.dont_write_bytecode = True
+    sys.path.insert(0, str(root))
+    load_trusted_yaml()
+    try:
+        modules = tuple(importlib.import_module("scripts." + name) for name in (
+            "workflow_release_bundle", "workflow_release_inventory", "rollout_workflow_fleet"))
+        for module in modules:
+            if not Path(module.__file__).is_relative_to(root):
+                raise ImportError
+        return VerifiedModules(*modules)
+    except (ImportError, OSError, ValueError):
+        raise VerificationError("verifier_root_invalid") from None
+
+
+def canonical_json_bytes(payload: dict[str, object]) -> bytes:
+    return (json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":"),
+                       allow_nan=False) + "\n").encode("ascii")
+
+
+def require_private_output_parent(path: Path) -> None:
+    try:
+        _no_symlinks(path)
+        observed = path.lstat()
+        if (not stat.S_ISDIR(observed.st_mode) or observed.st_uid != os.getuid()
+                or stat.S_IMODE(observed.st_mode) != 0o700):
+            raise ValueError
+    except (OSError, ValueError):
+        raise VerificationError("receipt_parent_invalid") from None
+
+
+def require_private_regular_owned(path: Path) -> None:
+    try:
+        observed = path.lstat()
+        if (not stat.S_ISREG(observed.st_mode) or observed.st_uid != os.getuid()
+                or stat.S_IMODE(observed.st_mode) != 0o600):
+            raise ValueError
+    except (OSError, ValueError):
+        raise VerificationError("receipt_file_invalid") from None
+
+
+def write_receipt(path: Path, payload: dict[str, object]) -> None:
+    require_private_output_parent(path.parent)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    created = False
+    try:
+        try:
+            path.lstat()
+        except FileNotFoundError:
+            pass
+        else:
+            raise VerificationError("receipt_path_exists")
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+        created = True
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(canonical_json_bytes(payload))
+            os.fchmod(stream.fileno(), 0o600)
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(temporary, path, follow_symlinks=False)
+        except FileExistsError:
+            raise VerificationError("receipt_path_exists") from None
+    except (OSError, ValueError) as error:
+        if isinstance(error, VerificationError):
+            raise
+        raise VerificationError("receipt_write_failed") from None
+    finally:
+        if created:
+            temporary.unlink(missing_ok=True)
+    require_private_regular_owned(path)
+
+
+def validate_request(request: VerificationRequest) -> None:
+    if (not isinstance(request.repository, str) or REPOSITORY.fullmatch(request.repository) is None
+            or type(request.pr) is not int or not 1 <= request.pr < 2**53
+            or SHA.fullmatch(request.expected_head) is None or SHA.fullmatch(request.expected_base) is None
+            or re.fullmatch(r"v[0-9]+(?:\.[0-9]+)+", request.release_ref) is None
+            or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*", request.remote) is None):
+        raise VerificationError("request_invalid")
+    if (not request.automation_root.is_absolute() or not request.output.is_absolute()
+            or request.output.resolve().is_relative_to(request.automation_root.resolve())):
+        raise VerificationError("request_invalid")
+
+
+@contextmanager
+def _fixed_tool_path():
+    previous = os.environ.get("PATH")
+    os.environ["PATH"] = "/usr/bin:/bin"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("PATH", None)
+        else:
+            os.environ["PATH"] = previous
+
+
+def verify_fleet_request(request: VerificationRequest, evidence: EvidenceProvider,
+                         modules: VerifiedModules) -> dict[str, object]:
+    with _fixed_tool_path():
+        return _verify_fleet_request(request, evidence, modules)
+
+
+def _verify_fleet_request(request, evidence, modules):
+    rollout = modules.rollout
+    try:
+        with modules.release_bundle.materialize_release_bundle(
+                request.automation_root, request.release_ref, remote=request.remote) as bundle:
+            with evidence.consumer_snapshot(request, modules) as snapshot:
+                repo = request.repository.split("/", 1)[1]
+                if snapshot.base_sha != request.expected_base:
+                    raise ValueError
+                plan = rollout.render_rollout_plan(snapshot, bundle, repo, bootstrap=False)
+                if plan.status != "drift":
+                    raise ValueError
+                changed = tuple(sorted(change.path.as_posix() for change in plan.changes))
+                rollout.validate_commit_tree(snapshot, request.expected_head, request.expected_base, plan)
+                branch = rollout.rollout_branch(bundle.ref, snapshot.base_branch, snapshot.default_branch)
+                if evidence.branch_sha(branch) != request.expected_head:
+                    raise ValueError
+                observed = evidence.pull_request(request.pr)
+                candidates = evidence.rollout_prs(branch)
+                if len(candidates) != 1 or candidates[0] != observed:
+                    raise ValueError
+                url = f"https://github.com/{request.repository}/pull/{request.pr}"
+                if (observed["number"] != request.pr or observed["html_url"] != url
+                        or observed["state"] != "open" or observed["merged"] is not False
+                        or observed["head"]["repo"]["fork"] is not False
+                        or observed["base"]["repo"]["full_name"] != request.repository
+                        or observed["base"]["sha"] != request.expected_base):
+                    raise ValueError
+                pr = rollout.PullRequest(
+                    observed["number"], observed["html_url"], observed["state"].upper(),
+                    observed["base"]["ref"], observed["head"]["ref"],
+                    observed["head"]["repo"]["full_name"], observed["head"]["sha"],
+                    observed["title"], observed["body"],
+                )
+                rollout.attest_pull_request(snapshot, bundle.ref, bundle.commit,
+                                           request.expected_head, changed, pr)
+                if evidence.branch_sha(branch) != request.expected_head:
+                    raise ValueError
+                diff = git_stdout(snapshot.path, "diff", "--no-ext-diff", "--no-textconv",
+                                  "--find-renames=50%", "--ignore-submodules=none", "-U3",
+                                  request.expected_base + ".." + request.expected_head)
+                return {"release_commit": bundle.commit,
+                        "_default_branch": snapshot.default_branch,
+                        "managed_diff_sha256": hashlib.sha256((diff + "\n").encode()).hexdigest(),
+                        "fleet": {"base_branch": pr.base, "changed_paths": list(changed),
+                                  "head_repository": pr.head_repo, "pull_request_url": pr.url,
+                                  "rollout_branch": branch}}
+    except Exception:
+        # Includes bounded release/catalog/transport errors; never relay remote text.
+        raise VerificationError("fleet_attestation_failed") from None
+
+
+def parse_default_caller_pin(document: object) -> str:
+    try:
+        if (type(document) is not dict or document.get("type") != "file"
+                or document.get("path") != ".github/workflows/claude.yml"
+                or document.get("encoding") != "base64"
+                or document.get("target") or document.get("submodule_git_url")
+                or type(document.get("content")) is not str or len(document["content"]) > 100000):
+            raise ValueError
+        content = base64.b64decode("".join(document["content"].split()), validate=True).decode("utf-8")
+        pins = re.findall(r"^    uses: jhw7500/automation/\.github/workflows/claude\.yml@([0-9a-f]{40})(?: +#[^\r\n]*)?$",
+                          content, re.MULTILINE)
+        if len(pins) != 1:
+            raise ValueError
+        return pins[0]
+    except (ValueError, TypeError, UnicodeError):
+        raise VerificationError("driver_pin_invalid") from None
+
+
+def _driver_module(root: Path, relative: str, name: str) -> ModuleType:
+    try:
+        spec = importlib.util.spec_from_file_location(name, root / relative)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module
+    except (OSError, ImportError, ValueError):
+        raise VerificationError("verifier_root_invalid") from None
+
+
+def _contract(root: Path) -> ModuleType:
+    return _driver_module(root, ".github/actions/claude-rollout-fallback/contract.py", "_verified_fallback_contract")
+
+
+def _budget(root: Path) -> ModuleType:
+    return _driver_module(root, ".github/actions/review-invocation-budget/review_invocation_budget.py", "_verified_fallback_budget")
+
+
+def _authenticated_bot(comment: dict[str, object]) -> bool:
+    return (type(comment.get("user")) is dict and comment["user"].get("login") == "github-actions[bot]"
+            and comment["user"].get("type") == "Bot")
+
+
+def _request_evidence(request: VerificationRequest, evidence: EvidenceProvider):
+    contract = _contract(request.automation_root)
+    comments = evidence.issue_comments(request.pr)
+    if type(comments) is not tuple or not all(type(item) is dict for item in comments):
+        raise VerificationError("evidence_invalid")
+    candidates = []
+    for comment in comments:
+        try:
+            parsed = contract.parse_request_body(comment.get("body"))
+        except contract.ContractError:
+            continue
+        if parsed.repository == request.repository and parsed.pr == request.pr:
+            candidates.append((comment, parsed))
+    if len(candidates) != 1:
+        raise VerificationError("request_evidence_invalid")
+    comment, parsed = candidates[0]
+    contract.require_exact_comment(comment, {"comment": comment}, parsed)
+    if parsed.expected_head_sha != request.expected_head or parsed.expected_base_sha != request.expected_base:
+        raise VerificationError("request_evidence_invalid")
+    contract.require_exact_open_same_repository_pr(evidence.pull_request(request.pr), parsed)
+    return contract, comments, comment, parsed
+
+
+def _ledger(request: VerificationRequest, comments):
+    budget = _budget(request.automation_root)
+    candidates = [comment for comment in comments if _authenticated_bot(comment)
+                  and isinstance(comment.get("body"), str)
+                  and comment["body"].startswith(budget.MARKERS["claude"] + "\n")]
+    if len(candidates) != 1:
+        raise VerificationError("budget_evidence_invalid")
+    body = candidates[0]["body"]
+    ledger = budget.parse_ledger(body, repository=request.repository, pr=request.pr, reviewer="claude")
+    if ledger is None:
+        raise VerificationError("budget_evidence_invalid")
+    return ledger
+
+
+def _fallback_invocation(ledger, parsed, comment):
+    candidates = [entry for entry in ledger.invocations if entry.route.kind == "default_branch_rollout_fallback"
+                  and entry.head_sha == parsed.expected_head_sha]
+    if len(candidates) != 1:
+        raise VerificationError("budget_evidence_invalid")
+    entry = candidates[0]
+    route = entry.route
+    if (entry.status != "finalized" or entry.outcome != "success" or entry.call_count != 1
+            or entry.remaining_finding_ids or entry.full_diff_sha256 != parsed.managed_diff_sha256
+            or route.request_comment_id != comment["id"] or route.request_nonce != parsed.nonce
+            or route.original_run_id != parsed.original_run_id or route.original_run_attempt != parsed.original_run_attempt
+            or route.expected_base_sha != parsed.expected_base_sha or route.release_commit != parsed.release_commit
+            or route.managed_diff_sha256 != parsed.managed_diff_sha256
+            or any(item.run_id == parsed.original_run_id for item in ledger.invocations)):
+        raise VerificationError("budget_evidence_invalid")
+    return entry
+
+
+def verify_automatic_failure(request: VerificationRequest, evidence: EvidenceProvider) -> dict[str, object]:
+    try:
+        contract, comments, comment, parsed = _request_evidence(request, evidence)
+        run = evidence.run_attempt(parsed.original_run_id, parsed.original_run_attempt)
+        if any(type(run.get(key)) is not int for key in ("id", "run_attempt")):
+            raise ValueError
+        contract.require_exact_automatic_run(run, parsed)
+        contract.require_causal_order(run, comment)
+        jobs = evidence.run_jobs(parsed.original_run_id, parsed.original_run_attempt)
+        contract.require_failed_before_provider({"total_count": len(jobs), "jobs": list(jobs)})
+        if any(type(job.get("run_attempt")) is not int or job.get("run_id") != parsed.original_run_id
+               or job.get("run_attempt") != parsed.original_run_attempt for job in jobs):
+            raise ValueError
+        job = next(job for job in jobs if re.search(r"(?:^| / )claude-review\Z", job["name"]))
+        check_url = job.get("check_run_url", "")
+        match = re.fullmatch(r"https://api\.github\.com/repos/" + re.escape(request.repository) + r"/check-runs/([1-9][0-9]*)", check_url)
+        if match is None:
+            raise ValueError
+        annotations = evidence.check_annotations(int(match[1]))
+        errors = [item for item in annotations if item.get("annotation_level") == "failure"]
+        if len(errors) != 1 or errors[0].get("message") != "workflow_validation_mismatch":
+            raise ValueError
+        entry = _fallback_invocation(_ledger(request, comments), parsed, comment)
+        return {"canonical_comment_id": entry.route.automatic_comment_id,
+                "admitted_state_sha256": entry.route.automatic_state_sha256,
+                "reason": "workflow_validation_mismatch", "review_execution": "not_performed",
+                "run_attempt": parsed.original_run_attempt, "run_id": parsed.original_run_id, "status": "FAILED"}
+    except Exception:
+        raise VerificationError("automatic_evidence_invalid") from None
+
+
+def verify_fallback_success(request: VerificationRequest, evidence: EvidenceProvider,
+                            automatic: dict[str, object], driver_commit: str) -> dict[str, object]:
+    try:
+        contract, comments, comment, parsed = _request_evidence(request, evidence)
+        entry = _fallback_invocation(_ledger(request, comments), parsed, comment)
+        if (entry.route.automatic_comment_id != automatic["canonical_comment_id"]
+                or entry.route.automatic_state_sha256 != automatic["admitted_state_sha256"]
+                or entry.referenced_workflow_sha != driver_commit):
+            raise ValueError
+        selected = [run for run in evidence.workflow_runs() if run.get("id") == entry.run_id]
+        if len(selected) != 1 or selected[0].get("run_attempt") != entry.run_attempt:
+            raise ValueError
+        run = evidence.run_attempt(entry.run_id, entry.run_attempt)
+        if (type(run.get("id")) is not int or type(run.get("run_attempt")) is not int
+                or run.get("id") != entry.run_id or run.get("run_attempt") != entry.run_attempt
+                or run.get("event") != "issue_comment" or run.get("status") != "completed"
+                or run.get("conclusion") != "success" or run.get("path") != ".github/workflows/claude.yml"
+                or run.get("repository", {}).get("full_name") != request.repository
+                or run.get("actor", {}).get("login") != comment["user"]["login"]
+                or contract._github_time(run.get("created_at")) < contract._github_time(comment.get("created_at"))):
+            raise ValueError
+        references = run.get("referenced_workflows")
+        if type(references) is not list or not 1 <= len(references) <= 2:
+            raise ValueError
+        nested = [ref for ref in references if type(ref) is dict and ref.get("path") == entry.referenced_workflow_path]
+        if len(nested) != 1 or nested[0].get("sha") != driver_commit:
+            raise ValueError
+        for ref in references:
+            if (type(ref) is not dict or ref.get("sha") != driver_commit
+                    or ref.get("path") not in {
+                        f"jhw7500/automation/.github/workflows/claude.yml@{driver_commit}",
+                        f"jhw7500/automation/.github/workflows/claude-code-review.yml@{driver_commit}"}):
+                raise ValueError
+        if len({ref["path"] for ref in references}) != len(references):
+            raise ValueError
+        jobs = evidence.run_jobs(entry.run_id, entry.run_attempt)
+        providers = []
+        for job in jobs:
+            if (type(job.get("run_attempt")) is not int
+                    or job.get("run_id") != entry.run_id or job.get("run_attempt") != entry.run_attempt
+                    or job.get("status") != "completed" or job.get("conclusion") not in {"success", "skipped"}):
+                raise ValueError
+            for step in job.get("steps", []):
+                if step.get("name") in {"Run Claude Code Review", "Run Claude Code"} and step.get("conclusion") != "skipped":
+                    providers.append((job, step))
+        if len(providers) != 1 or providers[0][1].get("name") != "Run Claude Code Review":
+            raise ValueError
+        job, provider = providers[0]
+        if provider.get("status") != "completed" or provider.get("conclusion") != "success":
+            raise ValueError
+        for name in ("Claim Claude review budget", "Finalize Claude review budget"):
+            steps = [step for step in job["steps"] if step.get("name") == name]
+            if len(steps) != 1 or steps[0].get("status") != "completed" or steps[0].get("conclusion") != "success":
+                raise ValueError
+        states = contract._state_comments(list(comments))
+        if len(states) != 1:
+            raise ValueError
+        canonical, state, raw = states[0]
+        route = {"managed_diff_sha256": parsed.managed_diff_sha256, "original_failed_run_id": parsed.original_run_id,
+                 "release_commit": parsed.release_commit, "request_comment_id": comment["id"],
+                 "reviewed_base_sha": parsed.expected_base_sha, "route": "default_branch_rollout_fallback"}
+        if (canonical.get("id") != automatic["canonical_comment_id"]
+                or any(type(state.get(key)) is not int for key in ("schema", "quality_schema", "pr", "run_id", "run_attempt"))
+                or set(state) != (contract.FAILURE_STATE_KEYS - {"failure_reason"}) | {"route"}
+                or state.get("schema") != 3 or state.get("quality_schema") != 1
+                or state.get("reviewer") != "claude" or state.get("pr") != request.pr
+                or state.get("run_id") != entry.run_id or state.get("run_attempt") != entry.run_attempt
+                or state.get("attempt_head") != request.expected_head or state.get("successful_head") != request.expected_head
+                or state.get("attempt_status") != "success" or state.get("review_execution") != "performed"
+                or state.get("diff_mode") != "full" or state.get("full_diff_sha256") != parsed.managed_diff_sha256
+                or state.get("route") != route or state.get("filtered_max_severity") != "none"
+                or any(type(state.get(key)) is not int or state[key] != 0 for key in ("accepted_count", "filtered_count", "normalized_count"))):
+            raise ValueError
+        return {"budget_status": "finalized", "canonical_comment_id": canonical["id"],
+                "canonical_state_sha256": hashlib.sha256(raw).hexdigest(), "driver_commit": driver_commit,
+                "filtered_max_severity": "none", "request_comment_id": comment["id"], "request_nonce": parsed.nonce,
+                "review_execution": "performed", "route": "default_branch_rollout_fallback",
+                "run_attempt": entry.run_attempt, "run_id": entry.run_id, "status": "CLEAN"}
+    except Exception:
+        raise VerificationError("fallback_evidence_invalid") from None
+
+
+def require_required_checks_clean(checks: tuple[dict[str, object], ...]) -> None:
+    if type(checks) is not tuple or any(type(check) is not dict or check.get("status") != "completed"
+            or check.get("conclusion") not in {"success", "neutral", "skipped"} for check in checks):
+        raise VerificationError("required_check_failed")
+
+
+def build_receipt(request: VerificationRequest, fleet: dict[str, object], automatic: dict[str, object],
+                  fallback: dict[str, object], driver_commit: str) -> dict[str, object]:
+    return {"automatic": automatic, "base_sha": request.expected_base, "effective_status": "CLEAN",
+            "fallback": fallback, "fleet": fleet["fleet"], "head_sha": request.expected_head,
+            "managed_diff_sha256": fleet["managed_diff_sha256"], "pr": request.pr,
+            "release_commit": fleet["release_commit"], "repository": request.repository,
+            "schema": 1, "verifier_commit": driver_commit}
+
+
+def verify(request: VerificationRequest, evidence_provider: EvidenceProvider) -> dict[str, object]:
+    validate_request(request)
+    evidence = evidence_provider
+    driver = parse_default_caller_pin(evidence.default_caller())
+    verify_source_root(request.automation_root, driver)
+    modules = load_verified_modules(request.automation_root)
+    fleet = verify_fleet_request(request, evidence, modules)
+    if driver == fleet["release_commit"]:
+        raise VerificationError("driver_pin_invalid")
+    try:
+        _, _, _, parsed = _request_evidence(request, evidence)
+        if parsed.release_commit != fleet["release_commit"] or parsed.managed_diff_sha256 != fleet["managed_diff_sha256"]:
+            raise ValueError
+    except Exception:
+        raise VerificationError("request_evidence_invalid") from None
+    automatic = verify_automatic_failure(request, evidence)
+    fallback = verify_fallback_success(request, evidence, automatic, driver)
+    require_required_checks_clean(evidence.required_checks(request.expected_head))
+    try:
+        contract, _, _, parsed = _request_evidence(request, evidence)
+        observed = evidence.pull_request(request.pr)
+        contract.require_exact_open_same_repository_pr(observed, parsed)
+        rollout = modules.rollout
+        base = fleet["fleet"]["base_branch"]
+        default = fleet["_default_branch"]
+        if (observed["title"] != rollout.pr_title(request.release_ref, base, default)
+                or observed["body"] != rollout.pr_body(request.release_ref, fleet["release_commit"],
+                    fleet["fleet"]["changed_paths"], base, default)
+                or observed["head"]["ref"] != fleet["fleet"]["rollout_branch"]
+                or observed["base"]["ref"] != base
+                or evidence.branch_sha(fleet["fleet"]["rollout_branch"]) != request.expected_head):
+            raise ValueError
+    except Exception:
+        raise VerificationError("fleet_attestation_failed") from None
+    return build_receipt(request, fleet, automatic, fallback, driver)
+
+
+def _unique_json(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError
+        result[key] = value
+    return result
+
+
+class GitHubEvidenceProvider:
+    """Fixed-origin bounded REST reads and disposable object-only Git fetches."""
+
+    def __init__(self, repository: str):
+        if REPOSITORY.fullmatch(repository) is None:
+            raise VerificationError("request_invalid")
+        self.repository = repository
+        self.prefix = "repos/" + repository
+        self.base_branch = None
+        self._cache = {}
+
+    def _json(self, endpoint: str, *, missing: bool = False):
+        if not endpoint.startswith(self.prefix + "/") and endpoint != self.prefix:
+            raise VerificationError("evidence_invalid")
+        environment = {"PATH": "/usr/bin:/bin", "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8",
+                       "GH_HOST": "github.com", "GH_PROMPT_DISABLED": "1"}
+        for key in ("HOME", "GH_TOKEN", "GITHUB_TOKEN", "GH_CONFIG_DIR", "XDG_CONFIG_HOME"):
+            if key in os.environ:
+                environment[key] = os.environ[key]
+        try:
+            result = subprocess.run([str(GITHUB_CLI), "api", "--hostname", "github.com", "--method", "GET",
+                                     "--include", endpoint], env=environment, capture_output=True, timeout=30)
+            raw = result.stdout
+            if len(raw) > 8 * 1024 * 1024:
+                raise ValueError
+            # gh's include header is CRLF on supported releases; normalize only headers.
+            separator = b"\r\n\r\n" if b"\r\n\r\n" in raw else b"\n\n"
+            headers, body = raw.split(separator, 1)
+            status = headers.splitlines()[0].split()[1]
+            if missing and status == b"404":
+                return None
+            if result.returncode or status != b"200":
+                raise ValueError
+            return json.loads(body, object_pairs_hook=_unique_json,
+                              parse_constant=lambda value: (_ for _ in ()).throw(ValueError()))
+        except (OSError, ValueError, IndexError, UnicodeError, subprocess.SubprocessError):
+            raise VerificationError("evidence_read_failed") from None
+
+    def _object(self, endpoint):
+        value = self._json(endpoint)
+        if type(value) is not dict:
+            raise VerificationError("evidence_invalid")
+        return value
+
+    def _pages(self, endpoint, *, key=None, pages=10):
+        if type(pages) is not int or not 1 <= pages <= 10:
+            raise VerificationError("evidence_invalid")
+        collected = []
+        for number in range(1, pages + 1):
+            separator = "&" if "?" in endpoint else "?"
+            response = self._json(f"{endpoint}{separator}per_page=100&page={number}")
+            values = response
+            if key is not None:
+                if type(response) is not dict or type(response.get("total_count")) is not int:
+                    raise VerificationError("evidence_invalid")
+                values = response.get(key)
+            if type(values) is not list or len(values) > 100 or not all(type(item) is dict for item in values):
+                raise VerificationError("evidence_invalid")
+            collected.extend(values)
+            if len(values) < 100:
+                if key is not None and response["total_count"] != len(collected):
+                    raise VerificationError("evidence_invalid")
+                return tuple(collected)
+        raise VerificationError("evidence_overflow")
+
+    def _cached_pages(self, endpoint, *, key=None, pages=10):
+        identity = (endpoint, key, pages)
+        if identity not in self._cache:
+            self._cache[identity] = self._pages(endpoint, key=key, pages=pages)
+        return self._cache[identity]
+
+    def default_caller(self):
+        metadata = self._object(self.prefix)
+        branch = metadata.get("default_branch")
+        if type(branch) is not str or not branch:
+            raise VerificationError("evidence_invalid")
+        sha = self.branch_sha(branch)
+        return self._object(self.prefix + "/contents/.github/workflows/claude.yml?ref=" + sha)
+
+    def branch_sha(self, branch):
+        value = self._object(self.prefix + "/branches/" + quote(branch, safe=""))
+        if type(value.get("commit")) is not dict:
+            raise VerificationError("evidence_invalid")
+        sha = value["commit"].get("sha")
+        if type(sha) is not str or SHA.fullmatch(sha) is None:
+            raise VerificationError("evidence_invalid")
+        return sha
+
+    def pull_request(self, number):
+        if type(number) is not int or number < 1:
+            raise VerificationError("evidence_invalid")
+        result = self._object(self.prefix + f"/pulls/{number}")
+        if (type(result.get("number")) is not int or result["number"] != number
+                or type(result.get("base")) is not dict or type(result["base"].get("ref")) is not str):
+            raise VerificationError("evidence_invalid")
+        self.base_branch = result["base"]["ref"]
+        return result
+
+    def rollout_prs(self, branch):
+        values = self._pages(self.prefix + "/pulls?state=all&head=" + quote(self.repository.split("/")[0] + ":" + branch, safe=""))
+        # List and detail APIs differ in incidental fields. Fetch the detail for each identity.
+        return tuple(self.pull_request(item.get("number")) for item in values)
+
+    def issue_comments(self, number):
+        return self._cached_pages(self.prefix + f"/issues/{number}/comments")
+
+    def run_attempt(self, run_id, attempt):
+        return self._object(self.prefix + f"/actions/runs/{run_id}/attempts/{attempt}")
+
+    def run_jobs(self, run_id, attempt):
+        return self._cached_pages(self.prefix + f"/actions/runs/{run_id}/attempts/{attempt}/jobs", key="jobs", pages=1)
+
+    def check_annotations(self, check_run_id):
+        return self._cached_pages(self.prefix + f"/check-runs/{check_run_id}/annotations")
+
+    def workflow_runs(self):
+        return self._cached_pages(self.prefix + "/actions/workflows/claude.yml/runs?event=issue_comment", key="workflow_runs")
+
+    def required_checks(self, head_sha):
+        try:
+            if type(self.base_branch) is not str or not self.base_branch:
+                raise ValueError
+            branch = quote(self.base_branch, safe="")
+            protection = self._json(self.prefix + "/branches/" + branch + "/protection/required_status_checks", missing=True)
+            required = set()
+            if protection is not None:
+                if type(protection) is not dict or type(protection.get("checks")) is not list or len(protection["checks"]) >= 100:
+                    raise ValueError
+                for item in protection["checks"]:
+                    required.add((item["context"], item.get("app_id")))
+                if type(protection.get("contexts")) is not list or len(protection["contexts"]) >= 100:
+                    raise ValueError
+                for name in protection["contexts"]:
+                    if not any(context == name for context, _ in required):
+                        required.add((name, None))
+            rules = self._pages(self.prefix + "/rules/branches/" + branch)
+            for rule in rules:
+                if rule.get("type") in {"workflows", "required_workflows"}:
+                    # Required workflow identities cannot safely be inferred from
+                    # status-context names; leave the native gate closed.
+                    raise ValueError
+                if rule.get("type") == "required_status_checks":
+                    contexts = rule["parameters"]["required_status_checks"]
+                    if type(contexts) is not list or len(contexts) >= 100:
+                        raise ValueError
+                    required.update((item["context"], item.get("integration_id")) for item in contexts)
+            if any(type(name) is not str or not name or (app is not None and type(app) is not int) for name, app in required):
+                raise ValueError
+            checks = self._pages(self.prefix + f"/commits/{head_sha}/check-runs?filter=latest", key="check_runs")
+            statuses = self._pages(self.prefix + f"/commits/{head_sha}/statuses")
+            result = []
+            for name, app in sorted(required, key=lambda item: (item[0], str(item[1]))):
+                matches = [check for check in checks if check.get("name") == name
+                           and (app in {None, -1} or check.get("app", {}).get("id") == app)]
+                if len(matches) == 1:
+                    if matches[0].get("head_sha") != head_sha:
+                        raise ValueError
+                    result.append(matches[0])
+                elif matches:
+                    raise ValueError
+                legacy = [status for status in statuses if status.get("context") == name]
+                if app in {None, -1} and legacy:
+                    if legacy[0].get("state") != "success":
+                        raise ValueError
+                    result.append({"name": name, "status": "completed", "conclusion": "success"})
+                elif not matches:
+                    raise ValueError
+            return tuple(result)
+        except Exception:
+            raise VerificationError("required_check_failed") from None
+
+    @contextmanager
+    def consumer_snapshot(self, request, modules):
+        try:
+            metadata = self._object(self.prefix)
+            pr = self.pull_request(request.pr)
+            default = metadata["default_branch"]
+            base_branch = pr["base"]["ref"]
+            if pr["base"]["sha"] != request.expected_base:
+                raise ValueError
+            with tempfile.TemporaryDirectory(prefix="claude-fleet-") as temporary:
+                root = Path(temporary) / self.repository.split("/", 1)[1]
+                root.mkdir()
+                git_stdout(root, "init", "--quiet", "--template=")
+                git_stdout(root, "fetch", "--no-tags", "--no-recurse-submodules",
+                           "https://github.com/" + self.repository + ".git", request.expected_base, request.expected_head)
+                # Materialize only regular .github data directly from objects. No
+                # checkout: consumer attributes, filters, hooks, and binaries never run.
+                for record in filter(None, git_stdout(root, "ls-tree", "-rz", request.expected_base, "--", ".github").split("\0")):
+                    metadata_record, relative = record.split("\t", 1)
+                    mode, kind, oid = metadata_record.split()
+                    parts = Path(relative).parts
+                    if mode != "100644" or kind != "blob" or not parts or parts[0] != ".github" or ".." in parts:
+                        raise ValueError
+                    path = root / relative
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_bytes(_git_bytes(root, "cat-file", "blob", oid))
+                secrets = self._pages(self.prefix + "/actions/secrets", key="secrets")
+                variables = self._pages(self.prefix + "/actions/variables", key="variables")
+                labels = self._pages(self.prefix + "/labels")
+                yield modules.rollout.RepositorySnapshot(root, default, request.expected_base,
+                    frozenset(item["name"] for item in secrets), frozenset(item["name"] for item in variables),
+                    base_branch=base_branch, label_names=frozenset(item["name"] for item in labels))
+        except Exception:
+            raise VerificationError("fleet_attestation_failed") from None
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    for name in ("automation-root", "release-ref", "remote", "repository", "pr",
+                 "expected-head", "expected-base", "output"):
+        result.add_argument("--" + name, required=True,
+                            type=Path if name in {"automation-root", "output"} else int if name == "pr" else str)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = parser().parse_args(argv)
+    try:
+        request = VerificationRequest(**vars(arguments))
+        validate_request(request)
+        require_private_output_parent(request.output.parent)
+        if not (sys.flags.isolated and sys.flags.no_site and sys.dont_write_bytecode):
+            raise VerificationError("verifier_root_invalid")
+        receipt = verify(request, GitHubEvidenceProvider(request.repository))
+        write_receipt(request.output, receipt)
+        return 0
+    except VerificationError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_claude_rollout_fallback.py
+++ b/scripts/verify_claude_rollout_fallback.py
@@ -200,14 +200,68 @@ def verify_source_root(root: Path, driver_commit: str) -> None:
         raise VerificationError("verifier_root_invalid") from None
 
 
-def require_trusted_dependency_directory(path: Path) -> None:
+def require_trusted_dependency_directory(
+    path: Path, *, allowed_owners: frozenset[int] = frozenset({0})
+) -> None:
     try:
+        if (
+            not isinstance(allowed_owners, frozenset)
+            or 0 not in allowed_owners
+            or any(
+                isinstance(owner, bool) or not isinstance(owner, int) or owner < 0
+                for owner in allowed_owners
+            )
+        ):
+            raise ValueError
         _no_symlinks(path)
         for node in (path, *path.parents):
             observed = node.lstat()
-            if not stat.S_ISDIR(observed.st_mode) or observed.st_uid != 0 or observed.st_mode & 0o022:
+            mode = stat.S_IMODE(observed.st_mode)
+            trusted_sticky = observed.st_uid == 0 and bool(mode & stat.S_ISVTX)
+            if (
+                not stat.S_ISDIR(observed.st_mode)
+                or observed.st_uid not in allowed_owners
+                or (mode & 0o022 and not trusted_sticky)
+            ):
                 raise ValueError
     except (OSError, ValueError):
+        raise VerificationError("verifier_dependency_invalid") from None
+
+
+def trusted_runtime_dependency_owners(path: Path) -> frozenset[int]:
+    """Trust the owner of the interpreter prefix that is already executing us."""
+
+    try:
+        _no_symlinks(path)
+        executable = Path(os.path.realpath(sys.executable))
+        _no_symlinks(executable)
+        observed = executable.lstat()
+        mode = stat.S_IMODE(observed.st_mode)
+        if (
+            not stat.S_ISREG(observed.st_mode)
+            or observed.st_uid not in {0, os.getuid()}
+            or mode & 0o022
+        ):
+            raise ValueError
+        # setup-python may keep a root-owned executable inside a prefix whose
+        # packages are installed by the isolated runner account. The executing
+        # interpreter and its configured prefix are already part of the TCB.
+        owners = frozenset({0, os.getuid(), observed.st_uid})
+        roots: list[Path] = []
+        for value in (sys.prefix, sys.base_prefix):
+            root = Path(value).resolve(strict=True)
+            if root not in roots:
+                roots.append(root)
+        for root in roots:
+            if not executable.is_relative_to(root) or not path.is_relative_to(root):
+                continue
+            require_trusted_dependency_directory(root, allowed_owners=owners)
+            require_trusted_dependency_directory(
+                executable.parent, allowed_owners=owners
+            )
+            return owners
+        raise ValueError
+    except (OSError, RuntimeError, ValueError, VerificationError):
         raise VerificationError("verifier_dependency_invalid") from None
 
 
@@ -219,7 +273,8 @@ def load_trusted_yaml() -> None:
         parent = Path(candidate)
         if not parent.exists():
             continue
-        require_trusted_dependency_directory(parent)
+        allowed_owners = trusted_runtime_dependency_owners(parent)
+        require_trusted_dependency_directory(parent, allowed_owners=allowed_owners)
         specification = importlib.machinery.PathFinder.find_spec("yaml", [str(parent)])
         if specification is None:
             continue
@@ -228,10 +283,12 @@ def load_trusted_yaml() -> None:
             if not origin.is_relative_to(parent) or specification.submodule_search_locations is None:
                 raise ValueError
             package = origin.parent
-            require_trusted_dependency_directory(package)
+            require_trusted_dependency_directory(
+                package, allowed_owners=allowed_owners
+            )
             for node in package.rglob("*"):
                 observed = node.lstat()
-                if (stat.S_ISLNK(observed.st_mode) or observed.st_uid != 0
+                if (stat.S_ISLNK(observed.st_mode) or observed.st_uid not in allowed_owners
                         or observed.st_mode & 0o022
                         or not (stat.S_ISREG(observed.st_mode) or stat.S_ISDIR(observed.st_mode))):
                     raise ValueError

--- a/scripts/verify_claude_rollout_fallback.py
+++ b/scripts/verify_claude_rollout_fallback.py
@@ -90,7 +90,7 @@ class EvidenceProvider(Protocol):
     def consumer_snapshot(self, request: VerificationRequest, modules: VerifiedModules): ...
 
 
-def _git_bytes(root: Path, *args: str) -> bytes:
+def _git_environment() -> dict[str, str]:
     environment = {
         "PATH": "/usr/bin:/bin", "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8",
         "GIT_OPTIONAL_LOCKS": "0", "GIT_TERMINAL_PROMPT": "0",
@@ -98,14 +98,30 @@ def _git_bytes(root: Path, *args: str) -> bytes:
         "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_GLOBAL": "/dev/null",
         "GIT_NO_REPLACE_OBJECTS": "1",
     }
+    for name in ("HOME", "GH_TOKEN", "GITHUB_TOKEN", "GH_CONFIG_DIR", "XDG_CONFIG_HOME"):
+        if name in os.environ:
+            environment[name] = os.environ[name]
+    settings = (("core.hooksPath", "/dev/null"), ("core.fsmonitor", "false"),
+                ("submodule.recurse", "false"), ("core.untrackedCache", "false"))
+    environment["GIT_CONFIG_COUNT"] = str(len(settings))
+    for index, (key, value) in enumerate(settings):
+        environment[f"GIT_CONFIG_KEY_{index}"] = key
+        environment[f"GIT_CONFIG_VALUE_{index}"] = value
+    return environment
+
+
+def _git_bytes(root: Path, *args: str) -> bytes:
+    environment = _git_environment()
     if args and args[0] == "fetch":
         # Only the fresh disposable repository uses this path. Supply credentials
         # in the child environment, never command arguments or diagnostics.
         token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
         if token:
             encoded = base64.b64encode(("x-access-token:" + token).encode()).decode()
-            environment.update(GIT_CONFIG_COUNT="1", GIT_CONFIG_KEY_0="http.https://github.com/.extraheader",
-                               GIT_CONFIG_VALUE_0="AUTHORIZATION: basic " + encoded)
+            index = int(environment["GIT_CONFIG_COUNT"])
+            environment["GIT_CONFIG_COUNT"] = str(index + 1)
+            environment[f"GIT_CONFIG_KEY_{index}"] = "http.https://github.com/.extraheader"
+            environment[f"GIT_CONFIG_VALUE_{index}"] = "AUTHORIZATION: basic " + encoded
     try:
         result = subprocess.run(
             ["/usr/bin/git", "-c", "core.hooksPath=/dev/null", "-c", "core.fsmonitor=false",
@@ -250,57 +266,131 @@ def canonical_json_bytes(payload: dict[str, object]) -> bytes:
                        allow_nan=False) + "\n").encode("ascii")
 
 
-def require_private_output_parent(path: Path) -> None:
-    try:
-        _no_symlinks(path)
-        observed = path.lstat()
-        if (not stat.S_ISDIR(observed.st_mode) or observed.st_uid != os.getuid()
-                or stat.S_IMODE(observed.st_mode) != 0o700):
+@contextmanager
+def _private_output_directory(path: Path):
+    descriptors = []
+    links = []
+
+    def validate_directory(descriptor, *, final=False):
+        observed = os.fstat(descriptor)
+        mode = stat.S_IMODE(observed.st_mode)
+        trusted_sticky = observed.st_uid == 0 and bool(mode & stat.S_ISVTX)
+        if (not stat.S_ISDIR(observed.st_mode) or observed.st_uid not in {0, os.getuid()}
+                or (mode & 0o022 and not trusted_sticky)
+                or (final and (observed.st_uid != os.getuid() or mode != 0o700))):
             raise ValueError
-    except (OSError, ValueError):
+        return observed
+
+    def check_identity():
+        try:
+            for descriptor in descriptors:
+                validate_directory(descriptor, final=descriptor == descriptors[-1])
+            for parent, name, descriptor in links:
+                observed = os.stat(name, dir_fd=parent, follow_symlinks=False)
+                opened = os.fstat(descriptor)
+                if (not stat.S_ISDIR(observed.st_mode)
+                        or (observed.st_dev, observed.st_ino) != (opened.st_dev, opened.st_ino)):
+                    raise ValueError
+        except (OSError, ValueError):
+            raise VerificationError("receipt_parent_invalid") from None
+
+    try:
+        if not path.is_absolute() or ".." in path.parts:
+            raise ValueError
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+        descriptors.append(os.open("/", flags))
+        validate_directory(descriptors[-1])
+        for name in path.parts[1:]:
+            parent = descriptors[-1]
+            descriptor = os.open(name, flags, dir_fd=parent)
+            descriptors.append(descriptor)
+            links.append((parent, name, descriptor))
+            validate_directory(descriptor)
+        check_identity()
+        yield descriptors[-1], check_identity
+    except (OSError, ValueError) as error:
+        if isinstance(error, VerificationError):
+            raise
         raise VerificationError("receipt_parent_invalid") from None
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+
+
+def require_private_output_parent(path: Path) -> None:
+    with _private_output_directory(path):
+        pass
+
+
+def _require_private_file_stat(observed) -> None:
+    if (not stat.S_ISREG(observed.st_mode) or observed.st_uid != os.getuid()
+            or stat.S_IMODE(observed.st_mode) != 0o600):
+        raise VerificationError("receipt_file_invalid")
 
 
 def require_private_regular_owned(path: Path) -> None:
     try:
-        observed = path.lstat()
-        if (not stat.S_ISREG(observed.st_mode) or observed.st_uid != os.getuid()
-                or stat.S_IMODE(observed.st_mode) != 0o600):
-            raise ValueError
+        with _private_output_directory(path.parent) as (directory, check_identity):
+            _require_private_file_stat(os.stat(path.name, dir_fd=directory, follow_symlinks=False))
+            check_identity()
     except (OSError, ValueError):
         raise VerificationError("receipt_file_invalid") from None
 
 
 def write_receipt(path: Path, payload: dict[str, object]) -> None:
-    require_private_output_parent(path.parent)
-    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    created = False
-    try:
+    with _private_output_directory(path.parent) as (directory, check_identity):
+        temporary = f".{path.name}.{os.getpid()}.tmp"
+        identity = None
+        published = False
+
+        def remove_owned(name):
+            try:
+                observed = os.stat(name, dir_fd=directory, follow_symlinks=False)
+                if (observed.st_dev, observed.st_ino) == identity:
+                    os.unlink(name, dir_fd=directory)
+            except FileNotFoundError:
+                pass
+
         try:
-            path.lstat()
-        except FileNotFoundError:
-            pass
-        else:
-            raise VerificationError("receipt_path_exists")
-        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
-        created = True
-        with os.fdopen(descriptor, "wb") as stream:
-            stream.write(canonical_json_bytes(payload))
-            os.fchmod(stream.fileno(), 0o600)
-            stream.flush()
-            os.fsync(stream.fileno())
-        try:
-            os.link(temporary, path, follow_symlinks=False)
-        except FileExistsError:
-            raise VerificationError("receipt_path_exists") from None
-    except (OSError, ValueError) as error:
-        if isinstance(error, VerificationError):
-            raise
-        raise VerificationError("receipt_write_failed") from None
-    finally:
-        if created:
-            temporary.unlink(missing_ok=True)
-    require_private_regular_owned(path)
+            try:
+                os.stat(path.name, dir_fd=directory, follow_symlinks=False)
+            except FileNotFoundError:
+                pass
+            else:
+                raise VerificationError("receipt_path_exists")
+            check_identity()
+            descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                                 0o600, dir_fd=directory)
+            with os.fdopen(descriptor, "wb") as stream:
+                observed = os.fstat(stream.fileno())
+                identity = (observed.st_dev, observed.st_ino)
+                stream.write(canonical_json_bytes(payload))
+                os.fchmod(stream.fileno(), 0o600)
+                stream.flush()
+                os.fsync(stream.fileno())
+            check_identity()
+            try:
+                os.link(temporary, path.name, src_dir_fd=directory, dst_dir_fd=directory,
+                        follow_symlinks=False)
+            except FileExistsError:
+                raise VerificationError("receipt_path_exists") from None
+            published = True
+            check_identity()
+            remove_owned(temporary)
+            observed = os.stat(path.name, dir_fd=directory, follow_symlinks=False)
+            _require_private_file_stat(observed)
+            if (observed.st_dev, observed.st_ino) != identity:
+                raise VerificationError("receipt_file_invalid")
+            check_identity()
+        except (OSError, ValueError) as error:
+            if published:
+                remove_owned(path.name)
+            if isinstance(error, VerificationError):
+                raise
+            raise VerificationError("receipt_write_failed") from None
+        finally:
+            if identity is not None:
+                remove_owned(temporary)
 
 
 def validate_request(request: VerificationRequest) -> None:
@@ -316,21 +406,21 @@ def validate_request(request: VerificationRequest) -> None:
 
 
 @contextmanager
-def _fixed_tool_path():
-    previous = os.environ.get("PATH")
-    os.environ["PATH"] = "/usr/bin:/bin"
+def _isolated_git_environment():
+    previous = dict(os.environ)
+    environment = _git_environment()
+    os.environ.clear()
+    os.environ.update(environment)
     try:
         yield
     finally:
-        if previous is None:
-            os.environ.pop("PATH", None)
-        else:
-            os.environ["PATH"] = previous
+        os.environ.clear()
+        os.environ.update(previous)
 
 
 def verify_fleet_request(request: VerificationRequest, evidence: EvidenceProvider,
                          modules: VerifiedModules) -> dict[str, object]:
-    with _fixed_tool_path():
+    with _isolated_git_environment():
         return _verify_fleet_request(request, evidence, modules)
 
 
@@ -386,6 +476,74 @@ def _verify_fleet_request(request, evidence, modules):
         raise VerificationError("fleet_attestation_failed") from None
 
 
+def _caller_scalar(value: str) -> str:
+    """Recognize the single-line scalar subset used by generated callers.
+
+    This is deliberately not a general YAML loader. Block/multiline scalars,
+    tags, aliases, anchors, flow mappings and complex keys are refused before
+    any installed dependency or checkout can become executable authority.
+    """
+    if value.startswith('"'):
+        scalar, end = json.JSONDecoder().raw_decode(value)
+        if type(scalar) is not str or value[end:].strip() and not value[end:].lstrip().startswith("#"):
+            raise ValueError
+        return scalar
+    if value.startswith("'"):
+        match = re.fullmatch(r"'((?:[^']|'')*)'(?:[ ]*#[^\n]*)?[ ]*", value)
+        if match is None:
+            raise ValueError
+        return match[1].replace("''", "'")
+    scalar = re.split(r" +#", value, maxsplit=1)[0].rstrip()
+    if scalar.startswith("["):
+        if re.fullmatch(r"\[[A-Za-z_]+(?:, *[A-Za-z_]+)*\]", scalar) is None:
+            raise ValueError
+    elif not scalar or scalar[0] in "!&*|>{}%@`" or ": " in scalar:
+        raise ValueError
+    return scalar
+
+
+def _caller_mapping(content: str) -> dict[str, object]:
+    document: dict[str, object] = {}
+    levels = [(-2, document)]
+    previous_indent = -2
+    previous_value: object = document
+    if any((ord(character) < 32 and character != "\n") or character in "\u0085\u2028\u2029"
+           for character in content):
+        raise ValueError
+    for line in content.split("\n"):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        match = re.fullmatch(r"( *)([A-Za-z_][A-Za-z0-9_-]*|'[A-Za-z_][A-Za-z0-9_-]*'|\"[A-Za-z_][A-Za-z0-9_-]*\"):(?: +(.*))?", line)
+        if match is None:
+            raise ValueError
+        indent = len(match[1])
+        if indent % 2 or indent > previous_indent + 2:
+            raise ValueError
+        if indent > previous_indent:
+            if type(previous_value) is not dict:
+                raise ValueError
+            levels.append((previous_indent, previous_value))
+        while levels[-1][0] >= indent:
+            levels.pop()
+        mapping = levels[-1][1]
+        key = match[2].strip("\"'")
+        if key in mapping:
+            raise ValueError
+        raw = (match[3] or "").strip()
+        value = {} if not raw or raw.startswith("#") else _caller_scalar(raw)
+        mapping[key] = value
+        previous_indent, previous_value = indent, value
+    if not set(document) <= {"name", "run-name", "on", "jobs", "permissions", "concurrency"}:
+        raise ValueError
+    jobs = document.get("jobs")
+    if type(jobs) is not dict or set(jobs) != {"claude"}:
+        raise ValueError
+    job = jobs["claude"]
+    if type(job) is not dict or not set(job) <= {"name", "if", "uses", "with", "secrets", "permissions"}:
+        raise ValueError
+    return document
+
+
 def parse_default_caller_pin(document: object) -> str:
     try:
         if (type(document) is not dict or document.get("type") != "file"
@@ -395,11 +553,14 @@ def parse_default_caller_pin(document: object) -> str:
                 or type(document.get("content")) is not str or len(document["content"]) > 100000):
             raise ValueError
         content = base64.b64decode("".join(document["content"].split()), validate=True).decode("utf-8")
-        pins = re.findall(r"^    uses: jhw7500/automation/\.github/workflows/claude\.yml@([0-9a-f]{40})(?: +#[^\r\n]*)?$",
-                          content, re.MULTILINE)
-        if len(pins) != 1:
+        caller = _caller_mapping(content)
+        uses = caller["jobs"]["claude"].get("uses")
+        if type(uses) is not str:
             raise ValueError
-        return pins[0]
+        pin = re.fullmatch(r"jhw7500/automation/\.github/workflows/claude\.yml@([0-9a-f]{40})", uses)
+        if pin is None:
+            raise ValueError
+        return pin[1]
     except (ValueError, TypeError, UnicodeError):
         raise VerificationError("driver_pin_invalid") from None
 
@@ -809,8 +970,16 @@ class GitHubEvidenceProvider:
             statuses = self._pages(self.prefix + f"/commits/{head_sha}/statuses")
             result = []
             for name, app in sorted(required, key=lambda item: (item[0], str(item[1]))):
-                matches = [check for check in checks if check.get("name") == name
-                           and (app in {None, -1} or check.get("app", {}).get("id") == app)]
+                matches = []
+                for check in checks:
+                    if check.get("name") != name:
+                        continue
+                    identity = check.get("app")
+                    if (type(identity) is not dict or type(identity.get("id")) is not int
+                            or identity["id"] <= 0):
+                        raise ValueError
+                    if app in {None, -1} or identity["id"] == app:
+                        matches.append(check)
                 if len(matches) == 1:
                     if matches[0].get("head_sha") != head_sha:
                         raise ValueError

--- a/scripts/verify_claude_rollout_fallback.py
+++ b/scripts/verify_claude_rollout_fallback.py
@@ -74,6 +74,7 @@ class VerifiedModules:
     release_bundle: ModuleType
     inventory: ModuleType
     rollout: ModuleType
+    canonicalizer: ModuleType
 
 
 class EvidenceProvider(Protocol):
@@ -246,6 +247,34 @@ def load_trusted_yaml() -> None:
     raise VerificationError("verifier_dependency_invalid")
 
 
+def _load_verified_canonicalizer(root: Path) -> ModuleType:
+    canonicalizer_root = root / ".github/actions/canonicalize-review"
+
+    def load_exact(name: str, filename: str) -> ModuleType:
+        path = canonicalizer_root / filename
+        existing = sys.modules.get(name)
+        if existing is not None:
+            if Path(existing.__file__) != path:
+                raise ImportError
+            return existing
+        specification = importlib.util.spec_from_file_location(name, path)
+        if specification is None or specification.loader is None:
+            raise ImportError
+        module = importlib.util.module_from_spec(specification)
+        sys.modules[name] = module
+        try:
+            specification.loader.exec_module(module)
+        except BaseException:
+            sys.modules.pop(name, None)
+            raise
+        if Path(module.__file__) != path:
+            raise ImportError
+        return module
+
+    load_exact("review_scope", "review_scope.py")
+    return load_exact("canonicalize_review", "canonicalize_review.py")
+
+
 def load_verified_modules(root: Path) -> VerifiedModules:
     sys.dont_write_bytecode = True
     sys.path.insert(0, str(root))
@@ -256,7 +285,7 @@ def load_verified_modules(root: Path) -> VerifiedModules:
         for module in modules:
             if not Path(module.__file__).is_relative_to(root):
                 raise ImportError
-        return VerifiedModules(*modules)
+        return VerifiedModules(*modules, _load_verified_canonicalizer(root))
     except (ImportError, OSError, ValueError):
         raise VerificationError("verifier_root_invalid") from None
 
@@ -675,8 +704,44 @@ def verify_automatic_failure(request: VerificationRequest, evidence: EvidencePro
         raise VerificationError("automatic_evidence_invalid") from None
 
 
+def _require_canonical_success_document(
+        canonicalizer: ModuleType, contract: ModuleType, request: VerificationRequest,
+        canonical: dict[str, object], state: dict[str, object], raw: bytes) -> None:
+    body = canonical.get("body")
+    if not isinstance(body, str):
+        raise ValueError
+    metadata = "\n".join((
+        "- Status: success",
+        "- Execution: performed",
+        f"- Run: https://github.com/{request.repository}/actions/runs/{state['run_id']}",
+        f"- Reviewed: {state['successful_head']}",
+        f"- Validation: accepted={state['accepted_count']}; filtered={state['filtered_count']}; "
+        f"normalized={state['normalized_count']}; filtered_max={state['filtered_max_severity']}",
+    ))
+    prefix = (
+        f"{contract.AUTOMATIC_HEADER}\n{contract.AUTOMATIC_MARKER}\n"
+        f"<!-- automation-state:{raw.decode('utf-8', 'strict')} -->\n\n{metadata}\n\n"
+    )
+    if not body.startswith(prefix):
+        raise ValueError
+    document = body[len(prefix):]
+    sections = canonicalizer._parse_document(document)
+    new = [canonicalizer._parse_prior_active(block, "claude")
+           for block in sections["New findings"]]
+    still_open = [canonicalizer._parse_prior_active(block, "claude")
+                  for block in sections["Still open"]]
+    resolved = [canonicalizer._validate_prior_closed(block)
+                for block in sections["Resolved"]]
+    retracted = [canonicalizer._validate_prior_closed(block)
+                 for block in sections["Retracted"]]
+    rendered = canonicalizer._render_document(new, still_open, resolved, retracted)
+    if rendered != document or len(new) + len(still_open) != state["accepted_count"]:
+        raise ValueError
+
+
 def verify_fallback_success(request: VerificationRequest, evidence: EvidenceProvider,
-                            automatic: dict[str, object], driver_commit: str) -> dict[str, object]:
+                            automatic: dict[str, object], driver_commit: str,
+                            canonicalizer: ModuleType) -> dict[str, object]:
     try:
         contract, comments, comment, parsed = _request_evidence(request, evidence)
         entry = _fallback_invocation(_ledger(request, comments), parsed, comment)
@@ -748,6 +813,9 @@ def verify_fallback_success(request: VerificationRequest, evidence: EvidenceProv
                 or state.get("route") != route or state.get("filtered_max_severity") != "none"
                 or any(type(state.get(key)) is not int or state[key] != 0 for key in ("accepted_count", "filtered_count", "normalized_count"))):
             raise ValueError
+        _require_canonical_success_document(
+            canonicalizer, contract, request, canonical, state, raw,
+        )
         return {"budget_status": "finalized", "canonical_comment_id": canonical["id"],
                 "canonical_state_sha256": hashlib.sha256(raw).hexdigest(), "driver_commit": driver_commit,
                 "filtered_max_severity": "none", "request_comment_id": comment["id"], "request_nonce": parsed.nonce,
@@ -788,7 +856,9 @@ def verify(request: VerificationRequest, evidence_provider: EvidenceProvider) ->
     except Exception:
         raise VerificationError("request_evidence_invalid") from None
     automatic = verify_automatic_failure(request, evidence)
-    fallback = verify_fallback_success(request, evidence, automatic, driver)
+    fallback = verify_fallback_success(
+        request, evidence, automatic, driver, modules.canonicalizer,
+    )
     require_required_checks_clean(evidence.required_checks(request.expected_head))
     try:
         contract, _, _, parsed = _request_evidence(request, evidence)

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -7601,9 +7601,9 @@ def _verify_opencode_recovery(tree: VerifiedCommitTree, ref: str) -> None:
 EXPECTED_CLAUDE_FALLBACK_SHA256 = {
     ".github/actions/claude-rollout-fallback/action.yml": "ee4b8e6b88ebfc1d0691e032da93b03ba8268fac1bd9377a26554d8200621c0a",
     ".github/actions/claude-rollout-fallback/contract.py": "ae39e0f9c0a1faa6831559c93150fca7f768fbaa0257aade70f045abd0eafff6",
-    "scripts/verify_claude_rollout_fallback.py": "281d443f4ebcc1dcd1f7db91abb0df3f31bc786527b6e0e0d4619c53d11f553e",
+    "scripts/verify_claude_rollout_fallback.py": "22567889d6d0ae0a4158e0d886d36eaceba52ceb688346ef284736eed5075eb4",
     ".github/actions/review-invocation-budget/action.yml": "c05acbba8cac7e952867706a181eccaa25bc4f7baf720c5562dcbb71d1a04c90",
-    ".github/actions/review-invocation-budget/review_invocation_budget.py": "64731d5c61c4d2a5109a738839589d3f419f1215030eff41b8ba608f8654b876",
+    ".github/actions/review-invocation-budget/review_invocation_budget.py": "3f1f140b1b95fcc24618851e3f196efca6fe7bb259e244d86a4e972b5c681851",
     ".github/workflows/claude.yml": "bb111fd319a6449f8f56cbe22a20572b662525f9f4a7765bc46a415bba5f5881",
     ".github/workflows/claude-code-review.yml": "e9ab0aafc14b21e5eb6780ad80b1ca3c3766e5f8f0cc5b60700cfe88eb18ab81",
     ".github/workflows/opencode-auto-review.yml": "ca6cbf2b1f1c9c57f524c45d4de0c863ac2bb249d0e261bbcf1da7e2017c5ea1",
@@ -7614,9 +7614,9 @@ EXPECTED_CLAUDE_FALLBACK_SHA256 = {
 EXPECTED_CLAUDE_FALLBACK_PARSED_SHA256 = {
     ".github/actions/claude-rollout-fallback/action.yml": "fa6b723778608c90683a9cd49bd64229b4f1bc5ad10845978be51e605f6ef894",
     ".github/actions/claude-rollout-fallback/contract.py": "b2b1c32742bab2642b24ff6e20fd9525432610721ce4e55b501c8255aa09a121",
-    "scripts/verify_claude_rollout_fallback.py": "65425e217b6574ff6af2cbc06c0f1fa422a51ad63b6102b2e6cd14915b2f62dd",
+    "scripts/verify_claude_rollout_fallback.py": "6daa78d4135a474e1c85254841a0cce38e1998f00aa2cc6ce2fc1f8a88ddf5d7",
     ".github/actions/review-invocation-budget/action.yml": "4a346ba8d26ea88efe5cc0dfa9f33f080ac8167cf777156d4eef635f1293b8ed",
-    ".github/actions/review-invocation-budget/review_invocation_budget.py": "a98dd0b04614ae1094e5fd8534ae8b2d27e117596fbaeac397d0e604158a588c",
+    ".github/actions/review-invocation-budget/review_invocation_budget.py": "05dd0f27335431fea106d9c84debfa60b39696324eb6474c3b0f58db31695dde",
     ".github/workflows/claude.yml": "5781ef1db5e22f83ed07fc83fabe0beb615544a1412e01b2b8dabfd5f06593ab",
     ".github/workflows/claude-code-review.yml": "130a3ee4164a2561ce6554e1fd6ddac25de11c734e7ec9504c8980841339407f",
     ".github/workflows/opencode-auto-review.yml": "da90fcad95d03f2b51120447edcf187eeb5fbdaa050ded885bb9c9907f3d7f9e",

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -7601,7 +7601,7 @@ def _verify_opencode_recovery(tree: VerifiedCommitTree, ref: str) -> None:
 EXPECTED_CLAUDE_FALLBACK_SHA256 = {
     ".github/actions/claude-rollout-fallback/action.yml": "ee4b8e6b88ebfc1d0691e032da93b03ba8268fac1bd9377a26554d8200621c0a",
     ".github/actions/claude-rollout-fallback/contract.py": "ae39e0f9c0a1faa6831559c93150fca7f768fbaa0257aade70f045abd0eafff6",
-    "scripts/verify_claude_rollout_fallback.py": "22567889d6d0ae0a4158e0d886d36eaceba52ceb688346ef284736eed5075eb4",
+    "scripts/verify_claude_rollout_fallback.py": "91b986a63ec0ab97d072b9b7a906b2191d6a4de4adae8025fc5d4855fab883f5",
     ".github/actions/review-invocation-budget/action.yml": "c05acbba8cac7e952867706a181eccaa25bc4f7baf720c5562dcbb71d1a04c90",
     ".github/actions/review-invocation-budget/review_invocation_budget.py": "3f1f140b1b95fcc24618851e3f196efca6fe7bb259e244d86a4e972b5c681851",
     ".github/workflows/claude.yml": "bb111fd319a6449f8f56cbe22a20572b662525f9f4a7765bc46a415bba5f5881",
@@ -7614,7 +7614,7 @@ EXPECTED_CLAUDE_FALLBACK_SHA256 = {
 EXPECTED_CLAUDE_FALLBACK_PARSED_SHA256 = {
     ".github/actions/claude-rollout-fallback/action.yml": "fa6b723778608c90683a9cd49bd64229b4f1bc5ad10845978be51e605f6ef894",
     ".github/actions/claude-rollout-fallback/contract.py": "b2b1c32742bab2642b24ff6e20fd9525432610721ce4e55b501c8255aa09a121",
-    "scripts/verify_claude_rollout_fallback.py": "6daa78d4135a474e1c85254841a0cce38e1998f00aa2cc6ce2fc1f8a88ddf5d7",
+    "scripts/verify_claude_rollout_fallback.py": "76d20b6674e4323c4971b0c27cbbac35c0641e363856d022fdbcb43ac71ce2f2",
     ".github/actions/review-invocation-budget/action.yml": "4a346ba8d26ea88efe5cc0dfa9f33f080ac8167cf777156d4eef635f1293b8ed",
     ".github/actions/review-invocation-budget/review_invocation_budget.py": "05dd0f27335431fea106d9c84debfa60b39696324eb6474c3b0f58db31695dde",
     ".github/workflows/claude.yml": "5781ef1db5e22f83ed07fc83fabe0beb615544a1412e01b2b8dabfd5f06593ab",

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -61,6 +61,7 @@ from scripts.workflow_release_inventory import (
     release_supports_expanded_review_budget,
     release_supports_claude_workflow_validation,
     release_supports_opencode_recovery,
+    release_supports_claude_rollout_fallback,
     release_retires_manual_pr_review,
     release_supports_same_head_cancel_guard,
     release_supports_review_policy,
@@ -2590,6 +2591,7 @@ def verify_opencode_runtime(
         EXPECTED_OPENCODE_CONTEXT_BUDGET_WORKFLOW_SHA256["opencode"],
         EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256["opencode"],
         EXPECTED_OPENCODE_RECOVERY_WORKFLOW_SHA256["opencode"],
+        EXPECTED_CLAUDE_FALLBACK_SHA256[".github/workflows/opencode-auto-review.yml"],
     }
     initial_validation_argument = " initial" if current_diagnostics_contract else ""
     repair_validation_argument = " repair" if current_diagnostics_contract else ""
@@ -2630,6 +2632,7 @@ def verify_opencode_runtime(
             EXPECTED_OPENCODE_CONTEXT_BUDGET_WORKFLOW_SHA256["opencode"],
             EXPECTED_OPENCODE_ACTIVE_SECTION_ORDER_WORKFLOW_SHA256["opencode"],
             EXPECTED_OPENCODE_RECOVERY_WORKFLOW_SHA256["opencode"],
+            EXPECTED_CLAUDE_FALLBACK_SHA256[".github/workflows/opencode-auto-review.yml"],
         }
         and run_step.get("shell") == "bash"
         and run_env.get("CANDIDATE_NONCE")
@@ -6147,6 +6150,26 @@ def _verify_review_invocation_budget(
         raise ReleaseVerificationError(
             "invocation-budget inventory is not closed"
         )
+    if release_supports_claude_rollout_fallback(ref):
+        # Schema 2 changes the legacy positional AST and Claude route wiring.
+        # Seal their complete parsed structures, including every budget gate;
+        # retain the unchanged Gemini contract below as well.
+        for relative in (
+            REVIEW_INVOCATION_BUDGET_ACTION_ROOT.path.as_posix(),
+            REVIEW_INVOCATION_BUDGET_HELPER_ROOT.path.as_posix(),
+            ".github/workflows/claude-code-review.yml",
+            ".github/workflows/opencode-auto-review.yml",
+        ):
+            payload = tree.read_file(relative)
+            parsed = (ast.parse(payload) if relative.endswith(".py") else
+                      _load_release_yaml(payload, reject_duplicate_keys=True))
+            _fallback_parsed_seal(relative, parsed)
+            if hashlib.sha256(payload).hexdigest() != EXPECTED_CLAUDE_FALLBACK_SHA256[relative]:
+                raise ReleaseVerificationError("invocation-budget authenticated source digest differs")
+        require_budget_workflow_contract(tree, "gemini-auto-review.yml", "gemini", review_policy=True)
+        if hashlib.sha256(tree.read_file(".github/workflows/gemini-auto-review.yml")).hexdigest() != EXPECTED_OPENCODE_RECOVERY_WORKFLOW_SHA256["gemini"]:
+            raise ReleaseVerificationError("invocation-budget authenticated source digest differs")
+        return
     action_path = REVIEW_INVOCATION_BUDGET_ACTION_ROOT.path.as_posix()
     try:
         action_payload = tree.read_file(action_path)
@@ -6269,6 +6292,8 @@ def expected_review_actions(ref: str, workflow: str) -> list[str]:
         actions.append(REVIEW_POLICY_ACTION)
     if _release_version(ref) >= (1, 46) and workflow == "gemini-auto-review.yml":
         actions.append(SETUP_GEMINI_AUTH_REVIEW)
+    if release_supports_claude_rollout_fallback(ref) and workflow == "claude-code-review.yml":
+        actions.append(FALLBACK_ACTION)
     if release_supports_prepare_review_diff(ref):
         actions.append(PREPARE_REVIEW_DIFF_ACTION)
     if release_supports_review_invocation_budget(ref):
@@ -6755,6 +6780,11 @@ def _verify_review_publication_contracts(
     )
     try:
         for name, raw_contract in REVIEW_PUBLICATION_CONTRACTS.items():
+            if release_supports_claude_rollout_fallback(ref) and name == "claude-code-review.yml":
+                # The schema-3 failure/fallback variants have an exact v1.77
+                # parsed seal, including the complete collector and publisher.
+                require_claude_fallback_inputs(documents[name])
+                continue
             contract = {
                 key: value
                 for key, value in raw_contract.items()
@@ -7473,10 +7503,267 @@ def _verify_opencode_recovery(tree: VerifiedCommitTree, ref: str) -> None:
         if any(secret in tree.read_text(path) for secret in ("ZHIPU_API_KEY", "secrets:", "opencode run", "pip install", "npm install")):
             raise ValueError("provider execution is forbidden in recovery")
         for relative, expected in EXPECTED_OPENCODE_RECOVERY_SHA256.items():
+            if release_supports_claude_rollout_fallback(ref):
+                expected = EXPECTED_CLAUDE_FALLBACK_SHA256.get(relative, expected)
             if hashlib.sha256(tree.read_file(relative)).hexdigest() != expected:
                 raise ReleaseVerificationError("OpenCode recovery authenticated source digest differs: " + relative)
     except (AttributeError, KeyError, TypeError, ValueError, yaml.YAMLError):
         raise ReleaseVerificationError("OpenCode recovery execution/caller contract is invalid") from None
+
+
+
+# Reviewed v1.77 inputs, never calculated from the candidate at verification time.
+# Parsed seals retain all existing policy statements while schema-2 replaces the
+# legacy positional schema-1 AST checks. Raw seals additionally authenticate bytes.
+EXPECTED_CLAUDE_FALLBACK_SHA256 = {
+    ".github/actions/claude-rollout-fallback/action.yml": "ee4b8e6b88ebfc1d0691e032da93b03ba8268fac1bd9377a26554d8200621c0a",
+    ".github/actions/claude-rollout-fallback/contract.py": "ae39e0f9c0a1faa6831559c93150fca7f768fbaa0257aade70f045abd0eafff6",
+    "scripts/verify_claude_rollout_fallback.py": "281d443f4ebcc1dcd1f7db91abb0df3f31bc786527b6e0e0d4619c53d11f553e",
+    ".github/actions/review-invocation-budget/action.yml": "c05acbba8cac7e952867706a181eccaa25bc4f7baf720c5562dcbb71d1a04c90",
+    ".github/actions/review-invocation-budget/review_invocation_budget.py": "61bb3e0efa79daaa4b38c1a2a3d52cd7b6abf0432f81208e4fcdfdad61477103",
+    ".github/workflows/claude.yml": "bb111fd319a6449f8f56cbe22a20572b662525f9f4a7765bc46a415bba5f5881",
+    ".github/workflows/claude-code-review.yml": "e9ab0aafc14b21e5eb6780ad80b1ca3c3766e5f8f0cc5b60700cfe88eb18ab81",
+    ".github/workflows/opencode-auto-review.yml": "ff4b2acfb3a87f66a77e5e9821d0d60237b6335cbe2a7afd6e7af484a80d66bb",
+    ".github/actions/recover-opencode-review/evidence.py": "9be2af2a2f121f36d8587d11efcdd197bc98e7306e901a0b727097d991dd1a01",
+    ".github/actions/recover-opencode-review/replay.js": "1587bc1c858708d30edf1da3559cc37486d6eaa6e8fbe7d57ab6debf24e6f503",
+    ".github/actions/recover-opencode-review/receipt.js": "49a10b88745fce3ef3e43d6f4b5a0448b70d5e37b40e358d530a0f99dcd51d82",
+}
+EXPECTED_CLAUDE_FALLBACK_PARSED_SHA256 = {
+    ".github/actions/claude-rollout-fallback/action.yml": "fa6b723778608c90683a9cd49bd64229b4f1bc5ad10845978be51e605f6ef894",
+    ".github/actions/claude-rollout-fallback/contract.py": "b2b1c32742bab2642b24ff6e20fd9525432610721ce4e55b501c8255aa09a121",
+    "scripts/verify_claude_rollout_fallback.py": "65425e217b6574ff6af2cbc06c0f1fa422a51ad63b6102b2e6cd14915b2f62dd",
+    ".github/actions/review-invocation-budget/action.yml": "4a346ba8d26ea88efe5cc0dfa9f33f080ac8167cf777156d4eef635f1293b8ed",
+    ".github/actions/review-invocation-budget/review_invocation_budget.py": "c7338146a36ad36077d10b22f6db8947822c5da725fd779b914d252a2b9671ec",
+    ".github/workflows/claude.yml": "5781ef1db5e22f83ed07fc83fabe0beb615544a1412e01b2b8dabfd5f06593ab",
+    ".github/workflows/claude-code-review.yml": "130a3ee4164a2561ce6554e1fd6ddac25de11c734e7ec9504c8980841339407f",
+    ".github/workflows/opencode-auto-review.yml": "f27759c57939c8739bc0ee8c9c373869dd828d12dc2d10415c834937176ecd51",
+    ".github/actions/recover-opencode-review/evidence.py": "ffbc745e3912974a46d4496a507c03c759ee6d3ef83f6f9eeba874b808fd5ae4",
+}
+FALLBACK_ACTION = "$/.github/actions/claude-rollout-fallback"
+FALLBACK_INPUT_OUTPUTS = {
+    "fallback_request_comment_id": "request-comment-id",
+    "fallback_request_nonce": "request-nonce",
+    "fallback_expected_head_sha": "expected-head-sha",
+    "fallback_expected_base_sha": "expected-base-sha",
+    "fallback_original_run_id": "original-run-id",
+    "fallback_original_run_attempt": "original-run-attempt",
+    "fallback_release_commit": "release-commit",
+    "fallback_managed_diff_sha256": "managed-diff-sha256",
+}
+FALLBACK_PERMISSIONS = {
+    "actions": "read", "contents": "read", "id-token": "write",
+    "issues": "read", "pull-requests": "write",
+}
+
+
+def _fallback_literals(source: str, *literals: str) -> None:
+    if any(literal not in source for literal in literals):
+        raise ReleaseVerificationError("Claude fallback literal contract differs")
+
+
+def _fallback_parsed_seal(relative: str, value: object) -> None:
+    if isinstance(value, ast.AST):
+        # Python 3.12 adds empty type_params fields; they carry no policy.
+        for node in ast.walk(value):
+            if hasattr(node, "type_params"):
+                if node.type_params:
+                    raise ReleaseVerificationError("unexpected generic fallback contract")
+                del node.type_params
+        payload = ast.dump(value, include_attributes=False)
+    else:
+        payload = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    if hashlib.sha256(payload.encode()).hexdigest() != EXPECTED_CLAUDE_FALLBACK_PARSED_SHA256[relative]:
+        raise ReleaseVerificationError("Claude fallback parsed contract differs: " + relative)
+
+
+def require_claude_fallback_permissions(caller: object, router: object, review: object) -> None:
+    try:
+        if (
+            caller.get("permissions") is not None
+            or set(caller["jobs"]) != {"claude"}
+            or caller["jobs"]["claude"].get("permissions") != FALLBACK_PERMISSIONS
+            or router.get("permissions") is not None
+            or router["jobs"]["claude"].get("permissions")
+                != {**FALLBACK_PERMISSIONS, "pull-requests": "read"}
+            or router["jobs"]["managed-rollout-review"].get("permissions") != FALLBACK_PERMISSIONS
+            or router["jobs"]["classify-request"].get("permissions") != {
+                "actions": "read", "contents": "read", "issues": "read", "pull-requests": "read",
+            }
+            or review.get("permissions") is not None
+            or review["jobs"]["claude-review"].get("permissions") != FALLBACK_PERMISSIONS
+        ):
+            raise ValueError("permissions differ")
+    except (AttributeError, KeyError, TypeError, ValueError):
+        raise ReleaseVerificationError("Claude fallback permission contract differs") from None
+
+
+def require_claude_fallback_routes(router: object) -> None:
+    try:
+        jobs = router["jobs"]
+        interactive, managed = jobs["claude"], jobs["managed-rollout-review"]
+        if (
+            set(jobs) != {"check-enabled", "classify-request", "claude", "managed-rollout-review", "skipped"}
+            or interactive["needs"] != ["check-enabled", "classify-request"]
+            or managed["needs"] != interactive["needs"]
+            or managed["if"] != "needs.classify-request.outputs.route == 'managed'"
+            or managed["uses"] != "$/.github/workflows/claude-code-review.yml"
+            or managed["with"] != {
+                "pr_number": "${{ github.event.issue.number }}", "review_mode": "request",
+                **{name: "${{ needs.classify-request.outputs." + output + " }}"
+                   for name, output in FALLBACK_INPUT_OUTPUTS.items()},
+            }
+            or managed["secrets"] != {"CLAUDE_CODE_OAUTH_TOKEN": "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"}
+        ):
+            raise ValueError("route differs")
+        condition = _normalize_expression(interactive["if"])
+        if not condition.startswith("needs.classify-request.outputs.route == 'interactive' && ("):
+            raise ValueError("interactive route differs")
+        _fallback_literals(condition,
+            "!startsWith(github.event.comment.body, '@claude managed rollout review for PR ')",
+            """contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)""")
+        _fallback_parsed_seal(".github/workflows/claude.yml", router)
+    except (AttributeError, KeyError, TypeError, ValueError):
+        raise ReleaseVerificationError("Claude fallback route contract differs") from None
+
+
+def require_claude_fallback_inputs(review: object) -> None:
+    try:
+        inputs = review["on"]["workflow_call"]["inputs"]
+        if {key: value for key, value in inputs.items() if key.startswith("fallback_")} != {
+            name: {"type": "string", "required": "false", "default": ""}
+            for name in FALLBACK_INPUT_OUTPUTS
+        }:
+            raise ValueError("fallback inputs differ")
+        steps = review["jobs"]["claude-review"]["steps"]
+        by_id = {step["id"]: step for step in steps if "id" in step}
+        for identifier in ("review-budget-claim", "review-budget-finalize"):
+            if by_id[identifier]["with"].get("invocation-route-json") != (
+                "${{ steps.claude-invocation-route.outputs.invocation_route_json }}"
+            ):
+                raise ValueError("invocation route wiring differs")
+        if by_id["fallback-admission"]["uses"] != FALLBACK_ACTION:
+            raise ValueError("fallback admission differs")
+        _fallback_literals(by_id["upsert-review-comment"]["with"]["script"],
+            "const failureStateKeys = [...expectedStateKeys, 'failure_reason'].sort();",
+            "const fallbackStateKeys = [...expectedStateKeys, 'route'].sort();",
+            "JSON.stringify(Object.keys(route).sort()) === JSON.stringify(fallbackRouteKeys)",
+            "route.route === 'default_branch_rollout_fallback'",
+            "if (!failed && fallbackMode) state.route = fallbackRoute;",
+            "publicationPr.base?.sha !== fallbackRoute.reviewed_base_sha")
+        _fallback_parsed_seal(".github/workflows/claude-code-review.yml", review)
+    except (AttributeError, KeyError, TypeError, ValueError):
+        raise ReleaseVerificationError("Claude fallback input/publication contract differs") from None
+
+
+def require_budget_schema_two(root: Path) -> None:
+    relative = ".github/actions/review-invocation-budget/review_invocation_budget.py"
+    try:
+        source = (root / relative).read_text(encoding="utf-8")
+        module = ast.parse(source)
+        _require_unique_module_bindings(module, frozenset({
+            "SCHEMA", "CHECKPOINT_SCHEMA", "InvocationRoute", "decode_invocation_route",
+            "Invocation", "LedgerState", "claim", "finalize", "load_checkpoint",
+        }))
+        if _static_literal(module, "SCHEMA") != 2 or _static_literal(module, "CHECKPOINT_SCHEMA") != 1:
+            raise ValueError("budget schema differs")
+        _fallback_literals(source,
+            'if schema == 1:\n        return InvocationRoute.from_legacy_event(caller_event)',
+            'if schema == 2:\n        return InvocationRoute.from_dict(value)',
+            'if kind != "default_branch_rollout_fallback":',
+            'if schema not in {1, SCHEMA}:',
+            'InvocationRoute.from_dict(_embedded_json(request, "invocation_route_json"))')
+        _fallback_parsed_seal(relative, module)
+        action = ".github/actions/review-invocation-budget/action.yml"
+        _fallback_parsed_seal(action, _load_release_yaml((root / action).read_bytes(), reject_duplicate_keys=True))
+    except (OSError, SyntaxError, TypeError, ValueError):
+        raise ReleaseVerificationError("Claude fallback budget schema-2 contract differs") from None
+
+
+def require_request_and_receipt_contracts(root: Path) -> None:
+    contract_path = ".github/actions/claude-rollout-fallback/contract.py"
+    receipt_path = "scripts/verify_claude_rollout_fallback.py"
+    try:
+        source = (root / contract_path).read_text(encoding="utf-8")
+        module = ast.parse(source)
+        constants = {
+            "REQUEST_KEYS": frozenset({
+                "repository", "pr", "expected_head_sha", "expected_base_sha",
+                "original_run_id", "original_run_attempt", "release_commit",
+                "managed_diff_sha256", "nonce",
+            }),
+            "ALLOWED_ASSOCIATIONS": frozenset({"OWNER", "MEMBER", "COLLABORATOR"}),
+            "FALLBACK_ROUTE_KEYS": frozenset({
+                "managed_diff_sha256", "original_failed_run_id", "release_commit",
+                "request_comment_id", "reviewed_base_sha", "route",
+            }),
+        }
+        _require_unique_module_bindings(module, frozenset(constants))
+        if any(_static_literal(module, name) != expected for name, expected in constants.items()):
+            raise ValueError("request keys differ")
+        _fallback_literals(source,
+            'set(value) != REQUEST_KEYS',
+            'range(1, 11)', 'if len(comments) >= 1000:',
+            'if provider.get("conclusion") != "skipped":',
+            'raise ContractError("provider_entered")',
+            'raise ContractError("comment_horizon_exceeded")',
+            'stat.S_IMODE(info.st_mode) != 0o600')
+        _fallback_parsed_seal(contract_path, module)
+        receipt = (root / receipt_path).read_text(encoding="utf-8")
+        receipt_module = ast.parse(receipt)
+        receipt_constants = {
+            "RECEIPT_KEYS": frozenset({
+                "automatic", "base_sha", "effective_status", "fallback", "fleet", "head_sha",
+                "managed_diff_sha256", "pr", "release_commit", "repository", "schema", "verifier_commit",
+            }),
+            "AUTOMATIC_KEYS": frozenset({
+                "admitted_state_sha256", "canonical_comment_id", "reason", "review_execution",
+                "run_attempt", "run_id", "status",
+            }),
+            "FALLBACK_KEYS": frozenset({
+                "budget_status", "canonical_comment_id", "canonical_state_sha256", "driver_commit",
+                "filtered_max_severity", "request_comment_id", "request_nonce", "review_execution",
+                "route", "run_attempt", "run_id", "status",
+            }),
+            "FLEET_KEYS": frozenset({
+                "base_branch", "changed_paths", "head_repository", "pull_request_url", "rollout_branch",
+            }),
+        }
+        _require_unique_module_bindings(receipt_module, frozenset(receipt_constants))
+        if any(_static_literal(receipt_module, name) != expected for name, expected in receipt_constants.items()):
+            raise ValueError("receipt keys differ")
+        _fallback_literals(receipt,
+            'os.fchmod(stream.fileno(), 0o600)',
+            'stat.S_IMODE(observed.st_mode) != 0o600',
+            'verify_source_root(request.automation_root, driver)',
+            'modules = load_verified_modules(request.automation_root)',
+            'require_required_checks_clean(evidence.required_checks(request.expected_head))',
+            'raise VerificationError("required_check_failed")',
+            'return build_receipt(request, fleet, automatic, fallback, driver)')
+        _fallback_parsed_seal(receipt_path, receipt_module)
+    except (OSError, SyntaxError, TypeError, ValueError):
+        raise ReleaseVerificationError("Claude fallback request/receipt contract differs") from None
+
+
+def verify_claude_rollout_fallback_contract(root: Path) -> None:
+    try:
+        def load(relative):
+            return _load_release_yaml((root / relative).read_bytes(), reject_duplicate_keys=True)
+        caller = load("examples/baseline-workflows/.github/workflows/claude.yml")
+        router = load(".github/workflows/claude.yml")
+        review = load(".github/workflows/claude-code-review.yml")
+        require_claude_fallback_permissions(caller, router, review)
+        require_claude_fallback_routes(router)
+        require_claude_fallback_inputs(review)
+        require_budget_schema_two(root)
+        require_request_and_receipt_contracts(root)
+        for relative in (".github/actions/claude-rollout-fallback/action.yml",
+                         ".github/workflows/opencode-auto-review.yml"):
+            _fallback_parsed_seal(relative, load(relative))
+        for relative, expected in EXPECTED_CLAUDE_FALLBACK_SHA256.items():
+            if hashlib.sha256((root / relative).read_bytes()).hexdigest() != expected:
+                raise ReleaseVerificationError("Claude fallback authenticated source digest differs: " + relative)
+    except (OSError, TypeError, ValueError, yaml.YAMLError):
+        raise ReleaseVerificationError("Claude fallback contract is invalid") from None
 
 
 def _verify_commit_content(
@@ -7486,6 +7773,16 @@ def _verify_commit_content(
     if _release_version(ref) >= (1, 40):
         _release_inventory(tree, ref)
         _verify_setup_gemini_auth(tree, ref)
+    if release_supports_claude_rollout_fallback(ref):
+        with tempfile.TemporaryDirectory(prefix="verify-claude-fallback-") as temporary:
+            candidate_root = Path(temporary)
+            for blob in validate_release_listing(
+                tree.listing(release_paths_for(ref)), release_roots_for(ref)
+            ):
+                target = candidate_root / blob.path
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(tree.read_file(blob.path))
+            verify_claude_rollout_fallback_contract(candidate_root)
     _verify_opencode_recovery(tree, ref)
     if release_supports_prepare_review_diff(ref):
         _verify_prepare_review_diff_action(tree, ref)

--- a/scripts/workflow-catalog.json
+++ b/scripts/workflow-catalog.json
@@ -33,7 +33,7 @@
             "contents": "read",
             "id-token": "write",
             "issues": "read",
-            "pull-requests": "read"
+            "pull-requests": "write"
           },
           "with": [],
           "secrets": [

--- a/scripts/workflow_release_inventory.py
+++ b/scripts/workflow_release_inventory.py
@@ -133,6 +133,14 @@ OPENCODE_RECOVERY_ROOTS = tuple(
     ReleaseRoot(PurePosixPath(f".github/actions/recover-opencode-review/{name}"), "file", "100644")
     for name in ("evidence.py", "replay.js", "receipt.js", "transport.py")
 )
+CLAUDE_ROLLOUT_FALLBACK_ROOTS = tuple(
+    ReleaseRoot(PurePosixPath(path), "file", "100644")
+    for path in (
+        ".github/actions/claude-rollout-fallback/action.yml",
+        ".github/actions/claude-rollout-fallback/contract.py",
+        "scripts/verify_claude_rollout_fallback.py",
+    )
+)
 RELEASE_ROOTS = (
     HISTORICAL_RELEASE_ROOTS
     + PREPARE_REVIEW_DIFF_ROOTS
@@ -140,6 +148,7 @@ RELEASE_ROOTS = (
     + REVIEW_INVOCATION_BUDGET_ROOTS
     + REVIEW_POLICY_ROOTS
     + OPENCODE_RECOVERY_ROOTS
+    + CLAUDE_ROLLOUT_FALLBACK_ROOTS
 )
 RELEASE_PATHS = tuple(root.path.as_posix() for root in RELEASE_ROOTS)
 EXACT_RELEASE_ROOTS = tuple(root for root in RELEASE_ROOTS if root.kind == "file")
@@ -169,6 +178,7 @@ OPENCODE_ACTIVE_SECTION_ORDER_RELEASE = (1, 73)
 EXPANDED_REVIEW_BUDGET_RELEASE = (1, 74)
 CLAUDE_WORKFLOW_VALIDATION_RELEASE = (1, 75)
 OPENCODE_RECOVERY_RELEASE = (1, 76)
+CLAUDE_ROLLOUT_FALLBACK_RELEASE = (1, 77)
 
 
 def _release_version(ref: str) -> tuple[int, ...]:
@@ -302,6 +312,19 @@ def release_retires_manual_pr_review(ref: str) -> bool:
     return _release_version(ref) >= MANUAL_PR_REVIEW_RETIRED_RELEASE
 
 
+def release_supports_claude_rollout_fallback(ref: str) -> bool:
+    """Return whether the release owns the managed Claude rollout fallback."""
+    return _release_version(ref) >= CLAUDE_ROLLOUT_FALLBACK_RELEASE
+
+
+def _with_claude_rollout_fallback_roots(
+    ref: str, roots: tuple[ReleaseRoot, ...],
+) -> tuple[ReleaseRoot, ...]:
+    if release_supports_claude_rollout_fallback(ref):
+        return roots + CLAUDE_ROLLOUT_FALLBACK_ROOTS
+    return roots
+
+
 def release_roots_for(ref: str) -> tuple[ReleaseRoot, ...]:
     """Select the authenticated inventory that existed at ``ref``'s release line."""
     roots = HISTORICAL_RELEASE_ROOTS
@@ -315,7 +338,7 @@ def release_roots_for(ref: str) -> tuple[ReleaseRoot, ...]:
         roots += REVIEW_POLICY_ROOTS
     if release_supports_opencode_recovery(ref):
         roots += OPENCODE_RECOVERY_ROOTS
-    return roots
+    return _with_claude_rollout_fallback_roots(ref, roots)
 
 
 def release_paths_for(ref: str) -> tuple[str, ...]:

--- a/tests/opencode_recovery_fixtures.py
+++ b/tests/opencode_recovery_fixtures.py
@@ -47,7 +47,7 @@ def git(root, *args):
                           stdout=subprocess.PIPE, stderr=subprocess.PIPE).stdout
 
 
-def original_bundle(tmp_path):
+def original_bundle(tmp_path, *, ledger_schema=1):
     repo = tmp_path / "target"
     repo.mkdir()
     git(repo, "init", "-q")
@@ -74,6 +74,15 @@ def original_bundle(tmp_path):
         "final-review/default", "opencode run session")
     claim_state = budget.claim(None, request, {(RUN, ATTEMPT): provenance}).state
     checkpoint = budget.render_checkpoint(claim_state)
+    if ledger_schema == 1:
+        checkpoint_value = json.loads(checkpoint)
+        checkpoint_value["ledger"]["schema"] = 1
+        for invocation in checkpoint_value["ledger"]["invocations"]:
+            invocation.pop("route")
+        checkpoint = (json.dumps(checkpoint_value, ensure_ascii=True, separators=(",", ":"),
+                                 sort_keys=True) + "\n").encode("ascii")
+    elif ledger_schema != 2:
+        raise ValueError("unsupported fixture ledger schema")
     scope = {"schema": 1, "repository": REPOSITORY, "pr_number": PR,
              "merge_base_sha": base, "head_sha": head,
              "files": [{"filename": "app.py", "status": "modified"}]}

--- a/tests/release_fixture_helpers.py
+++ b/tests/release_fixture_helpers.py
@@ -12,8 +12,49 @@ from pathlib import Path
 import hashlib
 
 
+V176_FALLBACK_BOUNDARY_COMMIT = "444a7347aee169ed178aae80e8bd8d10eca52e02"
+PRE_V177_FILES = (
+    ".github/workflows/claude.yml",
+    ".github/workflows/claude-code-review.yml",
+    "examples/baseline-workflows/.github/workflows/claude.yml",
+    ".github/actions/review-invocation-budget/action.yml",
+    ".github/actions/review-invocation-budget/review_invocation_budget.py",
+    ".github/workflows/opencode-auto-review.yml",
+    ".github/actions/recover-opencode-review/evidence.py",
+    ".github/actions/recover-opencode-review/receipt.js",
+    ".github/actions/recover-opencode-review/replay.js",
+    "scripts/workflow-catalog.json",
+)
+
+
+def restore_pre_v177_claude_rollout_fallback(repo: Path) -> None:
+    """Downgrade copied current bytes before applying any older fixture patches.
+
+    Restore only a current file, so repeated older restore chains cannot undo
+    earlier historical changes or deliberately mutated test bytes. The immutable
+    tree supplies the old ledger, publisher key sets, caller and catalog ceiling.
+    """
+    from scripts.verify_workflow_release import VerifiedCommitTree
+
+    root = Path(__file__).resolve().parents[1]
+    tree = None
+    for relative in PRE_V177_FILES:
+        path = repo / relative
+        if path.is_file() and path.read_bytes() == (root / relative).read_bytes():
+            if tree is None:
+                tree = VerifiedCommitTree.open(root, V176_FALLBACK_BOUNDARY_COMMIT)
+            path.write_bytes(tree.read_file(relative))
+    for relative in (
+        ".github/actions/claude-rollout-fallback/action.yml",
+        ".github/actions/claude-rollout-fallback/contract.py",
+        "scripts/verify_claude_rollout_fallback.py",
+    ):
+        (repo / relative).unlink(missing_ok=True)
+
+
 def restore_pre_v176_opencode_recovery(repo: Path) -> None:
     """Restore authenticated pre-recovery bytes only when new recovery markers exist."""
+    restore_pre_v177_claude_rollout_fallback(repo)
     from scripts.verify_workflow_release import VerifiedCommitTree
 
     root = Path(__file__).resolve().parents[1]

--- a/tests/test_action_pins.py
+++ b/tests/test_action_pins.py
@@ -115,6 +115,21 @@ class ActionPinsTest(unittest.TestCase):
             references,
         )
 
+    def test_claude_router_uses_only_repository_local_fallback_targets(self) -> None:
+        workflow = yaml.load(
+            (ROOT / ".github/workflows/claude.yml").read_text(encoding="utf-8"),
+            Loader=yaml.BaseLoader,
+        )
+
+        self.assertEqual(
+            "$/.github/actions/claude-rollout-fallback",
+            workflow["jobs"]["classify-request"]["steps"][0]["uses"],
+        )
+        self.assertEqual(
+            "$/.github/workflows/claude-code-review.yml",
+            workflow["jobs"]["managed-rollout-review"]["uses"],
+        )
+
     def test_manual_claude_path_exposes_full_output_behind_a_repository_variable(
         self,
     ) -> None:

--- a/tests/test_action_pins.py
+++ b/tests/test_action_pins.py
@@ -76,6 +76,31 @@ class ActionPinsTest(unittest.TestCase):
 
         self.assertEqual([f"actions/setup-python@{SETUP_PYTHON_SHA}"], references)
 
+    def test_fleet_tool_ci_locks_the_setup_python_runtime_after_install(self) -> None:
+        workflow = yaml.load(
+            (ROOT / ".github/workflows/test-fleet-tools.yml").read_text(
+                encoding="utf-8"
+            ),
+            Loader=yaml.BaseLoader,
+        )
+        steps = {
+            step.get("name"): step
+            for step in workflow["jobs"]["pytest"]["steps"]
+        }
+        script = steps["Install test dependencies"]["run"]
+
+        install = "python -m pip install pytest PyYAML"
+        recursive_lock = 'sudo chmod -R go-w "$runtime"'
+        self.assertIn(install, script)
+        self.assertIn('"${RUNNER_TOOL_CACHE:?}"', script)
+        self.assertIn('"$cache"/Python/*/x64', script)
+        self.assertIn(recursive_lock, script)
+        self.assertIn(
+            'sudo chmod go-w /opt "$cache" "$cache/Python" "$(dirname "$runtime")"',
+            script,
+        )
+        self.assertLess(script.index(install), script.index(recursive_lock))
+
     def test_managed_workflows_do_not_contain_empty_github_expressions(self) -> None:
         offenders: list[str] = []
         pattern = re.compile(r"\$\{\{\s*\}\}")

--- a/tests/test_canonical_workflow_tree.py
+++ b/tests/test_canonical_workflow_tree.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import re
 import sys
 
+import pytest
 import yaml
 
 
@@ -259,6 +260,16 @@ CLAUDE_COMMAND_PERMISSIONS = {
     "contents": "read",
     "id-token": "write",
     "issues": "read",
+    "pull-requests": "write",
+}
+CLAUDE_INTERACTIVE_PERMISSIONS = {
+    **CLAUDE_COMMAND_PERMISSIONS,
+    "pull-requests": "read",
+}
+CLAUDE_CLASSIFIER_PERMISSIONS = {
+    "actions": "read",
+    "contents": "read",
+    "issues": "read",
     "pull-requests": "read",
 }
 CLAUDE_REVIEW_PERMISSIONS = {
@@ -321,6 +332,13 @@ def caller_job_contracts(
     workflow: dict[str, object],
 ) -> tuple[CallerJobContract, ...]:
     return extract_caller_jobs(workflow)
+
+
+def route_jobs(classification: str) -> dict[str, bool]:
+    return {
+        "claude": classification == "interactive",
+        "managed-rollout-review": classification == "managed",
+    }
 
 
 def central_accepts(entry: CatalogEntry, central_root: Path) -> bool:
@@ -486,6 +504,135 @@ def test_canonical_callers_use_only_the_selected_auth_contract() -> None:
                 }
             else:
                 assert "secrets" not in job
+
+
+def test_claude_router_has_closed_jobs_outputs_and_permissions() -> None:
+    central = load_yaml(ROOT / ".github/workflows/claude.yml")
+    baseline = load_yaml(CANONICAL / "workflows/claude.yml")
+
+    assert set(central["jobs"]) == {
+        "check-enabled",
+        "classify-request",
+        "claude",
+        "managed-rollout-review",
+        "skipped",
+    }
+    classifier = central["jobs"]["classify-request"]
+    assert classifier["needs"] == "check-enabled"
+    assert classifier["if"] == "needs.check-enabled.outputs.enabled == 'true'"
+    assert classifier["permissions"] == CLAUDE_CLASSIFIER_PERMISSIONS
+    assert classifier["outputs"] == {
+        name: f"${{{{ steps.classify.outputs.{name} }}}}"
+        for name in (
+            "route",
+            "reason",
+            "request-comment-id",
+            "request-nonce",
+            "expected-head-sha",
+            "expected-base-sha",
+            "original-run-id",
+            "original-run-attempt",
+            "release-commit",
+            "managed-diff-sha256",
+            "automatic-comment-id",
+            "automatic-state-sha256",
+        )
+    }
+    classify_step = classifier["steps"][0]
+    assert classify_step == {
+        "id": "classify",
+        "uses": "$/.github/actions/claude-rollout-fallback",
+        "with": {"github-token": "${{ github.token }}"},
+    }
+
+    interactive = central["jobs"]["claude"]
+    managed = central["jobs"]["managed-rollout-review"]
+    assert set(interactive["needs"]) == {"check-enabled", "classify-request"}
+    assert interactive["permissions"] == CLAUDE_INTERACTIVE_PERMISSIONS
+    assert managed["needs"] == ["check-enabled", "classify-request"]
+    assert managed["if"] == "needs.classify-request.outputs.route == 'managed'"
+    assert managed["permissions"] == CLAUDE_REVIEW_PERMISSIONS
+    assert managed["uses"] == "$/.github/workflows/claude-code-review.yml"
+    assert managed["with"] == {
+        "pr_number": "${{ github.event.issue.number }}",
+        "review_mode": "request",
+        "fallback_request_comment_id": (
+            "${{ needs.classify-request.outputs.request-comment-id }}"
+        ),
+        "fallback_request_nonce": (
+            "${{ needs.classify-request.outputs.request-nonce }}"
+        ),
+        "fallback_expected_head_sha": (
+            "${{ needs.classify-request.outputs.expected-head-sha }}"
+        ),
+        "fallback_expected_base_sha": (
+            "${{ needs.classify-request.outputs.expected-base-sha }}"
+        ),
+        "fallback_original_run_id": (
+            "${{ needs.classify-request.outputs.original-run-id }}"
+        ),
+        "fallback_original_run_attempt": (
+            "${{ needs.classify-request.outputs.original-run-attempt }}"
+        ),
+        "fallback_release_commit": (
+            "${{ needs.classify-request.outputs.release-commit }}"
+        ),
+        "fallback_managed_diff_sha256": (
+            "${{ needs.classify-request.outputs.managed-diff-sha256 }}"
+        ),
+    }
+    assert managed["secrets"] == {
+        "CLAUDE_CODE_OAUTH_TOKEN": "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
+    }
+    assert baseline["jobs"]["claude"]["permissions"] == CLAUDE_COMMAND_PERMISSIONS
+
+
+@pytest.mark.parametrize(
+    ("classification", "interactive", "managed"),
+    [
+        ("interactive", True, False),
+        ("managed", False, True),
+        ("invalid", False, False),
+    ],
+)
+def test_claude_routes_are_mutually_exclusive(
+    classification: str, interactive: bool, managed: bool
+) -> None:
+    assert route_jobs(classification) == {
+        "claude": interactive,
+        "managed-rollout-review": managed,
+    }
+
+
+def test_claude_router_preserves_interactive_guards_and_bounds_invalid_reason() -> None:
+    central = load_yaml(ROOT / ".github/workflows/claude.yml")
+    condition = " ".join(central["jobs"]["claude"]["if"].split())
+
+    assert condition.startswith(
+        "needs.classify-request.outputs.route == 'interactive' && ("
+    )
+    assert (
+        "!startsWith(github.event.comment.body, "
+        "'@claude managed rollout review for PR ')" in condition
+    )
+    for fragment in (
+        "github.event_name == 'issue_comment'",
+        "github.event.comment.author_association",
+        "github.event_name == 'pull_request_review_comment'",
+        "github.event_name == 'pull_request_review'",
+        "github.event.review.author_association",
+        "github.event_name == 'issues'",
+        "github.event.issue.author_association",
+        "contains(github.event.issue.body, '@claude')",
+        "contains(github.event.issue.title, '@claude')",
+    ):
+        assert fragment in condition
+
+    invalid = central["jobs"]["classify-request"]["steps"][1]
+    assert invalid["if"] == "steps.classify.outputs.route == 'invalid'"
+    assert invalid["env"] == {"REASON": "${{ steps.classify.outputs.reason }}"}
+    assert '[[ "$REASON" =~ ^[a-z_]+$ ]]' in invalid["run"]
+    assert "$GITHUB_STEP_SUMMARY" in invalid["run"]
 
 
 def test_auto_review_callers_forward_the_resolved_review_mode() -> None:

--- a/tests/test_canonical_workflow_tree.py
+++ b/tests/test_canonical_workflow_tree.py
@@ -712,3 +712,19 @@ def test_comment_callers_carry_the_request_scoped_run_name() -> None:
 
         assert len(matches) == 1, filename
         assert load_yaml(path)["run-name"] == ISSUE_RUN_NAME_VALUE, filename
+
+
+def test_v177_catalog_ceiling_and_nested_claude_permissions_agree() -> None:
+    from scripts.verify_workflow_release import (
+        FALLBACK_PERMISSIONS,
+        require_claude_fallback_permissions,
+    )
+
+    caller = load_yaml(CANONICAL / "workflows/claude.yml")
+    router = load_yaml(ROOT / ".github/workflows/claude.yml")
+    review = load_yaml(ROOT / ".github/workflows/claude-code-review.yml")
+    require_claude_fallback_permissions(caller, router, review)
+    entry = next(entry for entry in load_catalog(ROOT).callers
+                 if entry.path.as_posix() == ".github/workflows/claude.yml")
+    assert len(entry.caller_jobs) == 1
+    assert dict(entry.caller_jobs[0].permissions) == FALLBACK_PERMISSIONS

--- a/tests/test_claude_rollout_fallback.py
+++ b/tests/test_claude_rollout_fallback.py
@@ -1,0 +1,650 @@
+#!/usr/bin/env python3
+"""Behavioral tests for authenticated Claude rollout fallback admission."""
+
+from __future__ import annotations
+
+import importlib.util
+from copy import deepcopy
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = ROOT / ".github/actions/claude-rollout-fallback/contract.py"
+SPEC = importlib.util.spec_from_file_location("claude_rollout_fallback_contract", CONTRACT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+contract = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = contract
+SPEC.loader.exec_module(contract)
+
+ContractError = contract.ContractError
+FallbackRequest = contract.FallbackRequest
+canonical_request_body = contract.canonical_request_body
+classify_event = contract.classify_event
+parse_request_body = contract.parse_request_body
+
+
+REQUEST = {
+    "expected_base_sha": "b" * 40,
+    "expected_head_sha": "a" * 40,
+    "managed_diff_sha256": "c" * 64,
+    "nonce": "d" * 32,
+    "original_run_attempt": 1,
+    "original_run_id": 34549275027,
+    "pr": 109,
+    "release_commit": "444a7347aee169ed178aae80e8bd8d10eca52e02",
+    "repository": "jhw7500/gstApp",
+}
+REQUEST_BODY = (
+    "@claude managed rollout review for PR 109\n"
+    '<!-- automation:claude-rollout-review-request:v1 {"expected_base_sha":'
+    '"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","expected_head_sha":'
+    '"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","managed_diff_sha256":'
+    '"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",'
+    '"nonce":"dddddddddddddddddddddddddddddddd","original_run_attempt":1,'
+    '"original_run_id":34549275027,"pr":109,"release_commit":'
+    '"444a7347aee169ed178aae80e8bd8d10eca52e02","repository":"jhw7500/gstApp"} -->'
+)
+
+
+def issue_comment_event(body: object = REQUEST_BODY) -> dict[str, object]:
+    return {"action": "created", "comment": {"id": 901, "body": body}}
+
+
+def mutated_request_body(change: str) -> object:
+    marker_prefix = "<!-- automation:claude-rollout-review-request:v1 "
+    payload_text = REQUEST_BODY.split(marker_prefix, 1)[1][:-4]
+    payload = dict(REQUEST)
+    if change == "duplicate_key":
+        payload_text = payload_text[:-1] + ',"pr":109}'
+    elif change == "extra_key":
+        payload["extra"] = True
+        payload_text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    elif change == "missing_key":
+        payload.pop("nonce")
+        payload_text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    elif change == "uppercase_head":
+        payload["expected_head_sha"] = "A" * 40
+        payload_text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    elif change == "zero_run":
+        payload["original_run_id"] = 0
+        payload_text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    elif change == "unsafe_integer":
+        payload["original_run_id"] = 2**53
+        payload_text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    elif change == "short_nonce":
+        payload["nonce"] = "d" * 31
+        payload_text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    elif change == "control_character":
+        payload["repository"] = "jhw7500/gstApp\u0001"
+        payload_text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    elif change == "malformed_json":
+        payload_text = payload_text[:-1]
+    body: object = (
+        "@claude managed rollout review for PR 109\n"
+        f"{marker_prefix}{payload_text} -->"
+    )
+    if change == "second_marker":
+        body = f"{body}\n{marker_prefix}{{}} -->"
+    elif change == "quoted_marker":
+        body = "> " + str(body)
+    elif change == "invalid_unicode":
+        body = str(body) + "\ud800"
+    elif change == "oversize":
+        body = str(body) + "x" * 4096
+    return body
+
+
+def test_request_parser_accepts_only_the_exact_canonical_body() -> None:
+    request = parse_request_body(REQUEST_BODY)
+    assert request == FallbackRequest(**REQUEST)
+    assert canonical_request_body(request) == REQUEST_BODY
+    assert parse_request_body(REQUEST_BODY + "\n") == request
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        "duplicate_key",
+        "extra_key",
+        "missing_key",
+        "uppercase_head",
+        "zero_run",
+        "unsafe_integer",
+        "short_nonce",
+        "second_marker",
+        "quoted_marker",
+        "control_character",
+        "invalid_unicode",
+        "oversize",
+        "malformed_json",
+    ],
+)
+def test_request_parser_rejects_noncanonical_bytes(change: str) -> None:
+    with pytest.raises(ContractError, match="^request_invalid$"):
+        parse_request_body(mutated_request_body(change))
+
+
+def test_classifier_never_routes_reserved_invalid_text_to_interactive() -> None:
+    bodies = (
+        "@claude managed rollout review for PR 109",
+        "> @claude managed rollout review for PR 109",
+        "<!-- automation:claude-rollout-review-request:v1 {} -->",
+    )
+    for body in bodies:
+        result = classify_event("issue_comment", issue_comment_event(body))
+        assert (result.route, result.reason, result.request) == (
+            "invalid",
+            "request_invalid",
+            None,
+        )
+
+
+def test_classifier_routes_ordinary_text_without_server_evidence() -> None:
+    result = classify_event("issue_comment", issue_comment_event("@claude explain this"))
+    assert (result.route, result.reason, result.request) == ("interactive", "", None)
+
+
+def test_classifier_accepts_only_an_issue_comment_managed_candidate() -> None:
+    result = classify_event("issue_comment", issue_comment_event())
+    assert (result.route, result.reason, result.request) == (
+        "managed_candidate",
+        "",
+        FallbackRequest(**REQUEST),
+    )
+
+
+def test_classifier_rejects_reserved_tokens_in_other_event_text_fields() -> None:
+    events = (
+        ("pull_request_review_comment", {"comment": {"body": REQUEST_BODY}}),
+        ("pull_request_review", {"review": {"body": REQUEST_BODY}}),
+        ("issues", {"issue": {"title": REQUEST_BODY, "body": "ordinary"}}),
+    )
+    for event_name, event in events:
+        result = classify_event(event_name, event)
+        assert (result.route, result.reason, result.request) == (
+            "invalid",
+            "request_invalid",
+            None,
+        )
+
+
+EvidenceBundle = contract.EvidenceBundle
+admit = contract.admit
+
+AUTOMATIC_STATE = {
+    "schema": 3,
+    "reviewer": "claude",
+    "pr": 109,
+    "run_id": 34549275027,
+    "run_attempt": 1,
+    "attempt_head": "a" * 40,
+    "successful_head": None,
+    "attempt_status": "failure",
+    "diff_mode": "full",
+    "review_execution": "not_performed",
+    "full_diff_sha256": None,
+    "quality_schema": 1,
+    "accepted_count": None,
+    "filtered_count": None,
+    "normalized_count": None,
+    "filtered_max_severity": None,
+    "failure_reason": "workflow_validation_mismatch",
+}
+AUTOMATIC_STATE_BYTES = json.dumps(
+    AUTOMATIC_STATE, ensure_ascii=True, separators=(",", ":")
+).encode("ascii")
+AUTOMATIC_BODY = (
+    "## Claude Code Review (latest)\n"
+    "<!-- automation:claude-code-review:v3 -->\n"
+    f"<!-- automation-state:{AUTOMATIC_STATE_BYTES.decode('ascii')} -->\n\n"
+    "- Status: failure\n"
+    "- Execution: not_performed\n"
+    "- Run: https://github.com/jhw7500/gstApp/actions/runs/34549275027\n"
+    "- Last attempt: failure "
+    "(https://github.com/jhw7500/gstApp/actions/runs/34549275027)\n\n"
+    "### Error\n\nClaude review failed: `workflow_validation_mismatch`."
+)
+
+
+def _request_comment(comment_id: int = 901, body: str = REQUEST_BODY) -> dict[str, object]:
+    return {
+        "id": comment_id,
+        "body": body,
+        "created_at": "2026-09-11T03:04:06Z",
+        "author_association": "MEMBER",
+        "user": {"login": "jhw7500", "type": "User"},
+    }
+
+
+def _automatic_comment(comment_id: int = 887) -> dict[str, object]:
+    return {
+        "id": comment_id,
+        "body": AUTOMATIC_BODY,
+        "created_at": "2026-09-11T03:04:05Z",
+        "author_association": "NONE",
+        "user": {"login": "github-actions[bot]", "type": "Bot"},
+    }
+
+
+def _review_job() -> dict[str, object]:
+    return {
+        "id": 500,
+        "name": "Claude Code Review / claude-review",
+        "run_id": 34549275027,
+        "run_attempt": 1,
+        "status": "completed",
+        "conclusion": "failure",
+        "steps": [
+            {"number": 1, "name": "Prepare review diff", "status": "completed", "conclusion": "success"},
+            {"number": 2, "name": "Validate Claude caller workflow", "status": "completed", "conclusion": "failure"},
+            {"number": 3, "name": "Claim Claude review budget", "status": "completed", "conclusion": "skipped"},
+            {"number": 4, "name": "Run Claude Code Review", "status": "completed", "conclusion": "skipped"},
+        ],
+    }
+
+
+def valid_bundle() -> EvidenceBundle:
+    event_comment = _request_comment()
+    event = {
+        "action": "created",
+        "repository": {"full_name": "jhw7500/gstApp"},
+        "issue": {
+            "number": 109,
+            "state": "open",
+            "pull_request": {"url": "https://api.github.com/repos/jhw7500/gstApp/pulls/109"},
+        },
+        "comment": event_comment,
+    }
+    pull_request = {
+        "number": 109,
+        "state": "open",
+        "merged": False,
+        "head": {
+            "sha": "a" * 40,
+            "repo": {"full_name": "jhw7500/gstApp", "fork": False},
+        },
+        "base": {
+            "sha": "b" * 40,
+            "repo": {"full_name": "jhw7500/gstApp"},
+        },
+    }
+    original_run = {
+        "id": 34549275027,
+        "run_attempt": 1,
+        "name": "Claude Code Review",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "failure",
+        "head_sha": "a" * 40,
+        "updated_at": "2026-09-11T03:04:05Z",
+        "repository": {"full_name": "jhw7500/gstApp"},
+        "pull_requests": [
+            {"number": 109, "head": {"sha": "a" * 40}, "base": {"sha": "b" * 40}}
+        ],
+        "referenced_workflows": [
+            {
+                "path": "jhw7500/automation/.github/workflows/claude-code-review.yml@"
+                "refs/tags/v1.77",
+                "sha": "444a7347aee169ed178aae80e8bd8d10eca52e02",
+                "ref": "refs/tags/v1.77",
+            }
+        ],
+    }
+    return EvidenceBundle(
+        event_name="issue_comment",
+        event=event,
+        comment=_request_comment(),
+        pull_request=pull_request,
+        original_run=original_run,
+        original_jobs={"total_count": 1, "jobs": [_review_job()]},
+        issue_comments=[_automatic_comment(), _request_comment()],
+    )
+
+
+def _fallback_success_comment() -> dict[str, object]:
+    state = {
+        **AUTOMATIC_STATE,
+        "run_id": 34550000000,
+        "attempt_status": "success",
+        "successful_head": "a" * 40,
+        "review_execution": "performed",
+        "full_diff_sha256": "c" * 64,
+        "accepted_count": 0,
+        "filtered_count": 0,
+        "normalized_count": 0,
+        "filtered_max_severity": "none",
+    }
+    state.pop("failure_reason")
+    state["route"] = {
+        "managed_diff_sha256": "c" * 64,
+        "original_failed_run_id": 34549275027,
+        "release_commit": "444a7347aee169ed178aae80e8bd8d10eca52e02",
+        "request_comment_id": 901,
+        "reviewed_base_sha": "b" * 40,
+        "route": "default_branch_rollout_fallback",
+    }
+    encoded = json.dumps(state, ensure_ascii=True, separators=(",", ":"))
+    return {
+        "id": 888,
+        "body": (
+            "## Claude Code Review (latest)\n"
+            "<!-- automation:claude-code-review:v3 -->\n"
+            f"<!-- automation-state:{encoded} -->\n\n- Status: success\n\n### New findings\nNone"
+        ),
+        "created_at": "2026-09-11T03:05:00Z",
+        "user": {"login": "github-actions[bot]", "type": "Bot"},
+    }
+
+
+def mutated_bundle(change: str) -> EvidenceBundle:
+    bundle = valid_bundle()
+    values = {name: deepcopy(getattr(bundle, name)) for name in EvidenceBundle.__dataclass_fields__}
+    if change == "event_not_created":
+        values["event"]["action"] = "edited"
+    elif change == "comment_bytes_changed":
+        values["comment"]["body"] = REQUEST_BODY + "\n"
+    elif change == "comment_timestamp_changed":
+        values["comment"]["created_at"] = "2026-09-11T03:04:07Z"
+    elif change == "actor_not_collaborator":
+        values["comment"]["author_association"] = "CONTRIBUTOR"
+    elif change == "pr_closed":
+        values["pull_request"]["state"] = "closed"
+    elif change == "fork_head":
+        values["pull_request"]["head"]["repo"]["fork"] = True
+    elif change == "head_changed":
+        values["pull_request"]["head"]["sha"] = "f" * 40
+    elif change == "base_changed":
+        values["pull_request"]["base"]["sha"] = "f" * 40
+    elif change == "wrong_attempt":
+        values["original_run"]["run_attempt"] = 2
+    elif change == "wrong_job_run":
+        values["original_jobs"]["jobs"][0]["run_id"] = 34549275028
+    elif change == "request_before_failure":
+        values["comment"]["created_at"] = "2026-09-11T03:04:04Z"
+        values["event"]["comment"]["created_at"] = "2026-09-11T03:04:04Z"
+    elif change == "wrong_release":
+        values["original_run"]["referenced_workflows"][0]["sha"] = "5" * 40
+    elif change == "provider_entered":
+        values["original_jobs"]["jobs"][0]["steps"][3]["conclusion"] = "success"
+    elif change == "budget_claimed":
+        values["original_jobs"]["jobs"][0]["steps"][2]["conclusion"] = "success"
+    elif change == "duplicate_request":
+        duplicate = FallbackRequest.from_dict({**REQUEST, "nonce": "e" * 32})
+        values["issue_comments"].append(_request_comment(902, canonical_request_body(duplicate)))
+    elif change == "duplicate_state":
+        values["issue_comments"].append(_automatic_comment(886))
+    elif change == "existing_fallback":
+        values["issue_comments"].append(_fallback_success_comment())
+    elif change == "job_overflow":
+        values["original_jobs"]["total_count"] = 101
+    elif change == "comment_horizon_exceeded":
+        values["issue_comments"] += [
+            {"id": 1000 + number, "body": "ordinary", "user": {"login": "u", "type": "User"}}
+            for number in range(998)
+        ]
+    else:
+        raise AssertionError(f"unknown mutation: {change}")
+    return EvidenceBundle(**values)
+
+
+def test_admission_binds_failure_before_provider_or_budget() -> None:
+    admission = admit(valid_bundle())
+    assert admission.request.original_run_id == 34549275027
+    assert admission.request_comment_id == 901
+    assert admission.automatic_comment_id == 887
+    assert admission.automatic_state_sha256 == sha256(AUTOMATIC_STATE_BYTES).hexdigest()
+    assert canonical_request_body(admission.request) == REQUEST_BODY
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        "event_not_created",
+        "comment_bytes_changed",
+        "comment_timestamp_changed",
+        "actor_not_collaborator",
+        "pr_closed",
+        "fork_head",
+        "head_changed",
+        "base_changed",
+        "wrong_attempt",
+        "wrong_job_run",
+        "request_before_failure",
+        "wrong_release",
+        "provider_entered",
+        "budget_claimed",
+        "duplicate_request",
+        "duplicate_state",
+        "existing_fallback",
+        "job_overflow",
+        "comment_horizon_exceeded",
+    ],
+)
+def test_admission_fails_closed(change: str) -> None:
+    with pytest.raises(ContractError, match="^[a-z_]+$"):
+        admit(mutated_bundle(change))
+
+
+@pytest.mark.parametrize(
+    ("change", "reason"),
+    [
+        ("request_before_failure", "request_order_invalid"),
+        ("duplicate_request", "request_ambiguous"),
+        ("comment_horizon_exceeded", "comment_horizon_exceeded"),
+    ],
+)
+def test_admission_uses_required_bounded_reason_codes(change: str, reason: str) -> None:
+    with pytest.raises(ContractError, match=f"^{reason}$"):
+        admit(mutated_bundle(change))
+
+
+OUTPUT_NAMES = {
+    "route",
+    "reason",
+    "request-comment-id",
+    "request-nonce",
+    "expected-head-sha",
+    "expected-base-sha",
+    "original-run-id",
+    "original-run-attempt",
+    "release-commit",
+    "managed-diff-sha256",
+    "automatic-comment-id",
+    "automatic-state-sha256",
+}
+
+
+def test_action_contract_exposes_only_closed_outputs_and_two_shell_steps() -> None:
+    action = yaml.load(
+        (CONTRACT_PATH.with_name("action.yml")).read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+    assert action["inputs"] == {"github-token": {"required": "true"}}
+    assert set(action["outputs"]) == OUTPUT_NAMES
+    assert [step["id"] for step in action["runs"]["steps"]] == ["collect", "verify"]
+    assert all(step["shell"] == "bash" for step in action["runs"]["steps"])
+
+
+def _run_contract(*arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CONTRACT_PATH), *arguments],
+        cwd=ROOT,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_plan_cli_emits_no_evidence_plan_for_interactive_text(tmp_path: Path) -> None:
+    event_file = tmp_path / "event.json"
+    plan_file = tmp_path / "plan.json"
+    output_file = tmp_path / "output"
+    event_file.write_text(json.dumps(issue_comment_event("@claude explain this")), encoding="utf-8")
+    result = _run_contract(
+        "plan",
+        "--event-name",
+        "issue_comment",
+        "--event-file",
+        str(event_file),
+        "--plan-file",
+        str(plan_file),
+        "--github-output",
+        str(output_file),
+    )
+    assert result.returncode == 0
+    assert not plan_file.exists()
+    assert output_file.read_text(encoding="utf-8") == "route=interactive\nreason=\n"
+
+
+def test_plan_cli_writes_private_fixed_endpoint_plan_for_candidate(tmp_path: Path) -> None:
+    event_file = tmp_path / "event.json"
+    plan_file = tmp_path / "plan.json"
+    output_file = tmp_path / "output"
+    event_file.write_text(json.dumps(valid_bundle().event), encoding="utf-8")
+    result = _run_contract(
+        "plan",
+        "--event-name",
+        "issue_comment",
+        "--event-file",
+        str(event_file),
+        "--plan-file",
+        str(plan_file),
+        "--github-output",
+        str(output_file),
+    )
+    assert result.returncode == 0
+    assert not output_file.exists() or output_file.read_text(encoding="utf-8") == ""
+    assert stat.S_IMODE(plan_file.stat().st_mode) == 0o600
+    assert json.loads(plan_file.read_text(encoding="utf-8")) == {
+        "event": valid_bundle().event,
+        "event_name": "issue_comment",
+        "request": REQUEST,
+        "requests": [
+            {
+                "endpoint": "repos/jhw7500/gstApp/issues/comments/901",
+                "name": "comment.json",
+            },
+            {
+                "endpoint": "repos/jhw7500/gstApp/pulls/109",
+                "name": "pull_request.json",
+            },
+            {
+                "endpoint": "repos/jhw7500/gstApp/actions/runs/34549275027/attempts/1",
+                "name": "original_run.json",
+            },
+            {
+                "endpoint": "repos/jhw7500/gstApp/actions/runs/34549275027/attempts/1/jobs?per_page=100",
+                "name": "original_jobs.json",
+            },
+            *[
+                {
+                    "endpoint": (
+                        "repos/jhw7500/gstApp/issues/109/comments"
+                        f"?per_page=100&page={page}"
+                    ),
+                    "name": f"comments-{page:02d}.json",
+                }
+                for page in range(1, 11)
+            ],
+        ],
+        "schema": 1,
+    }
+
+
+def _write_evidence(directory: Path, bundle: EvidenceBundle) -> None:
+    directory.mkdir(mode=0o700)
+    values = {
+        "comment.json": bundle.comment,
+        "pull_request.json": bundle.pull_request,
+        "original_run.json": bundle.original_run,
+        "original_jobs.json": bundle.original_jobs,
+        "comments-01.json": bundle.issue_comments,
+    }
+    for name, value in values.items():
+        path = directory / name
+        path.write_text(json.dumps(value), encoding="utf-8")
+        path.chmod(0o600)
+
+
+def test_verify_cli_writes_private_admission_and_closed_scalar_outputs(tmp_path: Path) -> None:
+    event_file = tmp_path / "event.json"
+    plan_file = tmp_path / "plan.json"
+    plan_output = tmp_path / "plan-output"
+    evidence_directory = tmp_path / "evidence"
+    admission_file = tmp_path / "admission.json"
+    output_file = tmp_path / "output"
+    event_file.write_text(json.dumps(valid_bundle().event), encoding="utf-8")
+    planned = _run_contract(
+        "plan", "--event-name", "issue_comment", "--event-file", str(event_file),
+        "--plan-file", str(plan_file), "--github-output", str(plan_output),
+    )
+    assert planned.returncode == 0
+    _write_evidence(evidence_directory, valid_bundle())
+    result = _run_contract(
+        "verify", "--plan-file", str(plan_file),
+        "--evidence-directory", str(evidence_directory),
+        "--admission-file", str(admission_file), "--github-output", str(output_file),
+    )
+    assert result.returncode == 0
+    assert stat.S_IMODE(admission_file.stat().st_mode) == 0o600
+    assert json.loads(admission_file.read_text(encoding="utf-8")) == {
+        "automatic_comment_id": 887,
+        "automatic_state_sha256": sha256(AUTOMATIC_STATE_BYTES).hexdigest(),
+        "request": REQUEST,
+        "request_comment_id": 901,
+        "schema": 1,
+    }
+    assert output_file.read_text(encoding="utf-8") == (
+        "route=managed\n"
+        "reason=\n"
+        "request-comment-id=901\n"
+        "request-nonce=dddddddddddddddddddddddddddddddd\n"
+        f"expected-head-sha={'a' * 40}\n"
+        f"expected-base-sha={'b' * 40}\n"
+        "original-run-id=34549275027\n"
+        "original-run-attempt=1\n"
+        "release-commit=444a7347aee169ed178aae80e8bd8d10eca52e02\n"
+        f"managed-diff-sha256={'c' * 64}\n"
+        "automatic-comment-id=887\n"
+        f"automatic-state-sha256={sha256(AUTOMATIC_STATE_BYTES).hexdigest()}\n"
+    )
+
+
+def test_verify_cli_fails_closed_without_an_admission_file(tmp_path: Path) -> None:
+    event_file = tmp_path / "event.json"
+    plan_file = tmp_path / "plan.json"
+    evidence_directory = tmp_path / "evidence"
+    admission_file = tmp_path / "admission.json"
+    output_file = tmp_path / "output"
+    event_file.write_text(json.dumps(valid_bundle().event), encoding="utf-8")
+    assert _run_contract(
+        "plan", "--event-name", "issue_comment", "--event-file", str(event_file),
+        "--plan-file", str(plan_file), "--github-output", str(tmp_path / "plan-output"),
+    ).returncode == 0
+    _write_evidence(evidence_directory, mutated_bundle("provider_entered"))
+    result = _run_contract(
+        "verify", "--plan-file", str(plan_file),
+        "--evidence-directory", str(evidence_directory),
+        "--admission-file", str(admission_file), "--github-output", str(output_file),
+    )
+    assert result.returncode == 0
+    assert not admission_file.exists()
+    outputs = dict(
+        line.split("=", 1)
+        for line in output_file.read_text(encoding="utf-8").splitlines()
+    )
+    assert outputs == {
+        **{name: "" for name in OUTPUT_NAMES - {"route", "reason"}},
+        "route": "invalid",
+        "reason": "provider_entered",
+    }

--- a/tests/test_claude_rollout_fallback.py
+++ b/tests/test_claude_rollout_fallback.py
@@ -377,6 +377,28 @@ def mutated_bundle(change: str) -> EvidenceBundle:
         values["original_jobs"]["jobs"][0]["steps"][3]["conclusion"] = "success"
     elif change == "budget_claimed":
         values["original_jobs"]["jobs"][0]["steps"][2]["conclusion"] = "success"
+    elif change == "extra_failed_job":
+        values["original_jobs"]["jobs"].append(
+            {
+                "id": 501,
+                "name": "Claude Code Review / post-review",
+                "run_id": 34549275027,
+                "run_attempt": 1,
+                "status": "completed",
+                "conclusion": "failure",
+                "steps": [],
+            }
+        )
+        values["original_jobs"]["total_count"] = 2
+    elif change == "extra_failed_step":
+        values["original_jobs"]["jobs"][0]["steps"].append(
+            {
+                "number": 5,
+                "name": "Publish unexpected failure",
+                "status": "completed",
+                "conclusion": "failure",
+            }
+        )
     elif change == "duplicate_request":
         duplicate = FallbackRequest.from_dict({**REQUEST, "nonce": "e" * 32})
         values["issue_comments"].append(_request_comment(902, canonical_request_body(duplicate)))
@@ -422,6 +444,8 @@ def test_admission_binds_failure_before_provider_or_budget() -> None:
         "wrong_release",
         "provider_entered",
         "budget_claimed",
+        "extra_failed_job",
+        "extra_failed_step",
         "duplicate_request",
         "duplicate_state",
         "existing_fallback",

--- a/tests/test_claude_workflow_validation.py
+++ b/tests/test_claude_workflow_validation.py
@@ -11,6 +11,261 @@ from test_review_workflow_logic import (
 )
 
 
+FALLBACK_INPUTS = {
+    "fallback_request_comment_id": "901",
+    "fallback_request_nonce": "dd" * 16,
+    "fallback_expected_head_sha": "aa" * 20,
+    "fallback_expected_base_sha": "bb" * 20,
+    "fallback_original_run_id": "34549275027",
+    "fallback_original_run_attempt": "1",
+    "fallback_release_commit": "444a7347aee169ed178aae80e8bd8d10eca52e02",
+    "fallback_managed_diff_sha256": "cc" * 32,
+}
+
+
+def _run_fallback_shell_step(tmp_path, name, env):
+    output = tmp_path / f"{name}.output"
+    step = _new_step(name)
+    result = subprocess.run(
+        ["bash", "-c", step.get("run", "")],
+        env={**os.environ, **env, "GITHUB_OUTPUT": str(output)},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, _github_outputs(output) if output.exists() else {}
+
+
+def _fallback_inputs_json(values):
+    return json.dumps({name: values.get(name, "") for name in FALLBACK_INPUTS})
+
+
+def _fallback_admission(tmp_path, **changes):
+    fixture = {
+        "route": "managed",
+        "request-comment-id": "901",
+        "request-nonce": "dd" * 16,
+        "expected-head-sha": "aa" * 20,
+        "expected-base-sha": "bb" * 20,
+        "original-run-id": "34549275027",
+        "original-run-attempt": "1",
+        "release-commit": "444a7347aee169ed178aae80e8bd8d10eca52e02",
+        "managed-diff-sha256": "cc" * 32,
+        "liveHead": "aa" * 20,
+        "liveBase": "bb" * 20,
+        **changes,
+    }
+    step = _new_step("Validate Claude fallback admission")
+    script = step.get("with", {}).get("script", "")
+    harness = r"""
+const fx = JSON.parse(process.argv[1]);
+const script = JSON.parse(process.argv[2]);
+const outputs = {}, failures = [], calls = [];
+const context = {repo: {owner: 'o', repo: 'r'}};
+for (const [key, value] of Object.entries(fx)) {
+  if (!['liveHead', 'liveBase'].includes(key)) process.env[key.toUpperCase().replaceAll('-', '_')] = value;
+}
+const inputMap = {
+  'request-comment-id': 'INPUT_REQUEST_COMMENT_ID',
+  'request-nonce': 'INPUT_REQUEST_NONCE',
+  'expected-head-sha': 'INPUT_EXPECTED_HEAD_SHA',
+  'expected-base-sha': 'INPUT_EXPECTED_BASE_SHA',
+  'original-run-id': 'INPUT_ORIGINAL_RUN_ID',
+  'original-run-attempt': 'INPUT_ORIGINAL_RUN_ATTEMPT',
+  'release-commit': 'INPUT_RELEASE_COMMIT',
+  'managed-diff-sha256': 'INPUT_MANAGED_DIFF_SHA256',
+};
+for (const [key, envName] of Object.entries(inputMap)) process.env[envName] = {
+  'request-comment-id': '901',
+  'request-nonce': 'dddddddddddddddddddddddddddddddd',
+  'expected-head-sha': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  'expected-base-sha': 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  'original-run-id': '34549275027',
+  'original-run-attempt': '1',
+  'release-commit': '444a7347aee169ed178aae80e8bd8d10eca52e02',
+  'managed-diff-sha256': 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+}[key];
+process.env.PR_NUMBER = '109';
+const github = {rest: {pulls: {get: async args => {
+  calls.push(args);
+  return {data: {head: {sha: fx.liveHead}, base: {sha: fx.liveBase}}};
+}}}};
+const core = {
+  setOutput: (key, value) => {outputs[key] = value;},
+  setFailed: message => failures.push(message),
+};
+(async () => {
+  await new Function('github', 'context', 'core',
+    'return (async () => {' + script + '})();')(github, context, core);
+  console.log(JSON.stringify({outputs, failures, calls}));
+})().catch(error => {console.error(error); process.exit(1);});
+"""
+    result = subprocess.run(
+        ["node", "-e", harness, json.dumps(fixture), json.dumps(script)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_fallback_workflow_call_inputs_are_exact_optional_strings():
+    inputs = _load("claude-code-review.yml")["on"]["workflow_call"]["inputs"]
+    for name in FALLBACK_INPUTS:
+        assert inputs[name] == {"type": "string", "required": "false", "default": ""}
+
+
+@pytest.mark.parametrize("present", range(1, 8))
+def test_partial_fallback_inputs_fail_before_diff(tmp_path, present):
+    values = dict(list(FALLBACK_INPUTS.items())[:present])
+    result, outputs = _run_fallback_shell_step(
+        tmp_path, "Resolve Claude fallback mode",
+        {"FALLBACK_INPUTS_JSON": _fallback_inputs_json(values)},
+    )
+    assert result.returncode != 0
+    assert outputs == {}
+
+
+@pytest.mark.parametrize(("values", "mode"), (({}, "normal"), (FALLBACK_INPUTS, "fallback")))
+def test_fallback_mode_is_all_or_none(tmp_path, values, mode):
+    result, outputs = _run_fallback_shell_step(
+        tmp_path, "Resolve Claude fallback mode",
+        {"FALLBACK_INPUTS_JSON": _fallback_inputs_json(values)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert outputs == {"mode": mode}
+
+
+@node_required
+@pytest.mark.parametrize("coordinate", tuple(FALLBACK_INPUTS))
+def test_fallback_admission_rejects_every_immutable_coordinate_mutation(tmp_path, coordinate):
+    output_name = {
+        "fallback_request_comment_id": "request-comment-id",
+        "fallback_request_nonce": "request-nonce",
+        "fallback_expected_head_sha": "expected-head-sha",
+        "fallback_expected_base_sha": "expected-base-sha",
+        "fallback_original_run_id": "original-run-id",
+        "fallback_original_run_attempt": "original-run-attempt",
+        "fallback_release_commit": "release-commit",
+        "fallback_managed_diff_sha256": "managed-diff-sha256",
+    }[coordinate]
+    result = _fallback_admission(tmp_path, **{output_name: "mismatch"})
+    assert result["failures"] == ["fallback_admission_mismatch"]
+    assert result["outputs"] == {"allowed": "false", "reason": "fallback_admission_mismatch"}
+
+
+@node_required
+@pytest.mark.parametrize("change", ({"route": "interactive"}, {"liveHead": "ee" * 20}, {"liveBase": "ff" * 20}))
+def test_fallback_admission_requires_managed_route_and_live_pr_coordinates(tmp_path, change):
+    result = _fallback_admission(tmp_path, **change)
+    assert result["failures"] == ["fallback_admission_mismatch"]
+    assert result["outputs"] == {"allowed": "false", "reason": "fallback_admission_mismatch"}
+
+
+@node_required
+def test_fallback_admission_accepts_exact_replayed_coordinates(tmp_path):
+    result = _fallback_admission(tmp_path)
+    assert result["failures"] == []
+    assert result["outputs"] == {"allowed": "true", "reason": ""}
+    assert result["calls"] == [{
+        "owner": "o", "repo": "r", "pull_number": 109, "request": {"timeout": 15000},
+    }]
+
+
+def test_fallback_requires_exact_recomputed_full_diff(tmp_path):
+    result, outputs = _run_fallback_shell_step(
+        tmp_path,
+        "Resolve Claude invocation route",
+        {
+            "FALLBACK_MODE": "fallback",
+            "DIFF_MODE": "full",
+            "COMPUTED_FULL_DIFF_SHA256": "12" * 32,
+            "FALLBACK_MANAGED_DIFF_SHA256": "34" * 32,
+            "FORCE_REVIEW": "false",
+            **{name.upper(): value for name, value in FALLBACK_INPUTS.items()},
+            "AUTOMATIC_COMMENT_ID": "887",
+            "AUTOMATIC_STATE_SHA256": "56" * 32,
+        },
+    )
+    assert result.returncode != 0
+    assert outputs == {}
+
+
+@pytest.mark.parametrize(
+    ("force_review", "expected"),
+    (("false", {"kind": "automatic"}), ("true", {"kind": "authorized_override"})),
+)
+def test_normal_claude_invocation_route_is_explicit(tmp_path, force_review, expected):
+    result, outputs = _run_fallback_shell_step(
+        tmp_path,
+        "Resolve Claude invocation route",
+        {
+            "FALLBACK_MODE": "normal",
+            "DIFF_MODE": "full",
+            "COMPUTED_FULL_DIFF_SHA256": "12" * 32,
+            "FALLBACK_MANAGED_DIFF_SHA256": "",
+            "FORCE_REVIEW": force_review,
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(outputs["invocation_route_json"]) == expected
+    assert outputs["state_route_json"] == ""
+
+
+def test_fallback_route_json_binds_fresh_admission_outputs(tmp_path):
+    result, outputs = _run_fallback_shell_step(
+        tmp_path,
+        "Resolve Claude invocation route",
+        {
+            "FALLBACK_MODE": "fallback",
+            "DIFF_MODE": "full",
+            "COMPUTED_FULL_DIFF_SHA256": "cc" * 32,
+            "FORCE_REVIEW": "false",
+            **{name.upper(): value for name, value in FALLBACK_INPUTS.items()},
+            "AUTOMATIC_COMMENT_ID": "887",
+            "AUTOMATIC_STATE_SHA256": "56" * 32,
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(outputs["invocation_route_json"]) == {
+        "kind": "default_branch_rollout_fallback",
+        "request_comment_id": 901,
+        "request_nonce": "dd" * 16,
+        "original_run_id": 34549275027,
+        "original_run_attempt": 1,
+        "expected_base_sha": "bb" * 20,
+        "release_commit": "444a7347aee169ed178aae80e8bd8d10eca52e02",
+        "managed_diff_sha256": "cc" * 32,
+        "automatic_comment_id": 887,
+        "automatic_state_sha256": "56" * 32,
+    }
+    assert json.loads(outputs["state_route_json"]) == {
+        "managed_diff_sha256": "cc" * 32,
+        "original_failed_run_id": 34549275027,
+        "release_commit": "444a7347aee169ed178aae80e8bd8d10eca52e02",
+        "request_comment_id": 901,
+        "reviewed_base_sha": "bb" * 20,
+        "route": "default_branch_rollout_fallback",
+    }
+
+
+@node_required
+def test_fallback_does_not_bypass_caller_validation(tmp_path):
+    result = _preflight(tmp_path, currentBlob="11" * 20, defaultBlob="22" * 20)
+    assert result["outputs"] == {
+        "allowed": "false", "reason": "workflow_validation_mismatch",
+    }
+
+
+def test_fallback_still_requires_live_request_policy():
+    workflow = _load("claude-code-review.yml")
+    assert workflow["jobs"]["claude-review"]["if"] == (
+        "needs.check-enabled.outputs.enabled == 'true' && "
+        "needs.check-enabled.outputs.policy_run == 'true'"
+    )
+
+
 def _new_step(name):
     steps = _load("claude-code-review.yml")["jobs"]["claude-review"]["steps"]
     return next((step for step in steps if step.get("name") == name), {})

--- a/tests/test_claude_workflow_validation.py
+++ b/tests/test_claude_workflow_validation.py
@@ -28,6 +28,7 @@ def _run_fallback_shell_step(tmp_path, name, env):
     step = _new_step(name)
     result = subprocess.run(
         ["bash", "-c", step.get("run", "")],
+        cwd=tmp_path,
         env={**os.environ, **env, "GITHUB_OUTPUT": str(output)},
         text=True,
         capture_output=True,
@@ -38,6 +39,16 @@ def _run_fallback_shell_step(tmp_path, name, env):
 
 def _fallback_inputs_json(values):
     return json.dumps({name: values.get(name, "") for name in FALLBACK_INPUTS})
+
+
+def _route_step_env():
+    return {
+        "FALLBACK_MODE": "normal",
+        "DIFF_MODE": "full",
+        "COMPUTED_FULL_DIFF_SHA256": "12" * 32,
+        "FALLBACK_MANAGED_DIFF_SHA256": "",
+        "FORCE_REVIEW": "false",
+    }
 
 
 def _fallback_admission(tmp_path, **changes):
@@ -135,6 +146,28 @@ def test_fallback_mode_is_all_or_none(tmp_path, values, mode):
     )
     assert result.returncode == 0, result.stderr
     assert outputs == {"mode": mode}
+
+
+@pytest.mark.parametrize("step_name", (
+    "Resolve Claude fallback mode", "Resolve Claude invocation route",
+))
+@pytest.mark.parametrize("module_name", ("json", "pathlib"))
+def test_fallback_python_steps_ignore_checkout_module_shadowing(
+    tmp_path, step_name, module_name,
+):
+    (tmp_path / f"{module_name}.py").write_text(
+        "open('consumer-code-ran', 'w').write('executed')\n",
+        encoding="utf-8",
+    )
+    env = (
+        {"FALLBACK_INPUTS_JSON": _fallback_inputs_json({})}
+        if step_name == "Resolve Claude fallback mode"
+        else _route_step_env()
+    )
+    result, outputs = _run_fallback_shell_step(tmp_path, step_name, env)
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / "consumer-code-ran").exists()
+    assert outputs
 
 
 @node_required

--- a/tests/test_opencode_recovery_evidence.py
+++ b/tests/test_opencode_recovery_evidence.py
@@ -26,7 +26,7 @@ def evidence_module():
 
 def test_current_workflow_replays_the_same_original_success(tmp_path):
     module = evidence_module()
-    bundle = original_bundle(tmp_path)
+    bundle = original_bundle(tmp_path, ledger_schema=2)
     bundle["workflow_source"] = (ROOT / ".github/workflows/opencode-auto-review.yml").read_text()
     result = module.validate_evidence(module.RecoveryTarget(**bundle["target"]), bundle, bundle["workspace"])
     assert result.request.call_count == 1
@@ -192,6 +192,10 @@ def test_claim_provenance_must_match_original_publication_even_with_sealed_hashe
     bundle = original_bundle(tmp_path)
     original = bundle['claim_state']
     changed = replace(original, invocations=(replace(original.invocations[0], **changes),))
+    if changes.get('caller_event') == 'workflow_dispatch':
+        with pytest.raises(budget.BudgetStateError, match='provenance_mismatch'):
+            budget.render_checkpoint(changed)
+        return
     checkpoint = budget.render_checkpoint(changed)
     with zipfile.ZipFile(io.BytesIO(bundle['artifacts']['handoff']['payload'])) as stream:
         files = {name: stream.read(name) for name in stream.namelist()}

--- a/tests/test_opencode_recovery_receipts.py
+++ b/tests/test_opencode_recovery_receipts.py
@@ -100,7 +100,7 @@ def node_validate(facts):
 AUTOMATIC_ROUTE = object()
 
 
-def schema_two_facts(route=AUTOMATIC_ROUTE):
+def schema_two_facts(route=AUTOMATIC_ROUTE, *, preserve_receipt_digest=False):
     facts = facts_fixture()
     if route is AUTOMATIC_ROUTE:
         route = {"kind": "automatic"}
@@ -113,12 +113,13 @@ def schema_two_facts(route=AUTOMATIC_ROUTE):
         "<!-- automation:review-invocation-budget:opencode:v1 -->\n"
         + prefix + compact(ledger) + " -->"
     )
-    facts["receipt"]["original"]["finalized_invocation_sha256"] = digest(
-        compact(ledger["invocations"][0])
-    )
-    facts["check"]["output"]["text"] = (
-        "<!-- automation-opencode-recovery:" + compact(facts["receipt"]) + " -->"
-    )
+    if not preserve_receipt_digest:
+        facts["receipt"]["original"]["finalized_invocation_sha256"] = digest(
+            compact(ledger["invocations"][0])
+        )
+        facts["check"]["output"]["text"] = (
+            "<!-- automation-opencode-recovery:" + compact(facts["receipt"]) + " -->"
+        )
     return facts
 
 
@@ -128,6 +129,10 @@ def test_receipt_accepts_historical_schema_one_invocation():
 
 def test_receipt_accepts_schema_two_automatic_invocation():
     assert node_validate(schema_two_facts())
+
+
+def test_receipt_accepts_unchanged_schema_one_digest_after_automatic_migration():
+    assert node_validate(schema_two_facts(preserve_receipt_digest=True))
 
 
 @pytest.mark.parametrize("route", [

--- a/tests/test_opencode_recovery_receipts.py
+++ b/tests/test_opencode_recovery_receipts.py
@@ -97,8 +97,46 @@ def node_validate(facts):
     return json.loads(result.stdout)["valid"]
 
 
-def test_receipt_accepts_complete_exact_provenance():
+AUTOMATIC_ROUTE = object()
+
+
+def schema_two_facts(route=AUTOMATIC_ROUTE):
+    facts = facts_fixture()
+    if route is AUTOMATIC_ROUTE:
+        route = {"kind": "automatic"}
+    prefix = "<!-- automation-budget-state:"
+    ledger = json.loads(facts["ledgerComment"]["body"].splitlines()[1][len(prefix):-4])
+    ledger["schema"] = 2
+    if route is not None:
+        ledger["invocations"][0]["route"] = route
+    facts["ledgerComment"]["body"] = (
+        "<!-- automation:review-invocation-budget:opencode:v1 -->\n"
+        + prefix + compact(ledger) + " -->"
+    )
+    facts["receipt"]["original"]["finalized_invocation_sha256"] = digest(
+        compact(ledger["invocations"][0])
+    )
+    facts["check"]["output"]["text"] = (
+        "<!-- automation-opencode-recovery:" + compact(facts["receipt"]) + " -->"
+    )
+    return facts
+
+
+def test_receipt_accepts_historical_schema_one_invocation():
     assert node_validate(facts_fixture())
+
+
+def test_receipt_accepts_schema_two_automatic_invocation():
+    assert node_validate(schema_two_facts())
+
+
+@pytest.mark.parametrize("route", [
+    None,
+    {"kind": "authorized_override"},
+    {"kind": "automatic", "unexpected": True},
+])
+def test_receipt_rejects_schema_two_noncanonical_automatic_route(route):
+    assert not node_validate(schema_two_facts(route))
 
 
 @pytest.mark.parametrize("field,value", [

--- a/tests/test_opencode_recovery_transport.py
+++ b/tests/test_opencode_recovery_transport.py
@@ -230,7 +230,7 @@ def test_finalized_without_receipt_retries_only_receipt_publication(tmp_path, tr
 
 
 def test_current_workflow_uses_tokenless_recovery_discovery_during_replay(tmp_path, transport):
-    b = original_bundle(tmp_path)
+    b = original_bundle(tmp_path, ledger_schema=2)
     b["workflow_source"] = (ROOT / ".github/workflows/opencode-auto-review.yml").read_text()
     api = FakeAPI(b)
     assert execute(transport, b, api)["decision"] == "finalized"
@@ -238,7 +238,7 @@ def test_current_workflow_uses_tokenless_recovery_discovery_during_replay(tmp_pa
 
 
 def test_current_history_authenticates_completed_receipt_from_server_facts(tmp_path, transport):
-    b = original_bundle(tmp_path)
+    b = original_bundle(tmp_path, ledger_schema=2)
     b["workflow_source"] = (ROOT / ".github/workflows/opencode-auto-review.yml").read_text()
     api = FakeAPI(b)
     execute(transport, b, api)

--- a/tests/test_review_invocation_budget.py
+++ b/tests/test_review_invocation_budget.py
@@ -24,6 +24,11 @@ HASH_2 = "2" * 64
 HASH_3 = "3" * 64
 CENTRAL_SHA = "d" * 40
 CENTRAL_REF = "refs/tags/v1.47"
+REQUEST_NONCE = "e" * 32
+DRIVER_COMMIT = "f" * 40
+TARGET_RELEASE_COMMIT = "9" * 40
+MANAGED_DIFF_SHA256 = "4" * 64
+AUTOMATIC_STATE_SHA256 = "5" * 64
 FINDING_1 = "RVW-111111111111"
 FINDING_2 = "RVW-222222222222"
 
@@ -58,6 +63,8 @@ def request(*, reviewer="claude", head=HEAD_A, full_hash=HASH_1, run_id=700, run
         "call_unit": CALL_UNITS[reviewer],
     }
     values.update(changes)
+    if values.get("force_review") and "route" not in changes:
+        values["route"] = budget.InvocationRoute(kind="authorized_override")
     return budget.ClaimRequest(**values)
 
 
@@ -96,7 +103,9 @@ def invocation(*, reviewer="claude", head=HEAD_A, full_hash=HASH_1, run_id=501, 
         run_id=run_id, run_attempt=run_attempt, head_sha=head,
         full_diff_sha256=full_hash,
         caller_workflow_path=f".github/workflows/{reviewer}-caller.yml",
-        caller_event="pull_request",
+        caller_event=(
+            "pull_request" if override_event_id is None else "workflow_dispatch"
+        ),
         referenced_workflow_path=(
             f"jhw7500/automation/{budget.WORKFLOWS[reviewer]}@{CENTRAL_SHA}"
         ),
@@ -109,6 +118,9 @@ def invocation(*, reviewer="claude", head=HEAD_A, full_hash=HASH_1, run_id=501, 
         elapsed_seconds=elapsed_seconds, status=status,
         outcome=outcome if status == "finalized" else None,
         stop_reason=outcome if status == "finalized" else "claimed", remaining_finding_ids=(),
+        route=budget.InvocationRoute(
+            kind="automatic" if override_event_id is None else "authorized_override",
+        ),
     )
 
 
@@ -209,6 +221,234 @@ def assert_stored_state_rejected(state, reason):
         budget.parse_ledger(
             ledger_body(state), repository=state.repository, pr=state.pr, reviewer=state.reviewer,
         )
+
+
+def fallback_route_dict():
+    return {
+        "kind": "default_branch_rollout_fallback",
+        "request_comment_id": 8101,
+        "request_nonce": REQUEST_NONCE,
+        "original_run_id": 7201,
+        "original_run_attempt": 2,
+        "expected_base_sha": HEAD_B,
+        "release_commit": TARGET_RELEASE_COMMIT,
+        "managed_diff_sha256": MANAGED_DIFF_SHA256,
+        "automatic_comment_id": 8102,
+        "automatic_state_sha256": AUTOMATIC_STATE_SHA256,
+    }
+
+
+def fallback_route():
+    return budget.InvocationRoute.from_dict(fallback_route_dict())
+
+
+def fallback_claim(**changes):
+    values = {
+        "route": fallback_route(),
+        "head": HEAD_A,
+        "run_id": 7301,
+        "run_attempt": 1,
+    }
+    values.update(changes)
+    return request(**values)
+
+
+def fallback_provenances(claim_request=None):
+    claim_request = fallback_claim() if claim_request is None else claim_request
+    return {
+        (claim_request.run_id, claim_request.run_attempt): budget.RunProvenance(
+            repository=REPOSITORY,
+            pr=PR,
+            head_sha=claim_request.head_sha,
+            caller_workflow_path=".github/workflows/claude.yml",
+            caller_event="issue_comment",
+            referenced_workflow_path=(
+                f"jhw7500/automation/{budget.WORKFLOWS['claude']}@{DRIVER_COMMIT}"
+            ),
+            referenced_workflow_ref="refs/tags/v1.76",
+            referenced_workflow_sha=DRIVER_COMMIT,
+            run_id=claim_request.run_id,
+            run_attempt=claim_request.run_attempt,
+            status="in_progress",
+            conclusion=None,
+        )
+    }
+
+
+def schema_one_ledger(*, caller_event="pull_request"):
+    override_event_id = 9001 if caller_event == "workflow_dispatch" else None
+    state = budget.LedgerState.initial(
+        REPOSITORY,
+        PR,
+        "claude",
+        invocations=(replace(
+            invocation(override_event_id=override_event_id),
+            caller_event=caller_event,
+        ),),
+        consumed_override_event_ids=(() if override_event_id is None else (override_event_id,)),
+    )
+    raw = state.to_dict()
+    raw["schema"] = 1
+    for item in raw["invocations"]:
+        item.pop("route", None)
+    return raw
+
+
+@pytest.mark.parametrize(("event", "kind"), [
+    ("pull_request", "automatic"),
+    ("workflow_dispatch", "authorized_override"),
+])
+def test_schema_one_invocations_gain_typed_route(event, kind):
+    raw = schema_one_ledger(caller_event=event)
+    state = budget.LedgerState.from_dict(raw)
+    assert state.invocations[0].route.kind == kind
+    assert state.to_dict()["schema"] == 2
+
+
+def test_schema_one_invocation_with_unknown_event_fails_closed():
+    raw = schema_one_ledger()
+    raw["invocations"][0]["caller_event"] = "issue_comment"
+    with pytest.raises(budget.BudgetStateError, match="^invocation_route_invalid$"):
+        budget.LedgerState.from_dict(raw)
+
+
+@pytest.mark.parametrize("kind", ["automatic", "authorized_override"])
+def test_simple_routes_serialize_only_kind(kind):
+    route = budget.InvocationRoute.from_dict({"kind": kind})
+    assert route.to_dict() == {"kind": kind}
+    with pytest.raises(budget.BudgetStateError, match="^invocation_route_invalid$"):
+        budget.InvocationRoute.from_dict({"kind": kind, "request_comment_id": None})
+
+
+def test_fallback_route_serializes_exact_evidence_fields():
+    raw = fallback_route_dict()
+    assert budget.InvocationRoute.from_dict(raw).to_dict() == raw
+
+
+def test_fallback_route_requires_every_evidence_field():
+    raw = fallback_route_dict()
+    raw.pop("automatic_state_sha256")
+    with pytest.raises(budget.BudgetStateError, match="^invocation_route_invalid$"):
+        budget.InvocationRoute.from_dict(raw)
+
+
+@pytest.mark.parametrize(("field", "value"), [
+    ("request_comment_id", 0),
+    ("request_nonce", "not-a-nonce"),
+    ("original_run_id", True),
+    ("original_run_attempt", 0),
+    ("expected_base_sha", "not-a-sha"),
+    ("release_commit", "not-a-sha"),
+    ("managed_diff_sha256", "not-a-digest"),
+    ("automatic_comment_id", -1),
+    ("automatic_state_sha256", "not-a-digest"),
+])
+def test_fallback_route_rejects_invalid_evidence(field, value):
+    raw = fallback_route_dict()
+    raw[field] = value
+    with pytest.raises(budget.BudgetStateError, match="^invocation_route_invalid$"):
+        budget.InvocationRoute.from_dict(raw)
+
+
+def test_fallback_claim_uses_pr_head_and_one_automatic_round():
+    claim_request = fallback_claim()
+    result = budget.claim(None, claim_request, fallback_provenances(claim_request))
+    invocation = result.state.invocations[-1]
+    assert result.allow_invocation is True
+    assert invocation.head_sha == HEAD_A
+    assert invocation.caller_event == "issue_comment"
+    assert invocation.caller_workflow_path == ".github/workflows/claude.yml"
+    assert invocation.referenced_workflow_sha == DRIVER_COMMIT
+    assert invocation.route.release_commit == TARGET_RELEASE_COMMIT
+    assert invocation.round_number == 1
+    assert invocation.override_event_id is None
+
+
+@pytest.mark.parametrize("change", [
+    "force_review", "wrong_caller", "wrong_pr_head", "wrong_base",
+    "wrong_request", "wrong_target_release", "wrong_driver", "wrong_state_digest",
+    "non_claude_reviewer",
+])
+def test_fallback_provenance_rejects_mismatches(change):
+    claim_request = fallback_claim()
+    provenances = fallback_provenances(claim_request)
+    key = (claim_request.run_id, claim_request.run_attempt)
+    if change == "force_review":
+        claim_request = replace(claim_request, force_review=True)
+    elif change == "wrong_caller":
+        provenances[key] = replace(
+            provenances[key], caller_workflow_path=".github/workflows/other.yml",
+        )
+    elif change == "wrong_pr_head":
+        claim_request = replace(claim_request, head_sha="not-a-sha")
+    elif change == "wrong_base":
+        claim_request = replace(
+            claim_request,
+            route=replace(claim_request.route, expected_base_sha="not-a-sha"),
+        )
+    elif change == "wrong_request":
+        claim_request = replace(
+            claim_request,
+            route=replace(claim_request.route, request_comment_id=0),
+        )
+    elif change == "wrong_target_release":
+        claim_request = replace(
+            claim_request,
+            route=replace(claim_request.route, release_commit="not-a-sha"),
+        )
+    elif change == "wrong_driver":
+        provenances[key] = replace(
+            provenances[key], referenced_workflow_sha="8" * 40,
+        )
+    elif change == "wrong_state_digest":
+        claim_request = replace(
+            claim_request,
+            route=replace(claim_request.route, automatic_state_sha256="not-a-digest"),
+        )
+    elif change == "non_claude_reviewer":
+        claim_request = replace(claim_request, reviewer="gemini")
+    transition = budget.claim(None, claim_request, provenances)
+    assert (transition.allow_invocation, transition.decision) == (False, "state_invalid")
+
+
+def test_finalize_requires_the_exact_claimed_fallback_route():
+    claim_request = fallback_claim()
+    claimed = budget.claim(None, claim_request, fallback_provenances(claim_request)).state
+    current = fallback_provenances(claim_request)
+    finalize = finalize_request(
+        head=claim_request.head_sha,
+        run_id=claim_request.run_id,
+        run_attempt=claim_request.run_attempt,
+        route=replace(claim_request.route, automatic_comment_id=9999),
+    )
+    result = budget.finalize(claimed, finalize, current)
+    assert result.decision == "state_invalid"
+    assert result.stop_reason == "invocation_route_mismatch"
+
+
+def test_idempotent_recovery_rejects_finalize_route_drift():
+    claim_request = request(reviewer="opencode")
+    claimed = budget.claim(
+        None, claim_request, claim_provenances(None, claim_request),
+    ).state
+    original_claim = claimed.invocations[-1]
+    authenticated = budget.AuthenticatedReview(True, HEAD_A, HASH_1)
+    finalize = finalize_request(
+        reviewer="opencode", authenticated_review=authenticated,
+        route=budget.InvocationRoute.automatic(),
+    )
+    completed = budget.recover_finalize(
+        claimed, original_claim, finalize, current_provenances(claimed),
+    )
+    assert completed.decision == "finalized"
+    drifted = budget.recover_finalize(
+        completed.state,
+        original_claim,
+        replace(finalize, route=budget.InvocationRoute(kind="authorized_override")),
+        valid_provenances(completed.state),
+    )
+    assert drifted.decision == "state_invalid"
+    assert drifted.stop_reason == "invocation_route_mismatch"
 
 
 @pytest.fixture
@@ -443,6 +683,7 @@ def test_force_review_claims_same_head_once_with_dispatch_and_authorized_overrid
     force_request = replace(
         request(run_id=700),
         force_review=True,
+        route=budget.InvocationRoute(kind="authorized_override"),
         override_events=(
             budget.OverrideEvent(9001, "labeled", "review-budget-override", "write"),
         ),
@@ -499,7 +740,10 @@ def test_force_review_fails_closed_without_dispatch_or_authorized_override():
         "claude",
         invocations=(invocation(),),
     )
-    force_request = replace(request(run_id=700), force_review=True)
+    force_request = replace(
+        request(run_id=700), force_review=True,
+        route=budget.InvocationRoute(kind="authorized_override"),
+    )
     pull_request_provenances = claim_provenances(existing, force_request)
 
     wrong_event = budget.claim(existing, force_request, pull_request_provenances)
@@ -798,7 +1042,7 @@ def test_parser_requires_exact_schema_and_serializes_deterministically():
     assert budget.parse_ledger(body, repository=REPOSITORY, pr=PR, reviewer="gemini") == state
     assert payload == json.dumps(state.to_dict(), ensure_ascii=True, separators=(",", ":"), sort_keys=True)
     with pytest.raises(budget.BudgetStateError):
-        budget.parse_ledger(body.replace('"schema":1', '"schema":true'), repository=REPOSITORY, pr=PR, reviewer="gemini")
+        budget.parse_ledger(body.replace('"schema":2', '"schema":true'), repository=REPOSITORY, pr=PR, reviewer="gemini")
 
 
 def test_parser_rejects_noncanonical_json_encoding():

--- a/tests/test_review_invocation_budget.py
+++ b/tests/test_review_invocation_budget.py
@@ -312,6 +312,17 @@ def test_schema_one_invocation_with_unknown_event_fails_closed():
         budget.LedgerState.from_dict(raw)
 
 
+def test_schema_one_checkpoint_is_canonical_before_migration_on_read():
+    ledger = schema_one_ledger()
+    payload = (json.dumps(
+        {"schema": 1, "ledger": ledger, "handoff": ledger["handoff"]},
+        ensure_ascii=True, separators=(",", ":"), sort_keys=True,
+    ) + "\n").encode("ascii")
+    restored = budget.load_checkpoint(payload)
+    assert restored.to_dict()["schema"] == 2
+    assert restored.invocations[0].route == budget.InvocationRoute(kind="automatic")
+
+
 @pytest.mark.parametrize("kind", ["automatic", "authorized_override"])
 def test_simple_routes_serialize_only_kind(kind):
     route = budget.InvocationRoute.from_dict({"kind": kind})

--- a/tests/test_review_invocation_budget_action.py
+++ b/tests/test_review_invocation_budget_action.py
@@ -18,6 +18,8 @@ HEAD_A = "a" * 40
 HEAD_B = "b" * 40
 HASH_1 = "1" * 64
 HASH_2 = "2" * 64
+BASE_SHA = "b" * 40
+TARGET_RELEASE_COMMIT = "e" * 40
 CENTRAL_REF = "refs/tags/v1.47"
 CENTRAL_SHA = "d" * 40
 CENTRAL_PATH = (
@@ -29,6 +31,21 @@ assert SPEC and SPEC.loader
 budget = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = budget
 SPEC.loader.exec_module(budget)
+
+
+def _fallback_route() -> dict[str, object]:
+    return {
+        "kind": "default_branch_rollout_fallback",
+        "request_comment_id": 8101,
+        "request_nonce": "9" * 32,
+        "original_run_id": 6101,
+        "original_run_attempt": 1,
+        "expected_base_sha": BASE_SHA,
+        "release_commit": TARGET_RELEASE_COMMIT,
+        "managed_diff_sha256": "3" * 64,
+        "automatic_comment_id": 8102,
+        "automatic_state_sha256": "4" * 64,
+    }
 
 
 def _prior_comment(round_count: int = 1) -> str:
@@ -55,6 +72,9 @@ def _prior_comment(round_count: int = 1) -> str:
             outcome="provider_failure",
             stop_reason="provider_failure",
             remaining_finding_ids=(),
+            route=budget.InvocationRoute.from_legacy_event(
+                "workflow_dispatch" if index >= 5 else "pull_request",
+            ),
         )
         for index in range(round_count)
     )
@@ -94,6 +114,53 @@ def _claimed_comment() -> str:
         outcome=None,
         stop_reason="claimed",
         remaining_finding_ids=(),
+        route=budget.InvocationRoute.automatic(),
+    )
+    state = budget.LedgerState.initial("example/repo", 52, "claude", invocations=(invocation,))
+    return (
+        f"{budget.MARKERS['claude']}\n"
+        f"{budget.STATE_PREFIX}{budget.serialize_ledger(state)}{budget.STATE_SUFFIX}\n\nprior"
+    )
+
+
+def _schema_one_prior_comment() -> str:
+    state = json.loads(
+        _prior_comment().split(budget.STATE_PREFIX, 1)[1].split(budget.STATE_SUFFIX, 1)[0]
+    )
+    state["schema"] = 1
+    for invocation in state["invocations"]:
+        invocation.pop("route")
+    payload = json.dumps(state, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    return (
+        f"{budget.MARKERS['claude']}\n"
+        f"{budget.STATE_PREFIX}{payload}{budget.STATE_SUFFIX}\n\nprior"
+    )
+
+
+def _fallback_claimed_comment() -> str:
+    invocation = budget.Invocation(
+        run_id=700,
+        run_attempt=1,
+        head_sha=HEAD_A,
+        full_diff_sha256=HASH_1,
+        caller_workflow_path=".github/workflows/claude.yml",
+        caller_event="issue_comment",
+        referenced_workflow_path=CENTRAL_PATH,
+        referenced_workflow_ref=CENTRAL_REF,
+        referenced_workflow_sha=CENTRAL_SHA,
+        round_number=1,
+        override_event_id=None,
+        model_route=("route-v2",),
+        effort="medium",
+        call_unit="claude-code-action review session",
+        call_count=0,
+        estimated_input_tokens=20_002,
+        elapsed_seconds=0,
+        status="claimed",
+        outcome=None,
+        stop_reason="claimed",
+        remaining_finding_ids=(),
+        route=budget.InvocationRoute.from_dict(_fallback_route()),
     )
     state = budget.LedgerState.initial("example/repo", 52, "claude", invocations=(invocation,))
     return (
@@ -130,7 +197,12 @@ if endpoint.endswith("/pulls/52"):
     head = config["head"]
     if config["scenario"] == "pr-head-changed-before-patch" and state["pr"] > 1:
         head = "c" * 40
-    response = {"number": 52, "head": {"sha": head}}
+    base_sha = "b" * 40
+    if config["scenario"] == "fallback-wrong-base" or (
+        config["scenario"] == "fallback-base-changed-before-patch" and state["pr"] > 1
+    ):
+        base_sha = "c" * 40
+    response = {"number": 52, "head": {"sha": head}, "base": {"sha": base_sha}}
 elif endpoint.endswith("/issues/52/comments?per_page=100"):
     state["comments"] += 1
     response = config["comments"]
@@ -163,16 +235,17 @@ elif "/actions/runs/501/attempts/1" in endpoint:
     if config["scenario"] == "historical-run-head-mismatch":
         response["head_sha"] = "b" * 40
 elif "/actions/runs/700/attempts/1" in endpoint:
+    fallback = config["scenario"].startswith("fallback-")
     response = {
         "id": 700,
         "run_attempt": 1,
-        "head_sha": config["head"],
-        "event": "pull_request",
-        "path": ".github/workflows/claude-review-caller.yml",
+        "head_sha": "6" * 40 if fallback else config["head"],
+        "event": "issue_comment" if fallback else "pull_request",
+        "path": ".github/workflows/claude.yml" if fallback else ".github/workflows/claude-review-caller.yml",
         "status": "in_progress",
         "conclusion": None,
         "repository": {"full_name": "example/repo"},
-        "pull_requests": [{"number": 52}],
+        "pull_requests": [] if fallback else [{"number": 52}],
         "referenced_workflows": [{
             "path": "jhw7500/automation/.github/workflows/claude-code-review.yml@" + "d" * 40,
             "ref": "refs/tags/v1.47",
@@ -231,6 +304,7 @@ class FakeGitHub:
         self, *, mode: str, scenario: str, hostile: bool = False,
         diff_mode: str = "full", env_overrides: dict[str, str] | None = None,
         timeline: list[dict] | None = None, permissions: dict[str, str] | None = None,
+        invocation_route: object | None = None,
     ) -> ActionResult:
         document = yaml.load(ACTION.read_text(), Loader=yaml.BaseLoader)
         run = document["runs"]["steps"][0]["run"]
@@ -262,12 +336,23 @@ class FakeGitHub:
         if scenario in {
             "first-comment-create", "empty-cas-pages",
             "current-run-reference-omits-ref",
+            "fallback-first-claim", "fallback-wrong-base",
+            "fallback-base-changed-before-patch",
         }:
             comments = []
             head, full_hash = HEAD_A, HASH_1
         elif scenario == "finalize-trusted-comment":
             comments = [_bot_comment(_claimed_comment())]
             head, full_hash = HEAD_A, HASH_1
+        elif scenario in {"fallback-finalize", "fallback-finalize-route-drift"}:
+            comments = [_bot_comment(_fallback_claimed_comment())]
+            head, full_hash = HEAD_A, HASH_1
+        elif scenario == "schema-one-migration":
+            comments = [_bot_comment(_schema_one_prior_comment())]
+            head, full_hash = HEAD_B, HASH_2
+        elif scenario == "fallback-duplicate-head":
+            comments = [_bot_comment(_prior_comment())]
+            head, full_hash = HEAD_A, HASH_2
         else:
             comments = [_bot_comment(prior)]
             head, full_hash = HEAD_B, HASH_2
@@ -303,6 +388,9 @@ class FakeGitHub:
                 "full_diff_sha256": None,
                 "remaining_finding_ids": [],
             }),
+            "INVOCATION_ROUTE_JSON": json.dumps(
+                {"kind": "automatic"} if invocation_route is None else invocation_route
+            ),
             "MODEL_ROUTE_JSON": json.dumps([route]),
             "EFFORT": effort,
             "ACTUAL_CALL_COUNT": "1" if mode == "finalize" else "0",
@@ -337,7 +425,9 @@ class FakeGitHub:
         assert not marker.exists()
         if hostile:
             argv = [json.loads(entry) for entry in argv_log.read_text().splitlines()]
-            for name in ("INPUT_FILES_JSON", "MODEL_ROUTE_JSON", "EFFORT"):
+            for name in (
+                "INPUT_FILES_JSON", "INVOCATION_ROUTE_JSON", "MODEL_ROUTE_JSON", "EFFORT",
+            ):
                 value = request_values[name]
                 assert sum(part == value for entry in argv for part in entry) == 1, name
         return ActionResult(outputs, json.loads(checkpoint.read_text()), calls)
@@ -353,7 +443,7 @@ def test_action_metadata_has_one_inert_environment_bridge():
     assert set(document["inputs"]) == {
         "github-token", "mode", "reviewer", "pr-number", "expected-head-sha",
         "full-diff-sha256", "diff-mode", "input-files-json", "authenticated-review-json",
-        "force-review",
+        "force-review", "invocation-route-json",
         "model-route-json", "effort", "checkpoint-file", "actual-call-count",
         "elapsed-seconds", "outcome", "stop-reason", "remaining-finding-ids-json",
         "max-rounds",
@@ -366,6 +456,7 @@ def test_action_metadata_has_one_inert_environment_bridge():
     assert {name: value["default"] for name, value in document["inputs"].items() if "default" in value} == {
         "actual-call-count": "0",
         "force-review": "false",
+        "invocation-route-json": '{"kind":"automatic"}',
         "elapsed-seconds": "0",
         "outcome": "checkpoint_failure",
         "stop-reason": "",
@@ -383,6 +474,7 @@ def test_action_metadata_has_one_inert_environment_bridge():
     assert step["shell"] == "bash"
     assert step["env"]["GH_TOKEN"] == "${{ inputs.github-token }}"
     assert step["env"]["REVIEW_MAX_ROUNDS"] == "${{ inputs.max-rounds }}"
+    assert step["env"]["INVOCATION_ROUTE_JSON"] == "${{ inputs.invocation-route-json }}"
     assert "${{ inputs." not in step["run"]
     assert step["run"].index('cat -- "$budget_dir/summary.md" >> "$GITHUB_STEP_SUMMARY"') < step[
         "run"
@@ -520,6 +612,91 @@ def test_first_claim_authenticates_and_stores_reusable_workflow_provenance(fake_
     assert invocation["referenced_workflow_path"] == CENTRAL_PATH
     assert invocation["referenced_workflow_ref"] == CENTRAL_REF
     assert invocation["referenced_workflow_sha"] == CENTRAL_SHA
+    assert invocation["route"] == {"kind": "automatic"}
+
+
+def test_schema_one_comment_migrates_on_the_next_claim(fake_github):
+    result = fake_github.run_action(mode="claim", scenario="schema-one-migration")
+    assert result.outputs["decision"] == "claimed"
+    assert result.checkpoint["ledger"]["schema"] == 2
+    assert [
+        invocation["route"]["kind"]
+        for invocation in result.checkpoint["ledger"]["invocations"]
+    ] == ["automatic", "automatic"]
+
+
+def test_fallback_claim_uses_fresh_pr_head_and_exact_base(fake_github):
+    result = fake_github.run_action(
+        mode="claim", scenario="fallback-first-claim", invocation_route=_fallback_route(),
+    )
+    invocation = result.checkpoint["ledger"]["invocations"][0]
+    assert result.outputs["decision"] == "claimed"
+    assert invocation["head_sha"] == HEAD_A
+    assert invocation["caller_event"] == "issue_comment"
+    assert invocation["caller_workflow_path"] == ".github/workflows/claude.yml"
+    assert invocation["referenced_workflow_sha"] == CENTRAL_SHA
+    assert invocation["route"] == _fallback_route()
+    assert invocation["round_number"] == 1
+    assert invocation["override_event_id"] is None
+
+
+def test_fallback_claim_rejects_fresh_pr_base_mismatch(fake_github):
+    result = fake_github.run_action(
+        mode="claim", scenario="fallback-wrong-base", invocation_route=_fallback_route(),
+    )
+    assert result.outputs["decision"] == "state_invalid"
+    assert result.outputs["allow-invocation"] == "false"
+    assert result.checkpoint["handoff"]["stop_reason"] == "pr_base_mismatch"
+
+
+def test_fallback_claim_rechecks_base_before_comment_mutation(fake_github):
+    result = fake_github.run_action(
+        mode="claim", scenario="fallback-base-changed-before-patch",
+        invocation_route=_fallback_route(),
+    )
+    mutations = [call for call in result.calls if "--method" in call]
+    assert result.outputs["decision"] == "state_invalid"
+    assert result.outputs["allow-invocation"] == "false"
+    assert mutations == []
+    assert result.checkpoint["handoff"]["stop_reason"] == "compare_and_swap_failed"
+
+
+def test_fallback_duplicate_head_reuses_existing_budget_without_a_round(fake_github):
+    result = fake_github.run_action(
+        mode="claim", scenario="fallback-duplicate-head", invocation_route=_fallback_route(),
+    )
+    assert result.outputs["decision"] == "duplicate_head"
+    assert result.outputs["allow-invocation"] == "false"
+    assert len(result.checkpoint["ledger"]["invocations"]) == 1
+
+
+def test_fallback_finalize_records_one_call_with_the_exact_route(fake_github):
+    result = fake_github.run_action(
+        mode="finalize", scenario="fallback-finalize", invocation_route=_fallback_route(),
+    )
+    invocation = result.checkpoint["ledger"]["invocations"][0]
+    assert result.outputs["decision"] == "finalized"
+    assert invocation["call_count"] == 1
+    assert invocation["route"] == _fallback_route()
+
+
+def test_malformed_invocation_route_json_refuses_before_github(fake_github):
+    result = fake_github.run_action(
+        mode="claim", scenario="first-comment-create",
+        env_overrides={"INVOCATION_ROUTE_JSON": "{"},
+    )
+    assert result.calls == []
+    assert result.outputs["decision"] == "state_invalid"
+    assert result.checkpoint["handoff"]["stop_reason"] == "invocation_route_json_invalid"
+
+
+def test_fallback_finalize_rejects_claim_route_drift(fake_github):
+    result = fake_github.run_action(
+        mode="finalize", scenario="fallback-finalize-route-drift",
+        invocation_route={"kind": "automatic"},
+    )
+    assert result.outputs["decision"] == "state_invalid"
+    assert result.checkpoint["handoff"]["stop_reason"] == "invocation_route_mismatch"
 
 
 def test_first_claim_uses_resolved_sha_when_github_omits_reusable_workflow_ref(fake_github):

--- a/tests/test_review_invocation_budget_action.py
+++ b/tests/test_review_invocation_budget_action.py
@@ -684,11 +684,10 @@ def test_force_review_default_route_claims_as_authorized_override(fake_github):
     assert invocation["override_event_id"] == 9001
 
 
-def test_force_review_default_route_finalizes_as_authorized_override(fake_github):
+def test_force_review_default_route_finalizes_with_action_defaults(fake_github):
     result = fake_github.run_action(
         mode="finalize",
         scenario="force-review-default-finalize",
-        env_overrides={"FORCE_REVIEW": "true"},
     )
     invocation = result.checkpoint["ledger"]["invocations"][0]
     assert result.outputs["decision"] == "finalized"

--- a/tests/test_review_invocation_budget_action.py
+++ b/tests/test_review_invocation_budget_action.py
@@ -123,6 +123,41 @@ def _claimed_comment() -> str:
     )
 
 
+def _override_claimed_comment() -> str:
+    invocation = budget.Invocation(
+        run_id=700,
+        run_attempt=1,
+        head_sha=HEAD_A,
+        full_diff_sha256=HASH_1,
+        caller_workflow_path=".github/workflows/claude-review-caller.yml",
+        caller_event="workflow_dispatch",
+        referenced_workflow_path=CENTRAL_PATH,
+        referenced_workflow_ref=CENTRAL_REF,
+        referenced_workflow_sha=CENTRAL_SHA,
+        round_number=1,
+        override_event_id=9001,
+        model_route=("route-v2",),
+        effort="medium",
+        call_unit="claude-code-action review session",
+        call_count=0,
+        estimated_input_tokens=20_002,
+        elapsed_seconds=0,
+        status="claimed",
+        outcome=None,
+        stop_reason="claimed",
+        remaining_finding_ids=(),
+        route=budget.InvocationRoute(kind="authorized_override"),
+    )
+    state = budget.LedgerState.initial(
+        "example/repo", 52, "claude", invocations=(invocation,),
+        consumed_override_event_ids=(9001,),
+    )
+    return (
+        f"{budget.MARKERS['claude']}\n"
+        f"{budget.STATE_PREFIX}{budget.serialize_ledger(state)}{budget.STATE_SUFFIX}\n\nprior"
+    )
+
+
 def _schema_one_prior_comment() -> str:
     state = json.loads(
         _prior_comment().split(budget.STATE_PREFIX, 1)[1].split(budget.STATE_SUFFIX, 1)[0]
@@ -236,16 +271,17 @@ elif "/actions/runs/501/attempts/1" in endpoint:
         response["head_sha"] = "b" * 40
 elif "/actions/runs/700/attempts/1" in endpoint:
     fallback = config["scenario"].startswith("fallback-")
+    override = config["scenario"].startswith("force-review-default-")
     response = {
         "id": 700,
         "run_attempt": 1,
         "head_sha": "6" * 40 if fallback else config["head"],
-        "event": "issue_comment" if fallback else "pull_request",
+        "event": "issue_comment" if fallback else "workflow_dispatch" if override else "pull_request",
         "path": ".github/workflows/claude.yml" if fallback else ".github/workflows/claude-review-caller.yml",
         "status": "in_progress",
         "conclusion": None,
         "repository": {"full_name": "example/repo"},
-        "pull_requests": [] if fallback else [{"number": 52}],
+        "pull_requests": [] if fallback or override else [{"number": 52}],
         "referenced_workflows": [{
             "path": "jhw7500/automation/.github/workflows/claude-code-review.yml@" + "d" * 40,
             "ref": "refs/tags/v1.47",
@@ -338,11 +374,15 @@ class FakeGitHub:
             "current-run-reference-omits-ref",
             "fallback-first-claim", "fallback-wrong-base",
             "fallback-base-changed-before-patch",
+            "force-review-default-claim",
         }:
             comments = []
             head, full_hash = HEAD_A, HASH_1
         elif scenario == "finalize-trusted-comment":
             comments = [_bot_comment(_claimed_comment())]
+            head, full_hash = HEAD_A, HASH_1
+        elif scenario == "force-review-default-finalize":
+            comments = [_bot_comment(_override_claimed_comment())]
             head, full_hash = HEAD_A, HASH_1
         elif scenario in {"fallback-finalize", "fallback-finalize-route-drift"}:
             comments = [_bot_comment(_fallback_claimed_comment())]
@@ -623,6 +663,36 @@ def test_schema_one_comment_migrates_on_the_next_claim(fake_github):
         invocation["route"]["kind"]
         for invocation in result.checkpoint["ledger"]["invocations"]
     ] == ["automatic", "automatic"]
+
+
+def test_force_review_default_route_claims_as_authorized_override(fake_github):
+    result = fake_github.run_action(
+        mode="claim",
+        scenario="force-review-default-claim",
+        env_overrides={"FORCE_REVIEW": "true"},
+        timeline=[{
+            "id": 9001,
+            "event": "labeled",
+            "label": {"name": "review-budget-override"},
+            "actor": {"login": "maintainer"},
+        }],
+        permissions={"maintainer": "write"},
+    )
+    invocation = result.checkpoint["ledger"]["invocations"][0]
+    assert result.outputs["decision"] == "claimed"
+    assert invocation["route"] == {"kind": "authorized_override"}
+    assert invocation["override_event_id"] == 9001
+
+
+def test_force_review_default_route_finalizes_as_authorized_override(fake_github):
+    result = fake_github.run_action(
+        mode="finalize",
+        scenario="force-review-default-finalize",
+        env_overrides={"FORCE_REVIEW": "true"},
+    )
+    invocation = result.checkpoint["ledger"]["invocations"][0]
+    assert result.outputs["decision"] == "finalized"
+    assert invocation["route"] == {"kind": "authorized_override"}
 
 
 def test_fallback_claim_uses_fresh_pr_head_and_exact_base(fake_github):

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -13806,6 +13806,7 @@ def _run_opencode_canonicalize(
                 "status": "claimed",
                 "outcome": None,
                 "stop_reason": "claimed",
+                "route": {"kind": "automatic"},
             }
         )
     budget_checkpoint = handoff_dir / "review-budget-claim.json"
@@ -13814,7 +13815,7 @@ def _run_opencode_canonicalize(
             {
                 "schema": 1,
                 "ledger": {
-                    "schema": 1,
+                    "schema": 2,
                     "repository": "example/repo",
                     "pr": 7,
                     "reviewer": "opencode",

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -599,6 +599,28 @@ def _review_run_fixtures(comments: list[dict], reviewer: str) -> list[dict]:
     return runs
 
 
+def _fallback_run_fixture(state: dict[str, object]) -> dict:
+    return {
+        "id": state["run_id"],
+        "run_attempt": state["run_attempt"],
+        "status": "completed",
+        "conclusion": "success" if state["attempt_status"] == "success" else "failure",
+        "head_sha": "44" * 20,
+        "event": "issue_comment",
+        "path": ".github/workflows/claude.yml",
+        "repository": {"full_name": "example/repo"},
+        "pull_requests": [],
+        "referenced_workflows": [{
+            "path": (
+                "jhw7500/automation/.github/workflows/"
+                "claude-code-review.yml@refs/tags/v1.77"
+            ),
+            "sha": "46" * 20,
+            "ref": "refs/tags/v1.77",
+        }],
+    }
+
+
 def _human(login: str, body: str, comment_id: int = 2, created: str = "t") -> dict:
     return {
         "id": comment_id,
@@ -4675,11 +4697,90 @@ def test_fallback_success_state_is_readable_as_authenticated_review_context(tmp_
         full_diff_sha256="cc" * 32,
         route=FALLBACK_STATE_ROUTE,
     )
-    _run_collect(tmp_path, [_bot("github-actions[bot]", _v3_body(state), 31)])
+    comment = _bot("github-actions[bot]", _v3_body(state), 31)
+    _run_collect(tmp_path, [comment], workflow_runs=[_fallback_run_fixture(state)])
     outputs = _github_outputs(tmp_path / "github-output")
     assert outputs["previous_sha"] == head
     assert outputs["previous_full_hash"] == "cc" * 32
     assert json.loads(outputs["authenticated_review_json"])["success"] is True
+
+
+@node_required
+def test_fallback_success_state_is_updated_on_subsequent_publication(tmp_path):
+    prior_state = _v3_state(
+        run_id=1,
+        head="ab" * 20,
+        full_diff_sha256="cc" * 32,
+        route=FALLBACK_STATE_ROUTE,
+    )
+    prior = _bot(
+        "github-actions[bot]", _v3_body(prior_state, "PRIOR FALLBACK REVIEW"), 31,
+    )
+    calls = _claude_upsert(
+        tmp_path,
+        "success",
+        [prior],
+        with_review=True,
+        review="SUBSEQUENT REVIEW",
+        workflow_runs=[_fallback_run_fixture(prior_state)],
+    )
+    assert [call[1]["comment_id"] for call in calls if call[0] == "update"] == [31]
+    assert not [call for call in calls if call[0] == "create"]
+
+
+def _malformed_extension_state(field: str, value: object) -> dict[str, object]:
+    if field == "failure_reason":
+        return _v3_state(
+            run_id=99,
+            attempt_status="failure",
+            successful_head=None,
+            diff_mode="unavailable",
+            review_execution="not_performed",
+            full_diff_sha256=None,
+            accepted_count=None,
+            filtered_count=None,
+            normalized_count=None,
+            filtered_max_severity=None,
+            failure_reason=value,
+        )
+    route = dict(FALLBACK_STATE_ROUTE)
+    route[field] = value
+    return _v3_state(run_id=99, full_diff_sha256="cc" * 32, route=route)
+
+
+@node_required
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("failure_reason", None),
+        ("failure_reason", True),
+        ("failure_reason", ["workflow_validation_mismatch"]),
+        ("reviewed_base_sha", ["bb" * 20]),
+        ("release_commit", ["444a7347aee169ed178aae80e8bd8d10eca52e02"]),
+    ),
+)
+def test_claude_readers_reject_non_string_extension_fields(tmp_path, field, value):
+    valid_state = _v3_state(run_id=1, head="ab" * 20)
+    valid = _bot(
+        "github-actions[bot]", _v3_body(valid_state, "VALID PRIOR REVIEW"), 11,
+    )
+    malformed_state = _malformed_extension_state(field, value)
+    malformed = _bot(
+        "github-actions[bot]", _v3_body(malformed_state, "MALFORMED EXTENSION"), 99,
+    )
+    _run_collect(tmp_path, [valid, malformed])
+    context = (tmp_path / "claude-review-context.md").read_text(encoding="utf-8")
+    assert "VALID PRIOR REVIEW" in context
+    assert "MALFORMED EXTENSION" not in context
+
+    calls = _claude_upsert(
+        tmp_path,
+        "failure",
+        [valid, malformed],
+        with_review=False,
+    )
+    assert [call[1]["comment_id"] for call in calls if call[0] == "update"] == [11]
+    assert not [call for call in calls if call[0] == "create"]
 
 
 @node_required

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -59,6 +59,15 @@ GEMINI_V2_MARKER = "<!-- automation:gemini-auto-review:v2 -->"
 GEMINI_V3_MARKER = "<!-- automation:gemini-auto-review:v3 -->"
 GITHUB_ACTIONS_APP_ID = 15368
 
+FALLBACK_STATE_ROUTE = {
+    "managed_diff_sha256": "cc" * 32,
+    "original_failed_run_id": 34549275027,
+    "release_commit": "444a7347aee169ed178aae80e8bd8d10eca52e02",
+    "request_comment_id": 901,
+    "reviewed_base_sha": "bb" * 20,
+    "route": "default_branch_rollout_fallback",
+}
+
 
 def _state_line(
     reviewer: str, pr: int, run_id: int, head: str, run_attempt: int = 1, **changes: object
@@ -1439,6 +1448,7 @@ def test_claude_budget_claim_is_durable_before_provider_and_every_model_path_is_
     claim = _step(workflow, "claude-review", "Claim Claude review budget")
     assert claim["if"] == (
         "${{ always() && steps.prepare-review-input.outcome == 'success' "
+        "&& steps.claude-invocation-route.outcome == 'success' "
         "&& steps.stage-claude-budget-input.outcome == 'success' "
         "&& (steps.prepare-diff.outputs.diff-ready != 'true' "
         "|| steps.prepare-diff.outputs.diff-mode == 'unchanged' "
@@ -1457,6 +1467,9 @@ def test_claude_budget_claim_is_durable_before_provider_and_every_model_path_is_
         ),
             "diff-mode": "${{ steps.prepare-diff.outputs.diff-mode || 'unavailable' }}",
             "force-review": "${{ inputs.force_review && 'true' || 'false' }}",
+        "invocation-route-json": (
+            "${{ steps.claude-invocation-route.outputs.invocation_route_json }}"
+        ),
         "input-files-json": (
             "${{ steps.stage-claude-budget-input.outputs.input_files_json }}"
         ),
@@ -1720,6 +1733,9 @@ def test_claude_budget_finalizes_after_review_state_upsert_and_uploads_both_chec
         "expected-head-sha": "${{ steps.prepare-diff.outputs.head-sha }}",
         "full-diff-sha256": "${{ steps.prepare-diff.outputs.full-diff-sha256 }}",
         "diff-mode": "${{ steps.prepare-diff.outputs.diff-mode }}",
+        "invocation-route-json": (
+            "${{ steps.claude-invocation-route.outputs.invocation_route_json }}"
+        ),
         "input-files-json": "[]",
         "authenticated-review-json": (
             "${{ steps.prepare-review-input.outputs.authenticated_review_json }}"
@@ -2890,7 +2906,12 @@ def test_shared_diff_wiring_is_exact_and_scope_safe():
             "pr-number": pr_number,
             "previous-sha": f"${{{{ steps.{_step_id(job, collector_name)}.outputs.previous_sha }}}}",
             "previous-full-hash": f"${{{{ steps.{_step_id(job, collector_name)}.outputs.previous_full_hash }}}}",
-            "force-full": "${{ inputs.force_review && 'true' || 'false' }}",
+            "force-full": (
+                "${{ (inputs.force_review || steps.fallback-mode.outputs.mode == "
+                "'fallback') && 'true' || 'false' }}"
+                if filename == "claude-code-review.yml"
+                else "${{ inputs.force_review && 'true' || 'false' }}"
+            ),
             "context-lines": context_lines,
             "output-directory": "${{ runner.temp }}",
         }
@@ -3143,9 +3164,13 @@ def test_force_review_is_opt_in_and_forces_a_full_diff_for_every_provider():
         force_input = workflow["on"]["workflow_call"]["inputs"]["force_review"]
         assert force_input["type"] == "boolean"
         assert force_input["default"] == "false"
-        assert _step(workflow, job_name, prepare_name)["with"]["force-full"] == (
-            "${{ inputs.force_review && 'true' || 'false' }}"
+        expected_force_full = (
+            "${{ (inputs.force_review || steps.fallback-mode.outputs.mode == "
+            "'fallback') && 'true' || 'false' }}"
+            if workflow_name == "claude-code-review.yml"
+            else "${{ inputs.force_review && 'true' || 'false' }}"
         )
+        assert _step(workflow, job_name, prepare_name)["with"]["force-full"] == expected_force_full
         assert _step(workflow, job_name, claim_name)["with"]["force-review"] == (
             "${{ inputs.force_review && 'true' || 'false' }}"
         )
@@ -4198,6 +4223,7 @@ let comments = JSON.parse(JSON.stringify(fx.comments));
 let checkRuns = JSON.parse(JSON.stringify(fx.checkRuns || []));
 const workflowRunAttemptOffsets = new Map();
 let listCommentCalls = 0;
+let pullRequestCalls = 0;
 let listWorkflowRunCalls = 0;
 let listCheckRunCalls = 0;
 let nextCommentId = Math.max(100, ...comments.map((item) => Number(item.id) || 0)) + 1;
@@ -4247,7 +4273,13 @@ const github = {
         },
     },
     pulls: {
-      get: async () => ({ data: fx.pullRequest || { head: { sha: fx.currentHead } } }),
+      get: async () => {
+        const sequence = fx.pullRequestSequence;
+        const data = Array.isArray(sequence) && sequence.length
+          ? sequence[Math.min(pullRequestCalls++, sequence.length - 1)]
+          : (fx.pullRequest || { head: { sha: fx.currentHead } });
+        return { data };
+      },
       listCommits: 'LIST_COMMITS',
     },
     checks: {
@@ -4397,6 +4429,7 @@ def _run_upsert(
     inject_comments_at_list_call: dict[int, list[dict]] | None = None,
     node_preload: Path | None = None,
     pull_request: dict | None = None,
+    pull_request_sequence: list[dict] | None = None,
     pull_commits: list[dict] | None = None,
 ) -> list:
     workflow = _load(workflow_file)
@@ -4444,6 +4477,7 @@ def _run_upsert(
         "checkRunListResponses": check_run_list_responses,
         "currentWorkflowRun": current_workflow_run,
         "pullRequest": pull_request,
+        "pullRequestSequence": pull_request_sequence,
         "pullCommits": pull_commits or [],
         "runJobs": [{"name": "OpenCode Auto PR Review / opencode-canonicalize", "conclusion": "success"}],
         "runJobsByAttempt": run_jobs_by_attempt or {},
@@ -4496,6 +4530,10 @@ def _claude_upsert(
     workflow_run_attempt_sequences: dict[str, list[dict]] | None = None,
     candidate_artifact: str = "success",
     provider_failure_reason: str = "",
+    fallback_mode: str = "normal",
+    fallback_state_route_json: str = "",
+    current_base: str | None = None,
+    pull_request_sequence: list[dict] | None = None,
 ) -> list:
     workdir = tmp_path / ("with-review" if with_review else "without-review")
     workdir.mkdir()
@@ -4526,6 +4564,8 @@ def _claude_upsert(
         "CANONICAL_FAILURE_REASON": canonical_failure_reason,
         "CANDIDATE_ARTIFACT": candidate_artifact,
         "BUDGET_ALLOW_INVOCATION": budget_allow_invocation,
+        "FALLBACK_MODE": fallback_mode,
+        "FALLBACK_STATE_ROUTE_JSON": fallback_state_route_json,
         "BOT_LOGIN": "github-actions[bot]",
     }
     if not literal_schema:
@@ -4539,6 +4579,11 @@ def _claude_upsert(
         comments,
         cwd=workdir,
         current_head=current_head or attempt_head,
+        pull_request={
+            "head": {"sha": current_head or attempt_head},
+            "base": {"sha": current_base or "ef" * 20},
+        },
+        pull_request_sequence=pull_request_sequence,
         workflow_runs=workflow_runs,
         workflow_run_attempt_sequences=workflow_run_attempt_sequences,
     )
@@ -4548,6 +4593,93 @@ def _posted_state(body: str) -> dict[str, object]:
     match = re.search(r"^<!-- automation-state:(\{.*\}) -->$", body, re.M)
     assert match
     return json.loads(match.group(1))
+
+
+def test_fallback_claim_and_finalize_use_identical_route_json():
+    workflow = _load("claude-code-review.yml")
+    claim = _step(workflow, "claude-review", "Claim Claude review budget")
+    finalize = _step(workflow, "claude-review", "Finalize Claude review budget")
+    expected = "${{ steps.claude-invocation-route.outputs.invocation_route_json }}"
+    assert claim["with"]["invocation-route-json"] == expected
+    assert finalize["with"]["invocation-route-json"] == expected
+
+
+@node_required
+def test_fallback_success_publishes_authenticated_route(tmp_path):
+    calls = _claude_upsert(
+        tmp_path,
+        "success",
+        [],
+        with_review=True,
+        fallback_mode="fallback",
+        fallback_state_route_json=json.dumps(FALLBACK_STATE_ROUTE, separators=(",", ":")),
+        current_base="bb" * 20,
+        full_diff_sha256="cc" * 32,
+    )
+    state = _posted_state(_single_mutation_body(calls))
+    assert state["attempt_status"] == "success"
+    assert state["review_execution"] == "performed"
+    assert set(state["route"]) == {
+        "managed_diff_sha256", "original_failed_run_id", "release_commit",
+        "request_comment_id", "reviewed_base_sha", "route",
+    }
+    assert state["route"]["route"] == "default_branch_rollout_fallback"
+    assert state["route"]["original_failed_run_id"] == 34549275027
+    assert state["route"]["reviewed_base_sha"] == "bb" * 20
+
+
+@node_required
+def test_mismatch_failure_publishes_authenticated_reason(tmp_path):
+    calls = _claude_upsert(
+        tmp_path,
+        "skipped",
+        [],
+        with_review=False,
+        canonical_outcome="skipped",
+        document_valid="false",
+        provider_failure_reason="workflow_validation_mismatch",
+    )
+    state = _posted_state(_single_mutation_body(calls))
+    assert (state["failure_reason"], state["review_execution"]) == (
+        "workflow_validation_mismatch", "not_performed",
+    )
+
+
+@node_required
+def test_fallback_rechecks_live_head_and_base_immediately_before_publication(tmp_path):
+    head = "cd" * 20
+    calls = _claude_upsert(
+        tmp_path,
+        "success",
+        [],
+        with_review=True,
+        fallback_mode="fallback",
+        fallback_state_route_json=json.dumps(FALLBACK_STATE_ROUTE, separators=(",", ":")),
+        current_base="bb" * 20,
+        full_diff_sha256="cc" * 32,
+        pull_request_sequence=[
+            {"head": {"sha": head}, "base": {"sha": "bb" * 20}},
+            {"head": {"sha": head}, "base": {"sha": "ee" * 20}},
+        ],
+    )
+    assert not [call for call in calls if call[0] in {"create", "update"}]
+    assert [call for call in calls if call[0] == "notice"] == [[
+        "notice", "Claude review publication coordinates changed; left sticky state unchanged.",
+    ]]
+
+
+def test_fallback_success_state_is_readable_as_authenticated_review_context(tmp_path):
+    head = "ab" * 20
+    state = _v3_state(
+        head=head,
+        full_diff_sha256="cc" * 32,
+        route=FALLBACK_STATE_ROUTE,
+    )
+    _run_collect(tmp_path, [_bot("github-actions[bot]", _v3_body(state), 31)])
+    outputs = _github_outputs(tmp_path / "github-output")
+    assert outputs["previous_sha"] == head
+    assert outputs["previous_full_hash"] == "cc" * 32
+    assert json.loads(outputs["authenticated_review_json"])["success"] is True
 
 
 @node_required

--- a/tests/test_rollout_workflow_fleet.py
+++ b/tests/test_rollout_workflow_fleet.py
@@ -7,9 +7,13 @@ from dataclasses import fields, replace
 import json
 from pathlib import Path, PurePosixPath
 import subprocess
+import sys
 from unittest import mock
 
 import pytest
+
+if str(Path(__file__).resolve().parents[1]) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts import rollout_workflow_fleet as rollout
 from scripts.prepare_workflow_rollout import (
@@ -2555,7 +2559,7 @@ def test_new_pull_request_is_attested_against_branch_and_exact_pr_metadata(
             rollout.fleet_git, "list_rollout_prs", return_value=(request,)
         ),
     ):
-        rollout.attest_pull_request(snap, "v1.40", COMMIT, HEAD, changed, request)
+        rollout._attest_published_pull_request(snap, "v1.40", COMMIT, HEAD, changed, request)
 
     with (
         mock.patch.object(
@@ -2566,7 +2570,23 @@ def test_new_pull_request_is_attested_against_branch_and_exact_pr_metadata(
         ),
     ):
         with pytest.raises(rollout.CommandError, match="branch"):
-            rollout.attest_pull_request(snap, "v1.40", COMMIT, HEAD, changed, request)
+            rollout._attest_published_pull_request(snap, "v1.40", COMMIT, HEAD, changed, request)
+
+
+def test_fleet_public_attestation_is_pure_and_returns_observed_request(tmp_path):
+    import inspect
+    assert tuple(inspect.signature(rollout.validate_commit_tree).parameters) == (
+        "snapshot", "expected_head", "expected_base", "plan")
+    snap = snapshot(tmp_path)
+    changed = (".github/workflows/claude.yml",)
+    request = exact_pr(rollout.pr_body("v1.40", COMMIT, changed))
+    with mock.patch.object(rollout.fleet_git, "remote_branch_sha", side_effect=AssertionError("remote read")), mock.patch.object(rollout.fleet_git, "list_rollout_prs", side_effect=AssertionError("remote read")):
+        assert rollout.attest_pull_request(snap, "v1.40", COMMIT, HEAD, changed, request) is request
+
+
+def test_fleet_public_renderer_matches_existing_wrapper(tmp_path, bundle):
+    snap = initialized_canonical_fleet_repository(tmp_path, bundle)
+    assert rollout.render_rollout_plan(snap, bundle, "gstApp", bootstrap=False) == rollout._render(snap, bundle, "gstApp", bootstrap=False)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_verify_claude_rollout_fallback.py
+++ b/tests/test_verify_claude_rollout_fallback.py
@@ -678,3 +678,165 @@ def test_required_workflow_rule_cannot_be_silently_ignored(verifier, monkeypatch
     monkeypatch.setattr(provider, "_pages", lambda endpoint, **kw: ({"type": "workflows", "parameters": {}},) if "/rules/" in endpoint else ())
     with pytest.raises(verifier.VerificationError, match="^required_check_failed$"):
         provider.required_checks("a" * 40)
+
+
+def caller_document(content):
+    import base64
+    return {"type": "file", "path": ".github/workflows/claude.yml", "encoding": "base64",
+            "content": base64.b64encode(content.encode()).decode()}
+
+
+@pytest.mark.parametrize("change", ["literal", "folded", "quoted_scalar", "plain_continuation",
+    "duplicate_jobs", "quoted_duplicate_jobs", "duplicate_uses", "alias", "tag", "second_job", "documents"])
+def test_fix_round1_caller_pin_rejects_inert_or_ambiguous_yaml(verifier, change):
+    inert, active = "1" * 40, "2" * 40
+    prefix = "jhw7500/automation/.github/workflows/claude.yml@"
+    job = f"jobs:\n  claude:\n    uses: {prefix}{inert}\n"
+    actual = f"jobs:\n  claude:\n    uses: '{prefix}{active}'\n"
+    values = {
+        "literal": f"env:\n  TEXT: |\n    uses: {prefix}{inert}\n" + actual,
+        "folded": f"env:\n  TEXT: >-\n    uses: {prefix}{inert}\n" + actual,
+        "quoted_scalar": f"name: 'inert\n    uses: {prefix}{inert}\n'\n" + actual,
+        "plain_continuation": f"name: inert\n    uses: {prefix}{inert}\n" + actual,
+        "duplicate_jobs": job + actual,
+        "quoted_duplicate_jobs": job + actual.replace("jobs:", "'jobs':"),
+        "duplicate_uses": job + f"    'uses': '{prefix}{active}'\n",
+        "alias": f"job: &definition\n    uses: {prefix}{inert}\njobs:\n  claude: *definition\n",
+        "tag": job.replace("jobs:", "jobs: !!map"),
+        "second_job": job + f"  other:\n    uses: '{prefix}{active}'\n",
+        "documents": job + "---\n" + actual,
+    }
+    with pytest.raises(verifier.VerificationError, match="^driver_pin_invalid$"):
+        verifier.parse_default_caller_pin(caller_document(values[change]))
+
+
+@pytest.mark.parametrize("style", ["plain", "single", "double", "canonical"])
+def test_fix_round1_caller_pin_accepts_active_canonical_job(verifier, style):
+    driver = "9" * 40
+    value = "jhw7500/automation/.github/workflows/claude.yml@" + driver
+    if style == "canonical":
+        content = (ROOT / "examples/baseline-workflows/.github/workflows/claude.yml").read_text().replace("__AUTOMATION_COMMIT__", driver)
+    else:
+        value = {"plain": value, "single": "'" + value + "'", "double": '"' + value + '"'}[style]
+        content = f"jobs:\n  claude:\n    uses: {value} # installed\n"
+    assert verifier.parse_default_caller_pin(caller_document(content)) == driver
+
+
+@pytest.mark.parametrize("separator", ["\u0085", "\u2028", "\u2029"])
+def test_fix_round1_caller_rejects_yaml_line_breaks_inside_comment(verifier, separator):
+    prefix = "jhw7500/automation/.github/workflows/claude.yml@"
+    first = f"jobs:\n  claude:\n    uses: {prefix}{'1' * 40}\n"
+    hidden = separator.join(["# comment", "jobs:", "  claude:", f"    uses: {prefix}{'2' * 40}"])
+    with pytest.raises(verifier.VerificationError, match="^driver_pin_invalid$"):
+        verifier.parse_default_caller_pin(caller_document(first + hidden))
+
+
+@pytest.mark.parametrize("override", ["GIT_DIR", "GIT_WORK_TREE", "GIT_OBJECT_DIRECTORY",
+                                    "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS"])
+def test_fix_round1_promoted_git_ignores_ambient_overrides(verifier, exact_rollout_fixture, monkeypatch, override):
+    fixture = exact_rollout_fixture
+    original = subprocess.run
+    seen = []
+    def run(args, **kwargs):
+        if Path(args[0]).name == "git":
+            seen.append((args, dict(kwargs.get("env") or os.environ)))
+        return original(args, **kwargs)
+    monkeypatch.setenv(override, "invalid-ambient-value")
+    monkeypatch.setenv("GIT_NO_REPLACE_OBJECTS", "0")
+    monkeypatch.setattr(subprocess, "run", run)
+    verifier.verify_fleet_request(fixture.request, fixture.provider, fixture.modules)
+    assert seen
+    assert all(environment.get("GIT_NO_REPLACE_OBJECTS") == "1" or "--no-replace-objects" in args
+               for args, environment in seen)
+    assert all(environment.get(override) != "invalid-ambient-value" for _, environment in seen)
+    assert os.environ[override] == "invalid-ambient-value"
+
+
+def test_fix_round1_replacement_objects_cannot_hide_wrong_commit(verifier, exact_rollout_fixture):
+    fixture = exact_rollout_fixture
+    repo = fixture.snapshot.path
+    valid_head = fixture.request.expected_head
+    git(repo, "checkout", "--detach", valid_head)
+    (repo / "extra").write_text("not renderer owned")
+    git(repo, "add", "extra")
+    git(repo, "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "--amend", "--no-edit", "-q")
+    invalid_head = git(repo, "rev-parse", "HEAD")
+    git(repo, "checkout", "--detach", fixture.request.expected_base)
+    git(repo, "replace", invalid_head, valid_head)
+    fixture.pr["head"]["sha"] = invalid_head
+    request = replace(fixture.request, expected_head=invalid_head)
+    with pytest.raises(verifier.VerificationError, match="^fleet_attestation_failed$"):
+        verifier.verify_fleet_request(request, fixture.provider, fixture.modules)
+
+
+@pytest.mark.parametrize("moment", ["before_create", "after_create", "before_link", "after_link"])
+def test_fix_round1_receipt_parent_replacement_never_redirects_or_leaks(verifier, tmp_path, monkeypatch, moment):
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    automation = tmp_path / "automation"
+    automation.mkdir(mode=0o700)
+    target = automation / "target"
+    target.mkdir(mode=0o700)
+    moved = automation / "moved"
+    output = parent / "receipt.json"
+    temporary = f".receipt.json.{os.getpid()}.tmp"
+    guard = target / (temporary if moment == "before_link" else "guard")
+    guard.write_bytes(b"untouched")
+    guard.chmod(0o600)
+    swapped = False
+    original_open, original_link = os.open, os.link
+    def swap():
+        nonlocal swapped
+        if not swapped:
+            parent.rename(moved)
+            parent.symlink_to(target, target_is_directory=True)
+            swapped = True
+    def opened(path, flags, *args, **kwargs):
+        temporary_open = bool(flags & os.O_CREAT) and str(path).endswith(".tmp")
+        if temporary_open and moment == "before_create": swap()
+        result = original_open(path, flags, *args, **kwargs)
+        if temporary_open and moment == "after_create": swap()
+        return result
+    def linked(src, dst, **kwargs):
+        if moment == "before_link": swap()
+        result = original_link(src, dst, **kwargs)
+        if moment == "after_link": swap()
+        return result
+    monkeypatch.setattr(os, "open", opened)
+    monkeypatch.setattr(os, "link", linked)
+    with pytest.raises(verifier.VerificationError):
+        verifier.write_receipt(output, {"schema": 1})
+    assert swapped
+    assert guard.read_bytes() == b"untouched"
+    assert not list(moved.iterdir())
+    assert list(target.iterdir()) == [guard]
+
+
+def test_fix_round1_receipt_rejects_writable_nonsticky_ancestor(verifier, tmp_path):
+    shared = tmp_path / "shared"
+    shared.mkdir(mode=0o777)
+    shared.chmod(0o777)
+    parent = shared / "private"
+    parent.mkdir(mode=0o700)
+    with pytest.raises(verifier.VerificationError, match="^receipt_parent_invalid$"):
+        verifier.write_receipt(parent / "receipt.json", {"schema": 1})
+    assert not list(parent.iterdir())
+
+
+@pytest.mark.parametrize("app", [{"id": True}, {"id": False}, {"id": "1"}, {"id": 1.0},
+                                {"id": None}, {"id": 0}, {"id": -1}, {}, None, 1, {"id": 1}])
+def test_fix_round1_required_check_app_identity_is_a_positive_integer(verifier, monkeypatch, app):
+    provider = verifier.GitHubEvidenceProvider("jhw7500/gstApp")
+    provider.base_branch = "main"
+    monkeypatch.setattr(provider, "_json", lambda *a, **kw: {"checks": [{"context": "CI", "app_id": 1}], "contexts": ["CI"]})
+    def pages(endpoint, **kwargs):
+        if "/check-runs" in endpoint:
+            return ({"name": "CI", "head_sha": "a" * 40, "app": app,
+                     "status": "completed", "conclusion": "success"},)
+        return ()
+    monkeypatch.setattr(provider, "_pages", pages)
+    if type(app) is dict and type(app.get("id")) is int and app["id"] == 1:
+        verifier.require_required_checks_clean(provider.required_checks("a" * 40))
+    else:
+        with pytest.raises(verifier.VerificationError, match="^required_check_failed$"):
+            verifier.require_required_checks_clean(provider.required_checks("a" * 40))

--- a/tests/test_verify_claude_rollout_fallback.py
+++ b/tests/test_verify_claude_rollout_fallback.py
@@ -1,0 +1,680 @@
+"""Trust-boundary and evidence tests for the read-only fallback verifier."""
+
+from contextlib import contextmanager
+from dataclasses import replace
+import hashlib
+import importlib
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def verifier():
+    return importlib.import_module("scripts.verify_claude_rollout_fallback")
+
+
+def git(root, *args):
+    return subprocess.run(
+        ["/usr/bin/git", "-c", "core.hooksPath=/dev/null", *args], cwd=root,
+        check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def source_root(tmp_path, verifier):
+    root = tmp_path / "automation"
+    root.mkdir()
+    for name in verifier.REQUIRED_MODULE_PATHS:
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# trusted fixture\n")
+    git(root, "init", "-q")
+    git(root, "add", ".")
+    git(root, "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+        "commit", "-qm", "fixture")
+    return root, git(root, "rev-parse", "HEAD")
+
+
+def request_for(verifier, root, output):
+    return verifier.VerificationRequest(root, "v1.52", "origin", "jhw7500/gstApp",
+                                        109, "a" * 40, "b" * 40, output)
+
+
+@pytest.mark.parametrize("change", ["wrong_head", "dirty_tracked", "untracked_shadow",
+                                     "ignored_shadow", "symlinked_module", "mode", "symlink_root"])
+def test_local_source_root_rejects_mutations(verifier, source_root, change, tmp_path):
+    root, commit = source_root
+    module = root / verifier.REQUIRED_MODULE_PATHS[0]
+    if change == "wrong_head":
+        commit = "a" * 40
+    elif change == "dirty_tracked":
+        module.write_text("raise RuntimeError('must never execute')\n")
+        git(root, "update-index", "--assume-unchanged", str(module.relative_to(root)))
+    elif change == "untracked_shadow":
+        (root / "yaml.py").write_text("raise RuntimeError('shadow')")
+    elif change == "ignored_shadow":
+        (root / ".git/info/exclude").write_text("yaml.py\n")
+        (root / "yaml.py").write_text("raise RuntimeError('shadow')")
+    elif change == "symlinked_module":
+        target = tmp_path / "target"
+        target.write_bytes(module.read_bytes())
+        module.unlink()
+        module.symlink_to(target)
+    elif change == "mode":
+        module.chmod(0o755)
+    else:
+        link = tmp_path / "link"
+        link.symlink_to(root, target_is_directory=True)
+        root = link
+    with pytest.raises(verifier.VerificationError, match="^verifier_root_invalid$"):
+        verifier.verify_source_root(root, commit)
+
+
+def test_local_source_root_accepts_exact_checkout(verifier, source_root):
+    verifier.verify_source_root(*source_root)
+
+
+@pytest.mark.parametrize("change", ["bad_repository", "zero_pr", "uppercase_head",
+                                     "bad_release_ref", "output_inside_root", "remote_option"])
+def test_local_request_rejects_mutations(verifier, tmp_path, change):
+    root = tmp_path / "automation"
+    root.mkdir()
+    request = request_for(verifier, root, tmp_path / "receipt.json")
+    values = {"bad_repository": {"repository": "../repo"}, "zero_pr": {"pr": 0},
+              "uppercase_head": {"expected_head": "A" * 40},
+              "bad_release_ref": {"release_ref": "v1.52;echo"},
+              "output_inside_root": {"output": root / "receipt.json"},
+              "remote_option": {"remote": "--upload-pack=evil"}}
+    with pytest.raises(verifier.VerificationError):
+        verifier.validate_request(replace(request, **values[change]))
+
+
+@pytest.mark.parametrize("change", ["existing_output", "broken_output_symlink",
+                                     "symlinked_output_parent", "public_parent"])
+def test_local_output_rejection_preserves_original_node(verifier, tmp_path, change):
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    path = parent / "receipt.json"
+    if change == "existing_output":
+        path.write_bytes(b"original")
+    elif change == "broken_output_symlink":
+        path.symlink_to(parent / "missing")
+    elif change == "symlinked_output_parent":
+        link = tmp_path / "link"
+        link.symlink_to(parent, target_is_directory=True)
+        path = link / path.name
+    else:
+        parent.chmod(0o755)
+    before = path.lstat() if path.is_symlink() or path.exists() else None
+    with pytest.raises(verifier.VerificationError):
+        verifier.write_receipt(path, {"schema": 1})
+    assert (path.lstat() if path.is_symlink() or path.exists() else None) == before
+    if change == "existing_output":
+        assert path.read_bytes() == b"original"
+
+
+@pytest.mark.parametrize("mask", [0o000, 0o077, 0o777])
+def test_receipt_is_private_regular_and_owned(verifier, tmp_path, mask):
+    tmp_path.chmod(0o700)
+    output = tmp_path / "receipt.json"
+    previous = os.umask(mask)
+    try:
+        verifier.write_receipt(output, {"z": 2, "a": 1})
+    finally:
+        os.umask(previous)
+    observed = output.lstat()
+    assert stat.S_ISREG(observed.st_mode)
+    assert observed.st_uid == os.getuid()
+    assert stat.S_IMODE(observed.st_mode) == 0o600
+    assert output.read_bytes() == b'{"a":1,"z":2}\n'
+    assert tuple(tmp_path.iterdir()) == (output,)
+
+
+def test_local_cli_exact_arguments_and_isolated_startup(verifier, tmp_path):
+    script = ROOT / "scripts/verify_claude_rollout_fallback.py"
+    poison = tmp_path / "sitecustomize.py"
+    poison.write_text("raise RuntimeError('site code executed')")
+    result = subprocess.run([sys.executable, "-I", "-S", "-B", str(script), "--help"],
+                            env={**os.environ, "PYTHONPATH": str(tmp_path)},
+                            capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    for name in ("automation-root", "release-ref", "remote", "repository", "pr",
+                 "expected-head", "expected-base", "output"):
+        assert "--" + name in result.stdout
+    assert not tuple(tmp_path.rglob("*.pyc"))
+    assert set(verifier.parser()._option_string_actions) == {
+        "-h", "--help", "--automation-root", "--release-ref", "--remote",
+        "--repository", "--pr", "--expected-head", "--expected-base", "--output"}
+
+
+def test_local_git_does_not_execute_filters_or_hooks(verifier, source_root, tmp_path):
+    root, commit = source_root
+    sentinel = tmp_path / "executed"
+    git(root, "config", "core.fsmonitor", f"touch {sentinel}")
+    git(root, "config", "filter.evil.clean", f"touch {sentinel}")
+    (root / ".git/info/attributes").write_text("* filter=evil\n")
+    verifier.verify_source_root(root, commit)
+    assert not sentinel.exists()
+
+
+def test_local_trusted_dependency_available_without_site_processing(verifier, tmp_path):
+    script = ROOT / "scripts/verify_claude_rollout_fallback.py"
+    code = ("import importlib.util,sys; "
+            f"s=importlib.util.spec_from_file_location('verifier',{str(script)!r}); "
+            "m=importlib.util.module_from_spec(s);sys.modules[s.name]=m;s.loader.exec_module(m); "
+            "m.load_trusted_yaml(); import yaml; print(yaml.__file__)")
+    (tmp_path / "yaml.py").write_text("raise RuntimeError('shadow')")
+    (tmp_path / "evil.pth").write_text("import os; raise RuntimeError('pth')")
+    result = subprocess.run([sys.executable, "-I", "-S", "-B", "-c", code], cwd=tmp_path,
+                            env={**os.environ, "PYTHONPATH": str(tmp_path),
+                                 "PYTHONUSERBASE": str(tmp_path)}, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert str(tmp_path) not in result.stdout
+
+
+@pytest.mark.parametrize("kind", ["writable", "symlink", "user_owned"])
+def test_local_dependency_directory_rejects_untrusted_paths(verifier, tmp_path, kind):
+    candidate = tmp_path / "site"
+    candidate.mkdir()
+    if kind == "writable":
+        candidate.chmod(0o777)
+    elif kind == "symlink":
+        link = tmp_path / "link"
+        link.symlink_to(candidate)
+        candidate = link
+    with pytest.raises(verifier.VerificationError, match="^verifier_dependency_invalid$"):
+        verifier.require_trusted_dependency_directory(candidate)
+
+
+@pytest.fixture
+def exact_rollout_fixture(verifier, tmp_path, monkeypatch):
+    import test_rollout_workflow_fleet as existing
+    from types import SimpleNamespace
+    from contextlib import nullcontext
+    from scripts import rollout_workflow_fleet as rollout
+    from scripts import workflow_release_bundle as release
+    from scripts import workflow_release_inventory as inventory
+
+    bundle = existing.bundle.__wrapped__()
+    snapshot = existing.initialized_canonical_fleet_repository(tmp_path, bundle)
+    bundle = replace(bundle, commit="4" * 40)
+    plan = rollout._render(snapshot, bundle, "gstApp", bootstrap=False)
+    assert plan.status == "drift"
+    existing.apply_render_plan(snapshot.path, plan)
+    git(snapshot.path, "add", ".")
+    head = existing.commit_managed_fixture(snapshot.path, "rollout")
+    git(snapshot.path, "checkout", "--detach", snapshot.base_sha)
+    changed = tuple(sorted(str(change.path) for change in plan.changes))
+    pr = dict(number=109, html_url="https://github.com/jhw7500/gstApp/pull/109",
+              state="open", merged=False, title=rollout.pr_title(bundle.ref),
+              body=rollout.pr_body(bundle.ref, bundle.commit, changed),
+              head={"sha": head, "ref": rollout.rollout_branch(bundle.ref),
+                    "repo": {"full_name": "jhw7500/gstApp", "fork": False}},
+              base={"sha": snapshot.base_sha, "ref": "main",
+                    "repo": {"full_name": "jhw7500/gstApp"}})
+    class Provider:
+        moved = False
+        requests = [pr]
+        def pull_request(self, number):
+            return pr
+        def consumer_snapshot(self, request, modules):
+            return nullcontext(snapshot)
+        def rollout_prs(self, branch):
+            return tuple(self.requests)
+        def branch_sha(self, branch):
+            return "e" * 40 if self.moved else pr["head"]["sha"]
+    provider = Provider()
+    request = replace(request_for(verifier, ROOT, tmp_path / "receipt.json"),
+                      release_ref=bundle.ref, expected_head=head, expected_base=snapshot.base_sha)
+    monkeypatch.setattr(release, "materialize_release_bundle", lambda *a, **kw: nullcontext(bundle))
+    return SimpleNamespace(request=request, provider=provider, bundle=bundle, snapshot=snapshot,
+                           modules=verifier.VerifiedModules(release, inventory, rollout), pr=pr,
+                           plan=plan)
+
+
+def test_fleet_exact_rendered_rollout_passes(verifier, exact_rollout_fixture):
+    fixture = exact_rollout_fixture
+    result = verifier.verify_fleet_request(fixture.request, fixture.provider, fixture.modules)
+    assert result["release_commit"] == fixture.bundle.commit
+    assert result["fleet"]["head_repository"] == fixture.request.repository
+    assert result["fleet"]["changed_paths"] == sorted(str(c.path) for c in fixture.plan.changes)
+
+
+@pytest.mark.parametrize("change", ["extra_path", "changed_blob", "executable_mode", "merge_commit",
+                                     "wrong_parent", "wrong_profile", "wrong_target_pin", "moved_branch",
+                                     "duplicate_pr", "fork_head", "stale_head", "changed_pr_body"])
+def test_fleet_attestation_rejects_mutation(verifier, exact_rollout_fixture, change):
+    fixture = exact_rollout_fixture
+    request = fixture.request
+    repo = fixture.snapshot.path
+    if change in {"extra_path", "changed_blob", "executable_mode"}:
+        git(repo, "checkout", "--detach", request.expected_head)
+        path = repo / str(fixture.plan.changes[0].path)
+        if change == "extra_path":
+            (repo / "extra").write_text("extra")
+        elif change == "changed_blob":
+            path.write_bytes(path.read_bytes() + b"\n# altered\n")
+        else:
+            path.chmod(0o755)
+        git(repo, "add", ".")
+        git(repo, "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "--amend", "--no-edit", "-q")
+        request = replace(request, expected_head=git(repo, "rev-parse", "HEAD"))
+        fixture.pr["head"]["sha"] = request.expected_head
+        git(repo, "checkout", "--detach", request.expected_base)
+    elif change in {"merge_commit", "wrong_parent"}:
+        tree = git(repo, "rev-parse", request.expected_head + "^{tree}")
+        parents = ["-p", request.expected_base, "-p", request.expected_head] if change == "merge_commit" else ["-p", request.expected_head]
+        head = git(repo, "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit-tree", tree, *parents, "-m", "invalid")
+        request = replace(request, expected_head=head)
+        fixture.pr["head"]["sha"] = head
+    elif change == "wrong_profile":
+        request = replace(request, repository="jhw7500/unknown-profile")
+    elif change == "wrong_target_pin":
+        fixture.pr["body"] = fixture.pr["body"].replace(fixture.bundle.commit, "9" * 40)
+    elif change == "moved_branch":
+        fixture.provider.moved = True
+    elif change == "duplicate_pr":
+        fixture.provider.requests.append(dict(fixture.pr))
+    elif change == "fork_head":
+        fixture.pr["head"]["repo"] = {"full_name": "fork/gstApp", "fork": True}
+    elif change == "stale_head":
+        fixture.pr["head"]["sha"] = "9" * 40
+    elif change == "changed_pr_body":
+        fixture.pr["body"] += "altered"
+    with pytest.raises(verifier.VerificationError, match="^fleet_attestation_failed$"):
+        verifier.verify_fleet_request(request, fixture.provider, fixture.modules)
+
+
+@pytest.fixture
+def exact_evidence(verifier, exact_rollout_fixture, monkeypatch):
+    import test_claude_rollout_fallback as admission
+    import test_review_invocation_budget as ledger
+    from copy import deepcopy
+    fixture = exact_rollout_fixture
+    request = fixture.request
+    driver = "9" * 40
+    fleet = verifier.verify_fleet_request(request, fixture.provider, fixture.modules)
+    contract_request = replace(admission.parse_request_body(admission.REQUEST_BODY),
+                               expected_head_sha=request.expected_head, expected_base_sha=request.expected_base,
+                               release_commit=fixture.bundle.commit,
+                               managed_diff_sha256=fleet["managed_diff_sha256"])
+    comment = admission._request_comment(body=admission.canonical_request_body(contract_request))
+    auto = deepcopy(admission.valid_bundle().original_run)
+    auto.update(head_sha=request.expected_head)
+    auto["pull_requests"][0].update(head={"sha": request.expected_head}, base={"sha": request.expected_base})
+    auto["referenced_workflows"][0]["sha"] = fixture.bundle.commit
+    job = admission._review_job()
+    job["check_run_url"] = "https://api.github.com/repos/jhw7500/gstApp/check-runs/500"
+    fallback_run = {"id": 34550000000, "run_attempt": 1, "name": "Claude Code",
+                    "event": "issue_comment", "status": "completed", "conclusion": "success",
+                    "path": ".github/workflows/claude.yml", "head_sha": request.expected_base,
+                    "repository": {"full_name": request.repository}, "actor": comment["user"],
+                    "created_at": "2026-09-11T03:04:07Z", "updated_at": "2026-09-11T03:06:00Z",
+                    "referenced_workflows": [
+                        {"path": f"jhw7500/automation/.github/workflows/claude.yml@{driver}", "sha": driver},
+                        {"path": f"jhw7500/automation/.github/workflows/claude-code-review.yml@{driver}", "sha": driver}]}
+    fallback_job = {"id": 501, "run_id": fallback_run["id"], "run_attempt": 1,
+                    "name": "Claude / managed-rollout-review / claude-review", "status": "completed",
+                    "conclusion": "success", "steps": [
+                        {"number": 1, "name": "Claim Claude review budget", "status": "completed", "conclusion": "success"},
+                        {"number": 2, "name": "Run Claude Code Review", "status": "completed", "conclusion": "success"},
+                        {"number": 3, "name": "Finalize Claude review budget", "status": "completed", "conclusion": "success"}]}
+    state = {**admission.AUTOMATIC_STATE, "run_id": fallback_run["id"], "attempt_head": request.expected_head,
+             "successful_head": request.expected_head, "attempt_status": "success", "diff_mode": "full",
+             "review_execution": "performed", "full_diff_sha256": fleet["managed_diff_sha256"],
+             "accepted_count": 0, "filtered_count": 0, "normalized_count": 0, "filtered_max_severity": "none",
+             "route": {"managed_diff_sha256": fleet["managed_diff_sha256"], "original_failed_run_id": auto["id"],
+                       "release_commit": fixture.bundle.commit, "request_comment_id": 901,
+                       "reviewed_base_sha": request.expected_base, "route": "default_branch_rollout_fallback"}}
+    state.pop("failure_reason")
+    canonical = admission._automatic_comment()
+    def state_body():
+        return "## Claude Code Review (latest)\n<!-- automation:claude-code-review:v3 -->\n<!-- automation-state:" + json.dumps(state, separators=(",", ":")) + " -->\n"
+    canonical["body"] = state_body()
+    route = ledger.budget.InvocationRoute(kind="default_branch_rollout_fallback", request_comment_id=901,
+        request_nonce=contract_request.nonce, original_run_id=auto["id"], original_run_attempt=1,
+        expected_base_sha=request.expected_base, release_commit=fixture.bundle.commit,
+        managed_diff_sha256=fleet["managed_diff_sha256"], automatic_comment_id=887, automatic_state_sha256="e" * 64)
+    invocation = replace(ledger.invocation(head=request.expected_head, full_hash=fleet["managed_diff_sha256"],
+        run_id=fallback_run["id"]), caller_workflow_path=".github/workflows/claude.yml", caller_event="issue_comment",
+        referenced_workflow_path=f"jhw7500/automation/.github/workflows/claude-code-review.yml@{driver}",
+        referenced_workflow_sha=driver, route=route)
+    ledger_state = ledger.budget.LedgerState.initial(request.repository, request.pr, "claude", invocations=(invocation,))
+    budget_comment = {"id": 902, "user": canonical["user"], "body": ledger.budget.MARKERS["claude"] + "\n<!-- automation-budget-state:" + ledger.budget.serialize_ledger(ledger_state) + " -->"}
+    class Provider(type(fixture.provider)):
+        comments = [comment, canonical, budget_comment]
+        runs = [fallback_run]
+        required = set()
+        annotations = [{"annotation_level": "failure", "message": "workflow_validation_mismatch"}]
+        def default_caller(self):
+            import base64
+            content = f"jobs:\n  claude:\n    uses: jhw7500/automation/.github/workflows/claude.yml@{driver}\n"
+            return {"type": "file", "path": ".github/workflows/claude.yml", "encoding": "base64",
+                    "content": base64.b64encode(content.encode()).decode()}
+        def issue_comments(self, number):
+            return tuple(self.comments)
+        def run_attempt(self, run_id, attempt):
+            return auto if run_id == auto["id"] else fallback_run
+        def run_jobs(self, run_id, attempt):
+            return (job,) if run_id == auto["id"] else (fallback_job,)
+        def check_annotations(self, check_run_id):
+            return tuple(self.annotations)
+        def workflow_runs(self):
+            return tuple(self.runs)
+        def required_checks(self, head):
+            return tuple({"name": name, "status": "completed", "conclusion": "failure"} for name in self.required)
+    fixture.provider = Provider()
+    fixture.provider.requests = [fixture.pr]
+    fixture.auto, fixture.job, fixture.fallback_run, fixture.fallback_job = auto, job, fallback_run, fallback_job
+    fixture.state, fixture.canonical, fixture.state_body = state, canonical, state_body
+    fixture.comment, fixture.budget_comment, fixture.ledger_state = comment, budget_comment, ledger_state
+    fixture.driver = driver
+    monkeypatch.setattr(verifier, "verify_source_root", lambda root, commit: None)
+    monkeypatch.setattr(verifier, "load_verified_modules", lambda root: fixture.modules)
+    return fixture
+
+
+def test_exact_chain_emits_effective_clean_receipt(verifier, exact_evidence):
+    f = exact_evidence
+    receipt = verifier.verify(f.request, f.provider)
+    assert set(receipt) == verifier.RECEIPT_KEYS
+    assert set(receipt["automatic"]) == verifier.AUTOMATIC_KEYS
+    assert set(receipt["fallback"]) == verifier.FALLBACK_KEYS
+    assert set(receipt["fleet"]) == verifier.FLEET_KEYS
+    assert receipt["automatic"]["reason"] == "workflow_validation_mismatch"
+    assert receipt["automatic"]["review_execution"] == "not_performed"
+    assert receipt["automatic"]["admitted_state_sha256"] == "e" * 64
+    assert receipt["fallback"]["review_execution"] == "performed"
+    assert receipt["fallback"]["budget_status"] == "finalized"
+    assert receipt["fallback"]["driver_commit"] == receipt["verifier_commit"] == f.driver
+    assert receipt["verifier_commit"] != receipt["release_commit"] == f.bundle.commit
+    assert receipt["effective_status"] == "CLEAN"
+
+
+@pytest.mark.parametrize("change", ["missing_request", "duplicate_request", "unauthorized_request",
+    "app_request", "freeform_request", "stale_request", "provider_entered", "missing_annotation",
+    "altered_annotation", "duplicate_annotation", "wrong_auto_run", "wrong_auto_attempt", "wrong_auto_base",
+    "call_zero", "call_two", "ledger_claimed", "wrong_driver", "wrong_target", "wrong_diff", "wrong_base",
+    "active_finding", "blocking_severity", "missing_state", "duplicate_state", "app_state", "app_ledger",
+    "missing_run", "duplicate_run", "wrong_fallback_attempt", "provider_skipped", "duplicate_provider",
+    "wrong_admitted_comment", "wrong_nonce", "required_automatic", "pending_required"])
+def test_evidence_mutations_fail_closed(verifier, exact_evidence, change):
+    from copy import deepcopy
+    import test_review_invocation_budget as ledger
+    f = exact_evidence
+    if change == "missing_request": f.provider.comments.remove(f.comment)
+    elif change == "duplicate_request": f.provider.comments.append(deepcopy(f.comment))
+    elif change == "unauthorized_request": f.comment["author_association"] = "NONE"
+    elif change == "app_request": f.comment["user"]["type"] = "Bot"
+    elif change == "freeform_request": f.comment["body"] = "@claude looks good"
+    elif change == "stale_request": f.comment["body"] = f.comment["body"].replace(f.request.expected_head, "f" * 40)
+    elif change == "provider_entered": f.job["steps"][-1]["conclusion"] = "success"
+    elif change == "missing_annotation": f.provider.annotations = []
+    elif change == "altered_annotation": f.provider.annotations[0]["message"] += " extra"
+    elif change == "duplicate_annotation": f.provider.annotations *= 2
+    elif change == "wrong_auto_run": f.auto["id"] += 1
+    elif change == "wrong_auto_attempt": f.auto["run_attempt"] = 2
+    elif change == "wrong_auto_base": f.auto["pull_requests"][0]["base"]["sha"] = "f" * 40
+    elif change in {"call_zero", "call_two", "ledger_claimed", "wrong_admitted_comment", "wrong_nonce"}:
+        invocation = f.ledger_state.invocations[0]
+        if change.startswith("call_"): invocation = replace(invocation, call_count=0 if change == "call_zero" else 2)
+        elif change == "ledger_claimed": invocation = replace(invocation, status="claimed", outcome=None, call_count=0, elapsed_seconds=0, stop_reason="claimed")
+        elif change == "wrong_admitted_comment": invocation = replace(invocation, route=replace(invocation.route, automatic_comment_id=999))
+        else: invocation = replace(invocation, route=replace(invocation.route, request_nonce="0" * 32))
+        raw = replace(f.ledger_state, invocations=(invocation,)).to_dict()
+        f.budget_comment["body"] = ledger.budget.MARKERS["claude"] + "\n<!-- automation-budget-state:" + json.dumps(raw, separators=(",", ":")) + " -->"
+    elif change == "wrong_driver": f.fallback_run["referenced_workflows"][-1]["sha"] = "f" * 40
+    elif change in {"wrong_target", "wrong_diff", "wrong_base"}:
+        key = {"wrong_target": "release_commit", "wrong_diff": "managed_diff_sha256", "wrong_base": "reviewed_base_sha"}[change]
+        f.state["route"][key] = "f" * (64 if change == "wrong_diff" else 40)
+    elif change == "active_finding": f.state["accepted_count"] = 1
+    elif change == "blocking_severity": f.state["filtered_max_severity"] = "HIGH"
+    elif change == "missing_state": f.provider.comments.remove(f.canonical)
+    elif change == "duplicate_state": f.provider.comments.append(deepcopy(f.canonical))
+    elif change == "app_state": f.canonical["user"] = {"login": "claude[bot]", "type": "Bot"}
+    elif change == "app_ledger": f.budget_comment["user"] = {"login": "claude[bot]", "type": "Bot"}
+    elif change == "missing_run": f.provider.runs = []
+    elif change == "duplicate_run": f.provider.runs *= 2
+    elif change == "wrong_fallback_attempt": f.fallback_run["run_attempt"] = 2
+    elif change == "provider_skipped": f.fallback_job["steps"][1]["conclusion"] = "skipped"
+    elif change == "duplicate_provider": f.fallback_job["steps"].append(deepcopy(f.fallback_job["steps"][1]))
+    elif change == "required_automatic": f.provider.required.add("Claude Code Review / claude-review")
+    elif change == "pending_required": f.provider.required_checks = lambda head: ({"name": "CI", "status": "queued", "conclusion": None},)
+    f.canonical["body"] = f.state_body()
+    reason = "^required_check_failed$" if change in {"required_automatic", "pending_required"} else None
+    with pytest.raises(verifier.VerificationError, match=reason):
+        verifier.verify(f.request, f.provider)
+    assert not f.request.output.exists()
+
+
+@pytest.mark.parametrize("kind,limit", [("runs", 10), ("jobs", 1), ("annotations", 10), ("comments", 10), ("checks", 10), ("contexts", 10)])
+def test_remote_enumeration_full_final_page_is_overflow(verifier, monkeypatch, kind, limit):
+    provider = verifier.GitHubEvidenceProvider("jhw7500/gstApp")
+    calls = []
+    def response(endpoint):
+        calls.append(endpoint)
+        return [{} for _ in range(100)]
+    monkeypatch.setattr(provider, "_json", response)
+    with pytest.raises(verifier.VerificationError, match="^evidence_overflow$"):
+        provider._pages("repos/jhw7500/gstApp/items", pages=limit)
+    assert len(calls) == limit
+
+
+def test_local_corrupted_commit_object_cannot_authorize_modified_source(verifier, source_root):
+    import zlib
+    root, commit = source_root
+    raw = subprocess.check_output(["/usr/bin/git", "cat-file", "commit", commit], cwd=root)
+    forged = raw.replace(b"fixture", b"forged!")
+    object_file = root / ".git/objects" / commit[:2] / commit[2:]
+    object_file.chmod(0o600)
+    object_file.write_bytes(zlib.compress(b"commit " + str(len(forged)).encode() + b"\0" + forged))
+    with pytest.raises(verifier.VerificationError, match="^verifier_root_invalid$"):
+        verifier.verify_source_root(root, commit)
+
+
+def test_local_output_publish_race_preserves_winner(verifier, tmp_path, monkeypatch):
+    output = tmp_path / "receipt.json"
+    tmp_path.chmod(0o700)
+    original = os.link
+    def concurrent_link(src, dst, **kwargs):
+        output.write_bytes(b"winner")
+        return original(src, dst, **kwargs)
+    monkeypatch.setattr(os, "link", concurrent_link)
+    with pytest.raises(verifier.VerificationError, match="^receipt_path_exists$"):
+        verifier.write_receipt(output, {"schema": 1})
+    assert output.read_bytes() == b"winner"
+    assert list(tmp_path.iterdir()) == [output]
+
+
+def test_local_fsync_failure_never_publishes_receipt(verifier, tmp_path, monkeypatch):
+    output = tmp_path / "receipt.json"
+    tmp_path.chmod(0o700)
+    def failed_sync(fd):
+        raise OSError("sensitive failure")
+    monkeypatch.setattr(os, "fsync", failed_sync)
+    with pytest.raises(verifier.VerificationError, match="^receipt_write_failed$"):
+        verifier.write_receipt(output, {"schema": 1})
+    assert not list(tmp_path.iterdir())
+
+
+@pytest.mark.parametrize("response", [None, {}, "body", [1], {"total_count": 1, "jobs": []}])
+def test_remote_malformed_pages_are_bounded(verifier, monkeypatch, response):
+    provider = verifier.GitHubEvidenceProvider("jhw7500/gstApp")
+    monkeypatch.setattr(provider, "_json", lambda endpoint: response)
+    with pytest.raises(verifier.VerificationError, match="^evidence_invalid$"):
+        provider._pages(provider.prefix + "/items", key="jobs" if type(response) is dict and "jobs" in response else None)
+
+
+def test_remote_comments_are_enumerated_once_per_verification(verifier, monkeypatch):
+    provider = verifier.GitHubEvidenceProvider("jhw7500/gstApp")
+    calls = []
+    def response(endpoint):
+        calls.append(endpoint)
+        return []
+    monkeypatch.setattr(provider, "_json", response)
+    assert provider.issue_comments(109) == provider.issue_comments(109) == ()
+    assert len(calls) == 1
+
+
+def test_required_legacy_failure_cannot_hide_behind_successful_check(verifier, monkeypatch):
+    provider = verifier.GitHubEvidenceProvider("jhw7500/gstApp")
+    provider.base_branch = "main"
+    monkeypatch.setattr(provider, "_json", lambda *a, **kw: {"checks": [{"context": "CI", "app_id": None}], "contexts": ["CI"]})
+    def pages(endpoint, **kwargs):
+        if "/rules/" in endpoint: return ()
+        if "/check-runs" in endpoint: return ({"name": "CI", "head_sha": "a" * 40, "status": "completed", "conclusion": "success"},)
+        return ({"context": "CI", "state": "failure"},)
+    monkeypatch.setattr(provider, "_pages", pages)
+    with pytest.raises(verifier.VerificationError, match="^required_check_failed$"):
+        verifier.require_required_checks_clean(provider.required_checks("a" * 40))
+
+
+def test_managed_diff_digest_matches_real_review_preparation(verifier, exact_rollout_fixture):
+    fixture = exact_rollout_fixture
+    helper_path = ROOT / ".github/actions/prepare-review-diff/prepare_review_diff.py"
+    spec = importlib.util.spec_from_file_location("prepare_diff_oracle", helper_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    expected = module.git_full_diff(fixture.request.expected_base, fixture.request.expected_head, 3, fixture.snapshot.path)
+    observed = verifier.verify_fleet_request(fixture.request, fixture.provider, fixture.modules)
+    assert observed["managed_diff_sha256"] == hashlib.sha256(expected).hexdigest()
+
+
+def test_local_delayed_project_imports_use_verified_root_under_isolation(verifier, tmp_path):
+    script = ROOT / "scripts/verify_claude_rollout_fallback.py"
+    code = ("import importlib.util,sys,pathlib; "
+            f"s=importlib.util.spec_from_file_location('verifier',{str(script)!r}); "
+            "m=importlib.util.module_from_spec(s);sys.modules[s.name]=m;s.loader.exec_module(m); "
+            f"result=m.load_verified_modules(pathlib.Path({str(ROOT)!r})); "
+            "print(result.rollout.__file__)")
+    result = subprocess.run([sys.executable, "-I", "-S", "-B", "-c", code], cwd=tmp_path,
+                            capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(ROOT / "scripts/rollout_workflow_fleet.py")
+
+
+@pytest.mark.parametrize("mutation", ["head", "base", "body"])
+def test_evidence_final_current_pr_change_rejects_receipt(verifier, exact_evidence, mutation):
+    f = exact_evidence
+    def checks(head):
+        if mutation == "body": f.pr["body"] += "changed"
+        else: f.pr[mutation]["sha"] = "f" * 40
+        return ()
+    f.provider.required_checks = checks
+    with pytest.raises(verifier.VerificationError):
+        verifier.verify(f.request, f.provider)
+
+
+def test_fleet_never_executes_consumer_path_binary(verifier, exact_rollout_fixture, monkeypatch):
+    fixture = exact_rollout_fixture
+    poison = fixture.snapshot.path / "bin"
+    poison.mkdir()
+    sentinel = fixture.snapshot.path / "executed"
+    executable = poison / "git"
+    executable.write_text(f"#!/bin/sh\necho executed > '{sentinel}'\nexit 1\n")
+    executable.chmod(0o755)
+    monkeypatch.setenv("PATH", str(poison) + ":/usr/bin:/bin")
+    verifier.verify_fleet_request(fixture.request, fixture.provider, fixture.modules)
+    assert not sentinel.exists()
+
+
+@pytest.mark.parametrize("record,field", [("auto", "run_attempt"), ("job", "run_attempt"),
+    ("fallback_run", "run_attempt"), ("fallback_job", "run_attempt"), ("state", "quality_schema")])
+def test_evidence_boolean_coordinates_are_not_integer_evidence(verifier, exact_evidence, record, field):
+    fixture = exact_evidence
+    getattr(fixture, record)[field] = True
+    fixture.canonical["body"] = fixture.state_body()
+    with pytest.raises(verifier.VerificationError):
+        verifier.verify(fixture.request, fixture.provider)
+
+
+def test_evidence_driver_cannot_equal_target_release(verifier, exact_evidence, monkeypatch):
+    import test_review_invocation_budget as ledger
+    fixture = exact_evidence
+    driver = fixture.bundle.commit
+    invocation = fixture.ledger_state.invocations[0]
+    invocation = replace(invocation, referenced_workflow_sha=driver,
+                         referenced_workflow_path=invocation.referenced_workflow_path.replace(fixture.driver, driver))
+    fixture.budget_comment["body"] = ledger.budget.MARKERS["claude"] + "\n<!-- automation-budget-state:" + ledger.budget.serialize_ledger(replace(fixture.ledger_state, invocations=(invocation,))) + " -->"
+    for reference in fixture.fallback_run["referenced_workflows"]:
+        reference["path"] = reference["path"].replace(fixture.driver, driver)
+        reference["sha"] = driver
+    monkeypatch.setattr(verifier, "parse_default_caller_pin", lambda document: driver)
+    with pytest.raises(verifier.VerificationError):
+        verifier.verify(fixture.request, fixture.provider)
+
+
+def test_local_private_parent_wrong_owner_is_rejected(verifier, tmp_path, monkeypatch):
+    tmp_path.chmod(0o700)
+    monkeypatch.setattr(os, "getuid", lambda: tmp_path.lstat().st_uid + 1)
+    with pytest.raises(verifier.VerificationError, match="^receipt_parent_invalid$"):
+        verifier.require_private_output_parent(tmp_path)
+
+
+def test_remote_fixed_gh_transport_ignores_response_body_in_errors(verifier, monkeypatch):
+    seen = []
+    def run(args, **kwargs):
+        seen.append((args, kwargs))
+        return subprocess.CompletedProcess(args, 1, b"HTTP/2.0 403 Forbidden\r\n\r\nSECRET_REMOTE_BODY", b"secret error")
+    monkeypatch.setattr(subprocess, "run", run)
+    provider = verifier.GitHubEvidenceProvider("jhw7500/gstApp")
+    with pytest.raises(verifier.VerificationError, match="^evidence_read_failed$"):
+        provider.default_caller()
+    assert seen[0][0][0] == "/usr/bin/gh"
+    assert "--method" in seen[0][0] and "GET" in seen[0][0]
+    assert not seen[0][1].get("shell")
+
+
+def test_fleet_production_snapshot_materializes_only_git_object_data(verifier, exact_rollout_fixture, monkeypatch):
+    fixture = exact_rollout_fixture
+    provider = verifier.GitHubEvidenceProvider(fixture.request.repository)
+    original = verifier._git_bytes
+    def local_transport(root, *args):
+        if args[0] == "fetch":
+            return original(root, "fetch", "--no-tags", str(fixture.snapshot.path),
+                            fixture.request.expected_base, fixture.request.expected_head)
+        return original(root, *args)
+    monkeypatch.setattr(verifier, "_git_bytes", local_transport)
+    monkeypatch.setattr(provider, "_object", lambda endpoint: fixture.pr if "/pulls/" in endpoint else {"default_branch": "main"})
+    def pages(endpoint, **kwargs):
+        names = fixture.snapshot.secret_names if endpoint.endswith("/secrets") else fixture.snapshot.variable_names if endpoint.endswith("/variables") else fixture.snapshot.label_names
+        return tuple({"name": name} for name in names)
+    monkeypatch.setattr(provider, "_pages", pages)
+    with provider.consumer_snapshot(fixture.request, fixture.modules) as observed:
+        assert observed.base_sha == fixture.snapshot.base_sha
+        assert observed.secret_names == fixture.snapshot.secret_names
+        plan = fixture.modules.rollout.render_rollout_plan(observed, fixture.bundle, "gstApp", bootstrap=False)
+        fixture.modules.rollout.validate_commit_tree(observed, fixture.request.expected_head,
+                                                     fixture.request.expected_base, plan)
+        assert not (observed.path / "README.md").exists()
+    assert not observed.path.exists()
+
+
+@pytest.mark.parametrize("method,response", [("branch", {"commit": []}), ("branch", {"commit": None}),
+                                            ("pr", {"base": []}), ("pr", {"base": None})])
+def test_remote_nested_type_errors_are_bounded(verifier, monkeypatch, method, response):
+    provider = verifier.GitHubEvidenceProvider("jhw7500/gstApp")
+    monkeypatch.setattr(provider, "_json", lambda endpoint: response)
+    with pytest.raises(verifier.VerificationError, match="^evidence_invalid$"):
+        provider.branch_sha("main") if method == "branch" else provider.pull_request(109)
+
+
+def test_required_workflow_rule_cannot_be_silently_ignored(verifier, monkeypatch):
+    provider = verifier.GitHubEvidenceProvider("jhw7500/gstApp")
+    provider.base_branch = "main"
+    monkeypatch.setattr(provider, "_json", lambda *a, **kw: None)
+    monkeypatch.setattr(provider, "_pages", lambda endpoint, **kw: ({"type": "workflows", "parameters": {}},) if "/rules/" in endpoint else ())
+    with pytest.raises(verifier.VerificationError, match="^required_check_failed$"):
+        provider.required_checks("a" * 40)

--- a/tests/test_verify_claude_rollout_fallback.py
+++ b/tests/test_verify_claude_rollout_fallback.py
@@ -239,7 +239,10 @@ def exact_rollout_fixture(verifier, tmp_path, monkeypatch):
                       release_ref=bundle.ref, expected_head=head, expected_base=snapshot.base_sha)
     monkeypatch.setattr(release, "materialize_release_bundle", lambda *a, **kw: nullcontext(bundle))
     return SimpleNamespace(request=request, provider=provider, bundle=bundle, snapshot=snapshot,
-                           modules=verifier.VerifiedModules(release, inventory, rollout), pr=pr,
+                           modules=verifier.VerifiedModules(
+                               release, inventory, rollout,
+                               verifier._load_verified_canonicalizer(ROOT),
+                           ), pr=pr,
                            plan=plan)
 
 
@@ -339,8 +342,23 @@ def exact_evidence(verifier, exact_rollout_fixture, monkeypatch):
                        "reviewed_base_sha": request.expected_base, "route": "default_branch_rollout_fallback"}}
     state.pop("failure_reason")
     canonical = admission._automatic_comment()
-    def state_body():
-        return "## Claude Code Review (latest)\n<!-- automation:claude-code-review:v3 -->\n<!-- automation-state:" + json.dumps(state, separators=(",", ":")) + " -->\n"
+    def state_body(content=None):
+        if content is None:
+            content = "### New findings\n\nNone\n\nNo validated blocking issues found.\n"
+        metadata = (
+            "- Status: success\n"
+            f"- Execution: {state['review_execution']}\n"
+            f"- Run: https://github.com/{request.repository}/actions/runs/{state['run_id']}\n"
+            f"- Reviewed: {state['successful_head']}\n"
+            f"- Validation: accepted={state['accepted_count']}; filtered={state['filtered_count']}; "
+            f"normalized={state['normalized_count']}; filtered_max={state['filtered_max_severity']}"
+        )
+        return (
+            "## Claude Code Review (latest)\n"
+            "<!-- automation:claude-code-review:v3 -->\n"
+            "<!-- automation-state:" + json.dumps(state, separators=(",", ":")) + " -->\n\n"
+            + metadata + "\n\n" + content
+        )
     canonical["body"] = state_body()
     route = ledger.budget.InvocationRoute(kind="default_branch_rollout_fallback", request_comment_id=901,
         request_nonce=contract_request.nonce, original_run_id=auto["id"], original_run_attempt=1,
@@ -400,6 +418,40 @@ def test_exact_chain_emits_effective_clean_receipt(verifier, exact_evidence):
     assert receipt["fallback"]["driver_commit"] == receipt["verifier_commit"] == f.driver
     assert receipt["verifier_commit"] != receipt["release_commit"] == f.bundle.commit
     assert receipt["effective_status"] == "CLEAN"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["missing_document", "wrong_execution", "wrong_reviewed", "active_high_zero_count"],
+)
+def test_fallback_canonical_envelope_matches_authenticated_state(
+    verifier, exact_evidence, mutation,
+):
+    f = exact_evidence
+    body = f.state_body()
+    if mutation == "missing_document":
+        body = body.split("\n\n", 2)[0] + "\n"
+    elif mutation == "wrong_execution":
+        body = body.replace("- Execution: performed", "- Execution: not_performed")
+    elif mutation == "wrong_reviewed":
+        body = body.replace(f"- Reviewed: {f.request.expected_head}", "- Reviewed: " + "f" * 40)
+    else:
+        title = "Unsafe disclosure"
+        identity = "\0".join(("claude", "workflow.yml", "1", "HIGH", title.casefold()))
+        finding_id = "RVW-" + hashlib.sha256(identity.encode()).hexdigest()[:12]
+        content = (
+            "### New findings\n\n"
+            f"#### {finding_id} [HIGH] {title}\n"
+            '- Changed anchor: {"path":"workflow.yml","line":1}\n'
+            '- Trigger evidence: {"path":"workflow.yml","line":1,"quote":"secret"}\n'
+            "- Impact class: security\n"
+            "- Material impact: A credential is exposed.\n"
+        )
+        body = f.state_body(content)
+    f.canonical["body"] = body
+    with pytest.raises(verifier.VerificationError, match="^fallback_evidence_invalid$"):
+        verifier.verify(f.request, f.provider)
+    assert not f.request.output.exists()
 
 
 @pytest.mark.parametrize("change", ["missing_request", "duplicate_request", "unauthorized_request",

--- a/tests/test_verify_claude_rollout_fallback.py
+++ b/tests/test_verify_claude_rollout_fallback.py
@@ -197,6 +197,71 @@ def test_local_dependency_directory_rejects_untrusted_paths(verifier, tmp_path, 
         verifier.require_trusted_dependency_directory(candidate)
 
 
+def test_local_dependency_directory_accepts_verified_runtime_owner(
+    verifier, tmp_path, monkeypatch
+):
+    runtime = tmp_path / "runtime"
+    executable = runtime / "bin/python3"
+    dependency = runtime / "lib/python3.12/site-packages/yaml"
+    executable.parent.mkdir(parents=True)
+    dependency.mkdir(parents=True)
+    for directory in (
+        runtime,
+        executable.parent,
+        runtime / "lib",
+        runtime / "lib/python3.12",
+        runtime / "lib/python3.12/site-packages",
+        dependency,
+    ):
+        directory.chmod(0o755)
+    executable.write_bytes(b"trusted runtime fixture\n")
+    executable.chmod(0o755)
+
+    monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setattr(sys, "prefix", str(runtime))
+    monkeypatch.setattr(sys, "base_prefix", str(runtime))
+
+    owners = verifier.trusted_runtime_dependency_owners(dependency)
+    assert owners == frozenset({0, os.getuid()})
+    verifier.require_trusted_dependency_directory(
+        dependency, allowed_owners=owners
+    )
+
+
+@pytest.mark.parametrize("kind", ["outside_prefix", "writable_prefix"])
+def test_local_dependency_directory_rejects_untrusted_runtime_boundary(
+    verifier, tmp_path, monkeypatch, kind
+):
+    runtime = tmp_path / "runtime"
+    executable = runtime / "bin/python3"
+    dependency = runtime / "lib/python3.12/site-packages/yaml"
+    executable.parent.mkdir(parents=True)
+    dependency.mkdir(parents=True)
+    for directory in (
+        runtime,
+        executable.parent,
+        runtime / "lib",
+        runtime / "lib/python3.12",
+        runtime / "lib/python3.12/site-packages",
+        dependency,
+    ):
+        directory.chmod(0o755)
+    executable.write_bytes(b"trusted runtime fixture\n")
+    executable.chmod(0o755)
+    if kind == "outside_prefix":
+        dependency = tmp_path / "outside/yaml"
+        dependency.mkdir(parents=True)
+    else:
+        runtime.chmod(0o775)
+
+    monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setattr(sys, "prefix", str(runtime))
+    monkeypatch.setattr(sys, "base_prefix", str(runtime))
+
+    with pytest.raises(verifier.VerificationError, match="^verifier_dependency_invalid$"):
+        verifier.trusted_runtime_dependency_owners(dependency)
+
+
 @pytest.fixture
 def exact_rollout_fixture(verifier, tmp_path, monkeypatch):
     import test_rollout_workflow_fleet as existing

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import ast
 import hashlib
 import json
 import os
@@ -63,6 +64,56 @@ def test_v177_adds_only_claude_rollout_fallback_roots():
     assert not release_inventory.release_supports_claude_rollout_fallback("v1.76")
     assert release_inventory.release_supports_claude_rollout_fallback("v1.77")
     assert release_inventory.release_supports_claude_rollout_fallback("v1.77.1")
+
+
+def test_v1771_publication_proves_owned_boundary_before_post():
+    document = (ROOT / "docs/workflow-fleet-rollout.md").read_text()
+    section = document.split("## Create-only v1.77 and v1.77.1 tag publication\n", 1)[1]
+    body = section.split("' <<'CLAUDE_RELEASE_PY'\n", 1)[1].split("\nCLAUDE_RELEASE_PY", 1)[0]
+    tree = ast.parse(body)
+    first_post = min(node.lineno for node in ast.walk(tree)
+                     if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                     and node.func.id == "post")
+    branches = [node for node in tree.body if isinstance(node, ast.If)
+                and ast.unparse(node.test) == "tag == 'v1.77.1'"]
+    assert len(branches) == 1, "v1.77.1 needs a pre-publication boundary proof"
+    branch = branches[0]
+    assert branch.end_lineno < first_post
+    assert not branch.orelse, "v1.77 first publication must not need an existing v1.77 tag"
+    source = ast.unparse(branch)
+    # Ordered checks bind the remote annotation and trusted inventory before any write.
+    checks = [
+        "pairs = [line.split('\\t') for line in public_tags('v1.77').splitlines()]",
+        "len(pairs) == 2 and all((len(pair) == 2 for pair in pairs))",
+        "set(refs) == {'refs/tags/v1.77', 'refs/tags/v1.77^{}'}",
+        "all((re.fullmatch('[0-9a-f]{40}', oid) for oid in refs.values()))",
+        "v177_tag = refs['refs/tags/v1.77']",
+        "v177_commit = refs['refs/tags/v1.77^{}']",
+        "require(commit != v177_commit,",
+        "git('fetch', '--no-tags', url, 'refs/tags/v1.77:refs/tags/v1.77', cwd=checkout)",
+        "git('rev-parse', 'refs/tags/v1.77', cwd=checkout) == v177_tag",
+        "git('rev-parse', 'refs/tags/v1.77^{}', cwd=checkout) == v177_commit",
+        "git('cat-file', '-t', v177_tag, cwd=checkout) == 'tag'",
+        "git('worktree', 'add', '--detach', str(baseline), v177_commit, cwd=checkout)",
+        "'scripts.verify_workflow_release', '--automation', str(baseline), '--ref', 'v1.77', '--expected-commit', v177_commit, '--remote', 'origin'",
+        "from scripts.workflow_release_inventory import release_paths_for",
+        'release_paths_for("v1.77")',
+        "owned = json.loads(inventory.stdout)",
+        "git('diff', '--raw', '--no-ext-diff', '--no-textconv', '--exit-code', v177_commit, commit, '--', *owned, cwd=checkout) == ''",
+        "set(public_tags('v1.77').splitlines()) == tag_pairs('v1.77', v177_tag, v177_commit)",
+    ]
+    offset = 0
+    for check in checks:
+        position = source.find(check, offset)
+        assert position >= 0, f"missing or out-of-order boundary check: {check}"
+        offset = position + len(check)
+    runs = [node for node in ast.walk(branch) if isinstance(node, ast.Call)
+            and ast.unparse(node.func) == "subprocess.run"]
+    assert len(runs) == 2
+    for run in runs:
+        keywords = {item.arg: ast.unparse(item.value) for item in run.keywords}
+        assert keywords["cwd"] == "baseline", "never import the candidate's reduced inventory"
+        assert keywords["check"] == "True"
 
 
 def test_v176_candidate_remains_accepted():

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -33,6 +33,7 @@ from release_fixture_helpers import (
     restore_pre_v172_opencode_context_budget,
     restore_pre_v173_opencode_active_section_order,
     restore_pre_v176_opencode_recovery,
+    restore_pre_v177_claude_rollout_fallback,
     restore_pre_v170_opencode_finding_ids,
     restore_retired_manual_pr_review,
     restore_pre_v166_label_mismatch_decline,
@@ -41,6 +42,101 @@ from release_fixture_helpers import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+
+V176_COMMIT = "444a7347aee169ed178aae80e8bd8d10eca52e02"
+FALLBACK_RELEASE_FILES = (
+    ".github/actions/claude-rollout-fallback/action.yml",
+    ".github/actions/claude-rollout-fallback/contract.py",
+    "scripts/verify_claude_rollout_fallback.py",
+)
+
+
+def test_v177_adds_only_claude_rollout_fallback_roots():
+    old = set(release_inventory.release_paths_for("v1.76"))
+    new = set(release_inventory.release_paths_for("v1.77"))
+    assert new - old == set(FALLBACK_RELEASE_FILES)
+    assert old - new == set()
+    roots = release_inventory.release_roots_for("v1.77")
+    assert {(str(root.path), root.kind, root.mode) for root in roots if str(root.path) in new - old} == {
+        (relative, "file", "100644") for relative in FALLBACK_RELEASE_FILES
+    }
+    assert not release_inventory.release_supports_claude_rollout_fallback("v1.76")
+    assert release_inventory.release_supports_claude_rollout_fallback("v1.77")
+    assert release_inventory.release_supports_claude_rollout_fallback("v1.77.1")
+
+
+def test_v176_candidate_remains_accepted():
+    assert release_verifier.verify_commit_content(ROOT, "v1.76", V176_COMMIT) == V176_COMMIT
+
+
+def test_v176_candidate_fixture_remains_accepted(recovery_release_repo):
+    repo, candidate = recovery_release_repo
+    assert release_verifier.verify_commit_content(repo, "v1.76", candidate) == candidate
+    tree = release_verifier.VerifiedCommitTree.open(ROOT, V176_COMMIT)
+    for relative in (
+        ".github/workflows/claude.yml",
+        ".github/workflows/claude-code-review.yml",
+        "examples/baseline-workflows/.github/workflows/claude.yml",
+        ".github/actions/review-invocation-budget/review_invocation_budget.py",
+        ".github/actions/canonicalize-review/canonicalize_review.py",
+    ):
+        assert (repo / relative).read_bytes() == tree.read_file(relative)
+    assert all(not (repo / relative).exists() for relative in FALLBACK_RELEASE_FILES)
+
+
+@pytest.fixture
+def fallback_release_repo(tmp_path):
+    repo = tmp_path / "fallback-release"
+    repo.mkdir()
+    for relative in RELEASE_PATHS:
+        source, target = ROOT / relative, repo / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_dir():
+            shutil.copytree(source, target)
+        else:
+            shutil.copy2(source, target)
+    git(repo, "init", "-q")
+    git(repo, "config", "user.name", "Test")
+    git(repo, "config", "user.email", "test@example.com")
+    return repo, commit(repo, "v1.77 fallback candidate")
+
+
+def test_v177_candidate_is_accepted(fallback_release_repo):
+    repo, candidate = fallback_release_repo
+    release_verifier.verify_claude_rollout_fallback_contract(repo)
+    assert release_verifier.verify_commit_content(repo, "v1.77", candidate) == candidate
+
+
+FALLBACK_MUTATIONS = {
+    "request_keys": (FALLBACK_RELEASE_FILES[1], '"nonce",', '"untrusted",'),
+    "actor_set": (FALLBACK_RELEASE_FILES[1], '{"OWNER", "MEMBER", "COLLABORATOR"}', '{"OWNER", "MEMBER", "COLLABORATOR", "NONE"}'),
+    "comment_page_bound": (FALLBACK_RELEASE_FILES[1], 'range(1, 11)', 'range(1, 12)'),
+    "provider_skipped": (FALLBACK_RELEASE_FILES[1], 'if provider.get("conclusion") != "skipped":', 'if False:'),
+    "nested_reference": ('.github/workflows/claude.yml', '$/.github/workflows/claude-code-review.yml', './.github/workflows/claude-code-review.yml'),
+    "interactive_exclusion": ('.github/workflows/claude.yml', "!startsWith(github.event.comment.body, '@claude managed rollout review for PR ')", 'true'),
+    "consumer_permission": ('examples/baseline-workflows/.github/workflows/claude.yml', 'pull-requests: write', 'pull-requests: read'),
+    "interactive_permission": ('.github/workflows/claude.yml', '      pull-requests: read\n      issues: read', '      pull-requests: write\n      issues: read'),
+    "route_json": ('.github/workflows/claude-code-review.yml', 'invocation-route-json: ${{ steps.claude-invocation-route.outputs.invocation_route_json }}', 'invocation-route-json: \'{"kind":"automatic"}\''),
+    "ledger_migration": ('.github/actions/review-invocation-budget/review_invocation_budget.py', 'if schema == 1:', 'if schema == 0:'),
+    "canonical_route": ('.github/actions/review-invocation-budget/review_invocation_budget.py', 'if kind != "default_branch_rollout_fallback":', 'if kind != "untrusted":'),
+    "receipt_keys": (FALLBACK_RELEASE_FILES[2], '"schema", "verifier_commit"}', '"schema", "untrusted"}'),
+    "receipt_mode": (FALLBACK_RELEASE_FILES[2], 'os.fchmod(stream.fileno(), 0o600)', 'os.fchmod(stream.fileno(), 0o644)'),
+    "required_check": (FALLBACK_RELEASE_FILES[2], 'require_required_checks_clean(evidence.required_checks(request.expected_head))', 'require_required_checks_clean(())'),
+}
+
+
+@pytest.mark.parametrize("mutation", list(FALLBACK_MUTATIONS))
+def test_v177_rejects_fallback_contract_mutation(fallback_release_repo, mutation):
+    repo, _ = fallback_release_repo
+    # Establish acceptance first: a legacy seal must not mask a missing v1.77 seal.
+    release_verifier.verify_claude_rollout_fallback_contract(repo)
+    relative, old, new = FALLBACK_MUTATIONS[mutation]
+    replace(repo / relative, old, new, count=1)
+    bad = commit(repo, f"mutate {mutation}")
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_claude_rollout_fallback_contract(repo)
+    with pytest.raises(ReleaseVerificationError):
+        release_verifier.verify_commit_content(repo, "v1.77", bad)
 
 RECOVERY_RELEASE_FILES = (
     ".github/actions/recover-opencode-review/evidence.py",
@@ -66,6 +162,7 @@ def recovery_release_repo(tmp_path):
     git(repo, "init", "-q")
     git(repo, "config", "user.name", "Test")
     git(repo, "config", "user.email", "test@example.com")
+    restore_pre_v177_claude_rollout_fallback(repo)
     return repo, commit(repo, "v1.76 recovery candidate")
 
 
@@ -2412,6 +2509,7 @@ def prepare_v175(repo: Path) -> str:
     prepare_v174(repo)
     relative = ".github/workflows/claude-code-review.yml"
     shutil.copy2(ROOT / relative, repo / relative)
+    restore_pre_v177_claude_rollout_fallback(repo)
     return commit(repo, "v1.75 candidate")
 
 
@@ -3288,10 +3386,13 @@ def test_v147_rejects_budget_helper_gate_removal(
 def test_v147_budget_helper_semantics_reject_authenticated_mutations(
     monkeypatch: pytest.MonkeyPatch, mutation: str
 ) -> None:
-    source = (
-        ROOT
-        / ".github/actions/review-invocation-budget/review_invocation_budget.py"
-    ).read_text(encoding="utf-8")
+    source = release_verifier.VerifiedCommitTree.open(ROOT, V176_COMMIT).read_text(
+        ".github/actions/review-invocation-budget/review_invocation_budget.py"
+    )
+    release_verifier.require_budget_helper_contract(
+        source, rounds_variable=True, filter_reasons=True,
+        dismissals=True, expanded_budget=True,
+    )
     if mutation == "ledger-schema":
         source = source.replace(
             'keys = {"schema", "repository", "pr", "reviewer", "budgets", '
@@ -3376,10 +3477,16 @@ def test_v147_budget_helper_semantics_reject_authenticated_mutations(
 def test_v147_budget_helper_semantics_bind_live_ast_relationships(
     mutation: str,
 ) -> None:
-    source = (
-        ROOT
-        / ".github/actions/review-invocation-budget/review_invocation_budget.py"
-    ).read_text(encoding="utf-8")
+    # These schema-1 mutations must exercise schema-1 statements, even after the
+    # live source migrates to schema 2. Authenticate the immutable v1.76 bytes.
+    source = release_verifier.VerifiedCommitTree.open(ROOT, V176_COMMIT).read_text(
+        ".github/actions/review-invocation-budget/review_invocation_budget.py"
+    )
+
+    release_verifier.require_budget_helper_contract(
+        source, rounds_variable=True, filter_reasons=True,
+        dismissals=True, expanded_budget=True,
+    )
 
     def substitute(old: str, new: str, *, count: int = 1) -> None:
         nonlocal source

--- a/tests/test_workflow_release_bundle.py
+++ b/tests/test_workflow_release_bundle.py
@@ -427,14 +427,19 @@ def test_review_policy_release_boundary() -> None:
     assert {root.kind for root in policy_roots} == {"file"}
 
 
-def test_review_invocation_budget_action_has_exact_safe_contract() -> None:
+def test_v177_review_invocation_budget_action_has_exact_safe_contract() -> None:
     payload = REVIEW_INVOCATION_BUDGET_ACTION.read_bytes()
     document = yaml.load(payload, Loader=yaml.BaseLoader)
 
     assert hashlib.sha256(payload).hexdigest() == (
-        "b9ebc50e0959d9a2db82b1b11715be81309581ac45bb29b6dab02dccacedb91c"
+        "c05acbba8cac7e952867706a181eccaa25bc4f7baf720c5562dcbb71d1a04c90"
     )
-    assert document == release_verifier.EXPECTED_REVIEW_INVOCATION_BUDGET_ACTION_V163
+    release_verifier._fallback_parsed_seal(
+        ".github/actions/review-invocation-budget/action.yml", document
+    )
+    assert document["inputs"]["invocation-route-json"] == {
+        "required": "false", "default": '{"kind":"automatic"}',
+    }
 
 
 def git(repo: Path, *args: str) -> str:


### PR DESCRIPTION
The Claude review rollout could stop before provider execution when a consumer caller and the immutable default-branch workflow were temporarily out of sync. This change adds a bounded, authenticated fallback that retries exactly that validation failure through the default-branch caller, records its budget provenance, and accepts a clean result only when the visible canonical document agrees with the authenticated state.

The release boundary moves to v1.78 after integrating v1.77's observational token-accounting contract. Recovery, fleet verification, release inventory, runbooks, and regression coverage are updated together. GitHub CI also hardens the setup-python runtime after dependency installation because hosted Ubuntu runners intentionally expose `/opt` as writable; the verifier's production trust policy remains strict.

Validation:

- GitHub Test Fleet on `21b99b3435`: 3,907 passed, 48 subtests passed
- Current-head Codex review: no major issues
- Current-head Claude and Gemini reviews: performed successfully, 0 accepted/filtered/normalized findings
- OpenCode exhausted its bounded retries on `candidate_contract_failed`; no review checkpoint was advanced
- Pre-PR tribunal Round 2 passed on the feature snapshot `a5767d4760` with 0 blockers; later CI ownership hardening was covered by current-head reviews and CI
- Focused workflow, verifier, and release suites: 9, 232, and 66 passed
- Commit-only release verification: v1.76, v1.77, and v1.78 passed
- YAML parsing, shell syntax, digest-verified actionlint 1.7.12, and `git diff --check` passed

Part of #182
