### PR TITLE
fix(claude): harden pre-admission workflow permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Check workflow config
         id: check
-        uses: jhw7500/automation/.github/actions/check-workflow-enabled@fec2c90743cca062f113a87bb5deaf73b61501ce
+        uses: jhw7500/automation/.github/actions/check-workflow-enabled@a08141d644ab1036cadd8167d48158e827dcd978
         with:
           workflow-name: claude
           force-run: ${{ inputs.force_run && 'true' || 'false' }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   check-enabled:
+    permissions:
+      contents: read
     name: Check if enabled
     runs-on: ubuntu-latest
     outputs:
@@ -28,7 +30,7 @@ jobs:
 
       - name: Check workflow config
         id: check
-        uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
+        uses: jhw7500/automation/.github/actions/check-workflow-enabled@fec2c90743cca062f113a87bb5deaf73b61501ce
         with:
           workflow-name: claude
           force-run: ${{ inputs.force_run && 'true' || 'false' }}
@@ -151,6 +153,7 @@ jobs:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
   skipped:
+    permissions: {}
     name: Workflow Skipped
     needs: check-enabled
     if: needs.check-enabled.outputs.enabled != 'true'

--- a/docs/superpowers/plans/2026-09-11-claude-caller-rollout-fallback.md
+++ b/docs/superpowers/plans/2026-09-11-claude-caller-rollout-fallback.md
@@ -1651,7 +1651,7 @@ further mutations.
 | --- | --- | --- |
 | v1.78 | Annotated tag `7efe562b49c7b5f9fdad6855ff8c2a73b090a122`, peeled commit `a08141d644ab1036cadd8167d48158e827dcd978` | Preserve unchanged |
 | Bootstrap PR | `jhw7500/wlan-package#331`, reviewed HEAD `8ed6b45e8c5df68391941fbd181cfb79f0380178`, base `a35064638d4881c06d7589cd6bfa08a2bffbaff0` | Blocked by tribunal finding A-R1-001; update to v1.78.1 and review the new HEAD |
-| v1.78.1 | Security patch candidate | Narrow pre-admission permissions and pin `check-workflow-enabled` to `fec2c90743cca062f113a87bb5deaf73b61501ce` |
+| v1.78.1 | Security patch candidate | Narrow pre-admission permissions and pin `check-workflow-enabled` to the immutable v1.78 commit `a08141d644ab1036cadd8167d48158e827dcd978`, preserving description-before-enabled fallback parsing |
 | v1.78.2 | Not yet created | Distinct docs-only release after v1.78.1 adoption, with every v1.78.1 release-owned path byte-identical |
 
 - [ ] **Step A: Complete the v1.78.1 hardening patch test-first.** Require

--- a/docs/superpowers/plans/2026-09-11-claude-caller-rollout-fallback.md
+++ b/docs/superpowers/plans/2026-09-11-claude-caller-rollout-fallback.md
@@ -15,26 +15,42 @@
 #183 published observational token estimates as immutable v1.77: annotated tag
 `81f44fb6786bdfcc40f93161db74b1d9a9e3b7c5` peels to
 `dd13f9dcc64540494c1c04bc3f9c7a4f2ef0ba19`. Integrate that exact main with a normal
-merge, preserving the reviewed #182 Task 1-6 history. The fallback boundary and
-all future publication/adoption approvals now use v1.78; its distinct, byte-identical
-release-owned boundary canary uses v1.78.1. Never republish or move v1.77.
+merge, preserving the reviewed #182 Task 1-6 history. The fallback boundary was
+published as immutable v1.78. Never republish or move v1.77 or v1.78.
 Schema 2 preserves v1.77's observational token estimates and summary field while
 retaining round, override, call-count, wall-time, checkpoint and provenance gates.
 The v1.76 bootstrap evidence and immutable v1.76 identity below remain historical.
 
+## Tribunal correction (2026-09-12)
+
+The first `wlan-package` bootstrap candidate at v1.78 reached exact-head tribunal
+review as PR #331. Reviewer A found that its caller-level `pull-requests: write`
+and `id-token: write` ceiling also reached the unconditional `check-enabled` job,
+where a mutable `check-workflow-enabled@v1.1` action ran before managed admission.
+The public exact-head Codex review therefore supersedes the earlier zero-finding
+comment and blocks that HEAD.
+
+The bounded correction is a normal security patch. v1.78.1 gives
+`check-enabled` only `contents: read`, gives `skipped` no permissions, and pins
+the nested check action to its exact reviewed commit. The release verifier keeps
+the immutable v1.78 contract accepted but requires this hardening at v1.78.1 and
+later. PR #331 must be updated to v1.78.1 and pass a complete new review round
+before any merge decision. The distinct release-owned-byte boundary canary moves
+to v1.78.2 after v1.78.1 is installed on the consumer default branch.
+
 ## Global Constraints
 
 - Work only in `/home/jhw/ai/opencode/worktrees/jhw-control/wt-7e615b91b0e8-jhw7500-automation-182` on `task/7e615b91b0e8-jhw7500-automation-182`, starting from design commit `b10503c` over immutable v1.76 source `444a7347aee169ed178aae80e8bd8d10eca52e02`.
-- Keep Task `tsk-01a08b34-cc9e-777f-a99d-7e615b91b0e8` and Claim `clm-01a08b35-4a07-75ba-8a22-a8ca96029ade`. Do not add, take over, delete, repair, or directly edit a Claim, lock, Registry record, budget ledger, secret, or Notion record.
+- Keep Task `tsk-01a08b34-cc9e-777f-a99d-7e615b91b0e8` and its current supported Claim. Do not add, take over, delete, repair, or directly edit a Claim, lock, Registry record, budget ledger, secret, or Notion record.
 - Every shell command starts with `rtk`; commands that need an unwrapped executable use `rtk proxy`. Apply source edits with `apply_patch`.
 - Write a failing behavioral test before each implementation change. Add no dependency and execute no code, action, hook, filter, binary, or artifact supplied by a consumer pull request.
-- Preserve v1.76 and v1.77 bytes, tags, release acceptance, and historical fixtures. Own the new workflow, action, verifier, and ledger schema behavior behind the v1.78 feature boundary.
+- Preserve v1.76, v1.77, and v1.78 bytes, tags, release acceptance, and historical fixtures. Own the fallback behind the v1.78 feature boundary and the pre-admission hardening behind v1.78.1.
 - Authenticate only `workflow_validation_mismatch` with `review_execution=not_performed`, the Claude provider step skipped, and no budget claim. `workflow_validation_unavailable`, provider entry, any other failure, stale coordinates, ambiguity, pagination overflow, and transport uncertainty remain blocking.
 - The fallback uses the existing Claude credential once and consumes one ordinary automatic review round for the exact pull-request HEAD/full diff. A retry reuses a valid request or finalized result and cannot add a second provider call.
 - Do not make the original failed automatic check successful, hide it, waive a required status, weaken branch protection, or replace target tests, mergeability, exact HEAD/base, origin, or GitHub-generated merge verification.
-- The consumer permission ceiling for `claude.yml` becomes `pull-requests: write`; the central interactive Claude job explicitly reduces itself to `pull-requests: read`; only the admitted nested managed job retains write permission for the canonical sticky comment.
+- The consumer permission ceiling for `claude.yml` becomes `pull-requests: write`; the central interactive Claude job explicitly reduces itself to `pull-requests: read`; `check-enabled` is limited to `contents: read`, `skipped` has no permissions, and only the admitted nested managed job retains write permission for the canonical sticky comment. The pre-admission check action is pinned to an immutable commit.
 - This plan changes only the automation repository. It ends with a versioned receipt schema and verifier CLI. Before editing `/home/jhw/ai/opencode/projects/jhw-notion-runtime`, run that repository's stateless Task nudge, obtain any required separate approval, and write a second implementation plan.
-- Do not publish v1.78 or mutate a consumer until the implementation branch passes local verification, native pre-PR tribunal, hosted review, and reviewed merge. Stop a canary if a required failed Claude check remains native-blocking.
+- Do not publish v1.78.1 or update the consumer candidate until the hardening branch passes local verification, native pre-PR tribunal, hosted review, and reviewed merge. Stop a canary if a required failed Claude check remains native-blocking.
 
 ---
 
@@ -47,7 +63,7 @@ The v1.76 bootstrap evidence and immutable v1.76 identity below remain historica
 | Budget ledger | `review-invocation-budget` | later review runs and verifier | schema 2, reads schema 1 |
 | Claude sticky state | `claude-code-review.yml` | review context and fleet verifier | schema 3 with exact optional extensions |
 | Fleet fallback receipt | `verify_claude_rollout_fallback.py` | later JHW command | schema 1 |
-| Workflow release | reviewed automation merge | release verifier and consumers | v1.78 |
+| Workflow release | reviewed automation merge | release verifier and consumers | v1.78 feature; v1.78.1 hardening |
 
 The only accepted request body is the following two-line form, with one optional final LF and no other bytes:
 
@@ -1624,6 +1640,61 @@ Close the telemetry run on every exit. A PASS records bound HEAD/diff. CRITICAL/
 - [ ] **Step 11: Merge and verify the remote result.** Merge only the reviewed HEAD through the supported method, then compare the API-returned merge commit and the new remote `main` object with the expected GitHub-generated commit. Any drift stops before release publication.
 
 ### Task 8: Immutable release, real-boundary canary, and bootstrap batch
+
+#### Current execution amendment (2026-09-12)
+
+This amendment supersedes the original numbered Task 8 procedure below. The old
+sequence is retained only as historical design provenance and must not be used for
+further mutations.
+
+| Boundary | Current evidence | Required next state |
+| --- | --- | --- |
+| v1.78 | Annotated tag `7efe562b49c7b5f9fdad6855ff8c2a73b090a122`, peeled commit `a08141d644ab1036cadd8167d48158e827dcd978` | Preserve unchanged |
+| Bootstrap PR | `jhw7500/wlan-package#331`, reviewed HEAD `8ed6b45e8c5df68391941fbd181cfb79f0380178`, base `a35064638d4881c06d7589cd6bfa08a2bffbaff0` | Blocked by tribunal finding A-R1-001; update to v1.78.1 and review the new HEAD |
+| v1.78.1 | Security patch candidate | Narrow pre-admission permissions and pin `check-workflow-enabled` to `fec2c90743cca062f113a87bb5deaf73b61501ce` |
+| v1.78.2 | Not yet created | Distinct docs-only release after v1.78.1 adoption, with every v1.78.1 release-owned path byte-identical |
+
+- [ ] **Step A: Complete the v1.78.1 hardening patch test-first.** Require
+  `check-enabled.permissions == {contents: read}`,
+  `skipped.permissions == {}`, and the exact immutable nested action pin. Keep
+  v1.78 accepted only at its existing authenticated bytes; require hardening for
+  v1.78.1 and later. Update release documentation and tests for the new sequence.
+- [ ] **Step B: Review and merge the automation patch.** Run focused and full
+  verification, actionlint, Python compilation and `git diff --check`; then run a
+  complete three-role native tribunal and hosted review on one exact automation
+  HEAD. Resolve every HIGH/CRITICAL finding with a decision and a new complete
+  round. Merge only after a clean verdict and an explicit reviewed-merge decision.
+- [ ] **Step C: Publish v1.78.1 only after concrete approval.** Present the exact
+  reviewed main commit, tree, verifier result, release-root digest, and proof that
+  both direct and peeled v1.78.1 refs are absent. Create the annotated tag once
+  through the create-only procedure in `docs/workflow-fleet-rollout.md`; never move,
+  delete, or retry an uncertain ref creation.
+- [ ] **Step D: Update the existing bootstrap PR.** Re-render only the managed
+  workflow paths in PR #331 from v1.78 to v1.78.1. Bind the new commit, tree, base,
+  full-diff digest and released central commit before the single remote update.
+  Preserve the original automatic mismatch and Round 1 tribunal evidence.
+- [ ] **Step E: Rereview and merge the bootstrap only if clean.** Record a formal
+  decision for A-R1-001, run all three tribunal roles as Round 2 against the new
+  exact HEAD, and rerun target, Gemini, OpenCode, shell, source and Codex gates.
+  A new finding or coordinate drift blocks merge. Present the live exact-head/base
+  merge tuple and obtain separate merge approval.
+- [ ] **Step F: Create and publish the v1.78.2 boundary candidate.** After v1.78.1
+  is installed on the consumer default branch, add only
+  `docs/workflows/v1.78.2-boundary-canary.md` on a distinct automation commit.
+  Prove an empty raw Git diff over the authenticated v1.78.1 release inventory,
+  run complete automation review, merge, and obtain separate tag approval.
+- [ ] **Step G: Exercise the real pin boundary.** Create one managed rollout PR
+  from the installed v1.78.1 caller to v1.78.2. Require the expected automatic
+  `workflow_validation_mismatch`, one separately authorized canonical fallback
+  request, exactly one provider entry, a finalized budget, canonical clean state,
+  and a receipt verified from the exact v1.78.1 driver commit. Merge only after
+  independent review and separate approval.
+- [ ] **Step H: Close the operational handoff.** Record both new tag objects and
+  peeled commits, PR/run/comment/receipt tuples, review decisions, provider count,
+  fleet audits, remaining blockers and untouched evidence digests. Complete the
+  supported Task lifecycle only after every requested rollout result is verified.
+
+#### Archived original Task 8 sequence (superseded)
 
 **Files:**
 

--- a/docs/superpowers/specs/2026-09-11-claude-caller-rollout-fallback-design.md
+++ b/docs/superpowers/specs/2026-09-11-claude-caller-rollout-fallback-design.md
@@ -7,11 +7,13 @@ Issue: https://github.com/jhw7500/automation/issues/182
 Integration note (2026-09-11): #183 published observational token estimates as
 immutable v1.77, tag object `81f44fb6786bdfcc40f93161db74b1d9a9e3b7c5` at exact
 commit `dd13f9dcc64540494c1c04bc3f9c7a4f2ef0ba19`. The #182 fallback release is
-therefore v1.78, with its distinct byte-identical boundary canary at v1.78.1.
-The normal main merge preserves reviewed Task 1-6 history. Both future publication
-paths authenticate v1.77 and unchanged v1.76 before any write; v1.78.1 additionally
-authenticates v1.78 and compares all release-owned paths using that baseline's
-inventory. Schema 2 keeps token estimates observational and preserves the v1.77
+therefore immutable v1.78. A consumer tribunal finding after publication requires
+the pre-admission permission and action-pin correction in v1.78.1; the distinct
+byte-identical boundary canary moves to v1.78.2. The normal main merge preserves
+reviewed Task 1-6 history. Both new publication paths authenticate v1.78, v1.77,
+and unchanged v1.76 before any write; v1.78.2 additionally authenticates v1.78.1
+and compares all release-owned paths using that baseline's inventory. Schema 2
+keeps token estimates observational and preserves the v1.77
 summary field, round, override, call-count, wall-time, checkpoint and provenance
 gates. v1.77 continues to validate its authentic schema-1 helper. The v1.76 source
 and bootstrap evidence below are historical and remain unchanged.
@@ -168,10 +170,12 @@ workflow's exact commit; it does not select code from the consumer checkout.
 
 The consumer caller grants `pull-requests: write` as the permission ceiling required
 for the canonical sticky comment. The central interactive job continues to reduce
-its own permissions to read-only. Only the admitted managed rollout job retains the
-write permission used by the existing canonical publication path. Both jobs keep
-`contents: read`, `actions: read`, `issues: read` and `id-token: write` at the minimum
-already required by their provider paths.
+its own permissions to read-only. The unconditional `check-enabled` job receives
+only `contents: read`, the `skipped` job receives no permissions, and the nested
+check action is pinned to an exact commit. Only the admitted managed rollout job
+retains the write permission used by the existing canonical publication path.
+Provider paths keep `contents: read`, `actions: read`, `issues: read` and
+`id-token: write` at the minimum already required by those paths.
 
 The nested review receives new optional, all-or-none fallback inputs:
 

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -626,7 +626,7 @@ inventory, locking, health checks, and deployment lifecycle. Other provider-key 
 must use their separately reviewed owner process. There is intentionally no command that
 combines workflow PR publication with token synchronization.
 
-## Create-only v1.78 and v1.78.1 tag publication
+## Create-only v1.78.1 and v1.78.2 tag publication
 
 This is an operator procedure for a separately approved publication, not an action
 performed by implementing the fallback. The Git Data sequence used for the
@@ -634,7 +634,7 @@ immutable v1.76 boundary remains create-only. Never publish with ordinary Git pu
 move a tag or delete a tag. The older v1.40.1 example above is historical.
 
 For each release separately, obtain the exact reviewed merge commit from the
-approved public-main change. Set `RELEASE_TAG` to `v1.78` or `v1.78.1`,
+approved public-main change. Set `RELEASE_TAG` to `v1.78.1` or `v1.78.2`,
 `EXPECTED_RELEASE_COMMIT` to that 40-character commit and `RELEASE_DIRECTORY` to
 an absolute, absent disposable directory under a trusted parent. Exactly one of
 `GH_TOKEN` and `GITHUB_TOKEN` must contain the intended publication token. Never
@@ -649,17 +649,23 @@ is created as a current-user-owned non-symlink regular file and independently se
 to 0600. It computes the intended tag OID before the first POST and verifies both
 response OIDs, then verifies the local and public direct/peeled identities.
 
-For v1.78.1, before either POST it also authenticates the existing annotated
-v1.78 tag and peeled commit, requires a distinct reviewed candidate, and compares
-every v1.78 inventory-owned path, mode and blob. The inventory is loaded from
-the authenticated v1.78 checkout, so the candidate cannot reduce the comparison.
-Any release-owned difference invalidates this boundary canary and requires a
-normal reviewed patch design. First publication of v1.78 has no prior-v1.78 check.
-Both paths authenticate immutable v1.77 tag object
+Both paths authenticate the existing annotated v1.78 tag object
+`7efe562b49c7b5f9fdad6855ff8c2a73b090a122` and peeled commit
+`a08141d644ab1036cadd8167d48158e827dcd978`. v1.78.1 is the reviewed security
+patch that narrows pre-admission Claude permissions and pins the nested
+check-workflow-enabled action to an immutable commit. For v1.78.2, before either
+POST the procedure also authenticates the existing annotated v1.78.1 tag and
+peeled commit, requires a distinct reviewed candidate, and compares every
+v1.78.1 inventory-owned path, mode and blob. The inventory is loaded from the
+authenticated v1.78.1 checkout, so the candidate cannot reduce the comparison.
+Any release-owned difference invalidates the v1.78.2 boundary canary and requires
+a normal reviewed patch design. First publication of v1.78.1 has no
+prior-v1.78.1 check. Both paths also authenticate immutable v1.77 tag object
 `81f44fb6786bdfcc40f93161db74b1d9a9e3b7c5`, peeled commit
 `dd13f9dcc64540494c1c04bc3f9c7a4f2ef0ba19`, and the unchanged v1.76 identity
 before any publication write. v1.77 is #183's observational-token release;
-#182's fallback begins in v1.78 and its distinct boundary canary is v1.78.1.
+#182's fallback begins in v1.78, is hardened in v1.78.1, and uses v1.78.2 for
+the distinct real-boundary canary.
 
 ```bash
 rtk proxy /usr/bin/python3 -I -S -B -c '
@@ -675,7 +681,7 @@ if not 0 < len(token) <= 4096 or b"\n" in token or b"\r" in token:
 tag = os.environ.get("RELEASE_TAG", "")
 commit = os.environ.get("EXPECTED_RELEASE_COMMIT", "")
 directory = os.environ.get("RELEASE_DIRECTORY", "")
-if tag not in {"v1.78", "v1.78.1"} or re.fullmatch(r"[0-9a-f]{40}", commit) is None:
+if tag not in {"v1.78.1", "v1.78.2"} or re.fullmatch(r"[0-9a-f]{40}", commit) is None:
     raise SystemExit("invalid reviewed release identity")
 if not directory.startswith("/"):
     raise SystemExit("absolute disposable directory required")
@@ -745,10 +751,14 @@ v176_commit = "444a7347aee169ed178aae80e8bd8d10eca52e02"
 v176_tag = "09af80682619129fcf343091b78413d2686a4579"
 v177_commit = "dd13f9dcc64540494c1c04bc3f9c7a4f2ef0ba19"
 v177_tag = "81f44fb6786bdfcc40f93161db74b1d9a9e3b7c5"
+v178_commit = "a08141d644ab1036cadd8167d48158e827dcd978"
+v178_tag = "7efe562b49c7b5f9fdad6855ff8c2a73b090a122"
 require(set(public_tags("v1.77").splitlines()) == tag_pairs("v1.77", v177_tag, v177_commit),
         "v1.77 identity changed")
 require(set(public_tags("v1.76").splitlines()) == tag_pairs("v1.76", v176_tag, v176_commit),
         "v1.76 identity changed")
+require(set(public_tags("v1.78").splitlines()) == tag_pairs("v1.78", v178_tag, v178_commit),
+        "v1.78 identity changed")
 require(public_tags(tag) == "", "release direct or peeled ref already exists")
 main = git("ls-remote", "--heads", url, "refs/heads/main")
 require(main == commit + "\trefs/heads/main", "public main differs from reviewed commit")
@@ -759,11 +769,13 @@ git("checkout", "--detach", commit, cwd=checkout)
 require(git("status", "--porcelain", cwd=checkout) == "", "dirty release checkout")
 for historical_tag, direct, peeled in (
     ("v1.76", v176_tag, v176_commit), ("v1.77", v177_tag, v177_commit),
+    ("v1.78", v178_tag, v178_commit),
 ):
     require(git("rev-parse", "refs/tags/" + historical_tag, cwd=checkout) == direct
             and git("rev-parse", "refs/tags/" + historical_tag + "^{}", cwd=checkout) == peeled
             and git("cat-file", "-t", direct, cwd=checkout) == "tag",
             historical_tag + " annotation or peeled commit differs")
+require(commit != v178_commit, "patch release requires a distinct reviewed commit")
 
 def verify_release(*extra):
     subprocess.run(["/usr/bin/python3", "-B", "-m", "scripts.verify_workflow_release",
@@ -771,44 +783,46 @@ def verify_release(*extra):
                     "--expected-commit", commit, *extra], cwd=checkout, env=runtime, check=True)
 
 verify_release("--commit-only")
-if tag == "v1.78.1":
-    pairs = [line.split("\t") for line in public_tags("v1.78").splitlines()]
+if tag == "v1.78.2":
+    pairs = [line.split("\t") for line in public_tags("v1.78.1").splitlines()]
     require(len(pairs) == 2 and all(len(pair) == 2 for pair in pairs),
-            "missing or ambiguous v1.78 direct/peeled identity")
+            "missing or ambiguous v1.78.1 direct/peeled identity")
     refs = {ref: oid for oid, ref in pairs}
-    require(set(refs) == {"refs/tags/v1.78", "refs/tags/v1.78^{}"}
+    require(set(refs) == {"refs/tags/v1.78.1", "refs/tags/v1.78.1^{}"}
             and all(re.fullmatch("[0-9a-f]{40}", oid) for oid in refs.values()),
-            "invalid v1.78 direct/peeled identity")
-    v178_tag = refs["refs/tags/v1.78"]
-    v178_commit = refs["refs/tags/v1.78^{}"]
-    require(commit != v178_commit, "boundary canary requires a distinct reviewed commit")
-    git("fetch", "--no-tags", url, "refs/tags/v1.78:refs/tags/v1.78", cwd=checkout)
-    require(git("rev-parse", "refs/tags/v1.78", cwd=checkout) == v178_tag
-            and git("rev-parse", "refs/tags/v1.78^{}", cwd=checkout) == v178_commit
-            and git("cat-file", "-t", v178_tag, cwd=checkout) == "tag",
-            "fetched v1.78 annotation or peeled commit differs")
-    baseline = root / "v178-baseline"
-    git("worktree", "add", "--detach", str(baseline), v178_commit, cwd=checkout)
+            "invalid v1.78.1 direct/peeled identity")
+    v1781_tag = refs["refs/tags/v1.78.1"]
+    v1781_commit = refs["refs/tags/v1.78.1^{}"]
+    require(commit != v1781_commit, "boundary canary requires a distinct reviewed commit")
+    git("fetch", "--no-tags", url, "refs/tags/v1.78.1:refs/tags/v1.78.1", cwd=checkout)
+    require(git("rev-parse", "refs/tags/v1.78.1", cwd=checkout) == v1781_tag
+            and git("rev-parse", "refs/tags/v1.78.1^{}", cwd=checkout) == v1781_commit
+            and git("cat-file", "-t", v1781_tag, cwd=checkout) == "tag",
+            "fetched v1.78.1 annotation or peeled commit differs")
+    baseline = root / "v1781-baseline"
+    git("worktree", "add", "--detach", str(baseline), v1781_commit, cwd=checkout)
     subprocess.run(["/usr/bin/python3", "-B", "-m", "scripts.verify_workflow_release",
-                    "--automation", str(baseline), "--ref", "v1.78",
-                    "--expected-commit", v178_commit, "--remote", "origin"],
+                    "--automation", str(baseline), "--ref", "v1.78.1",
+                    "--expected-commit", v1781_commit, "--remote", "origin"],
                    cwd=baseline, env=runtime, check=True)
     inventory = subprocess.run(["/usr/bin/python3", "-B", "-c",
         'import json; from scripts.workflow_release_inventory import release_paths_for; '
-        'print(json.dumps(release_paths_for("v1.78")))'],
+        'print(json.dumps(release_paths_for("v1.78.1")))'],
         cwd=baseline, env=runtime, check=True, capture_output=True, text=True)
     owned = json.loads(inventory.stdout)
     require(isinstance(owned, list) and owned and all(isinstance(path, str) for path in owned),
-            "invalid authenticated v1.78 inventory")
+            "invalid authenticated v1.78.1 inventory")
     require(git("diff", "--raw", "--no-ext-diff", "--no-textconv", "--exit-code",
-                v178_commit, commit, "--", *owned, cwd=checkout) == "",
+                v1781_commit, commit, "--", *owned, cwd=checkout) == "",
             "release-owned difference invalidates boundary canary; normal reviewed patch design required")
-    require(set(public_tags("v1.78").splitlines()) == tag_pairs("v1.78", v178_tag, v178_commit),
-            "v1.78 identity moved before write")
+    require(set(public_tags("v1.78.1").splitlines()) == tag_pairs("v1.78.1", v1781_tag, v1781_commit),
+            "v1.78.1 identity moved before write")
 require(set(public_tags("v1.76").splitlines()) == tag_pairs("v1.76", v176_tag, v176_commit),
         "v1.76 identity moved before write")
 require(set(public_tags("v1.77").splitlines()) == tag_pairs("v1.77", v177_tag, v177_commit),
         "v1.77 identity moved before write")
+require(set(public_tags("v1.78").splitlines()) == tag_pairs("v1.78", v178_tag, v178_commit),
+        "v1.78 identity moved before write")
 require(git("ls-remote", "--heads", url, "refs/heads/main") == main, "main moved before write")
 require(public_tags(tag) == "", "release ref appeared before write")
 now = datetime.now(timezone.utc).replace(microsecond=0)
@@ -855,6 +869,12 @@ require(set(public_tags("v1.77").splitlines()) == tag_pairs("v1.77", v177_tag, v
         "v1.77 identity changed")
 require(set(public_tags("v1.76").splitlines()) == tag_pairs("v1.76", v176_tag, v176_commit),
         "v1.76 identity changed")
+require(set(public_tags("v1.78").splitlines()) == tag_pairs("v1.78", v178_tag, v178_commit),
+        "v1.78 identity changed")
+if tag == "v1.78.2":
+    require(set(public_tags("v1.78.1").splitlines())
+            == tag_pairs("v1.78.1", v1781_tag, v1781_commit),
+            "v1.78.1 identity changed")
 git("fetch", "--no-tags", url, "refs/tags/" + tag + ":refs/tags/" + tag, cwd=checkout)
 require(git("rev-parse", "refs/tags/" + tag, cwd=checkout) == tag_oid, "local direct ref differs")
 require(git("rev-parse", "refs/tags/" + tag + "^{}", cwd=checkout) == commit, "local peeled ref differs")
@@ -866,7 +886,7 @@ CLAUDE_RELEASE_PY
 A failed or uncertain POST stops the procedure. Preserve both raw response files
 that exist and reconcile with read-only API/public Git reads. An orphan annotated
 object is harmless; a concurrent ref creation must never be repaired by moving
-or deleting the tag. Repeat this procedure for v1.78.1 only after its separate
+or deleting the tag. Repeat this procedure for v1.78.2 only after its separate
 reviewed main change and publication authorization.
 
 ## v1.76 bootstrap evidence
@@ -881,34 +901,36 @@ evidence; neither a new comment nor a receipt can retroactively enable v1.78 cod
 Use a separately reviewed adoption/merge decision to establish the new default
 caller. Never rewrite the original failure as a successful run.
 
-## v1.78 route adoption
+## v1.78.1 hardened route adoption
 
 After create-only publication and release verification, render consumer caller
 changes with the existing fleet plan/publish/audit workflow, explicitly selecting
 the immutable release ref and approved consumer/base branch. Review the generated
 managed diff and adoption PR before a separately authorized merge. Verify the
-default-branch `claude.yml` pins the peeled v1.78 commit and has the catalogued
+default-branch `claude.yml` pins the peeled v1.78.1 commit and has the catalogued
 write ceiling. Keep the ordinary automatic reviewer on the reviewed release pin.
+An open v1.78 bootstrap PR must be updated to v1.78.1 and reviewed again at its
+new exact HEAD; do not merge the superseded v1.78 candidate.
 
 Record the new default caller SHA and its central commit as the future fallback
-driver. A v1.78 adoption PR alone is not the real boundary canary: until merged,
+driver. A v1.78.1 adoption PR alone is not the real boundary canary: until merged,
 the default branch still runs the older caller. Request/admission/ledger/comment
 and receipt schemas are defined in [the consumer contract](workflows/contracts.md).
 
-## v1.78.1 real-boundary canary
+## v1.78.2 real-boundary canary
 
-Publish a separately reviewed v1.78.1 commit after v1.78 caller adoption. It must
-be distinct from the authenticated v1.78 peeled commit while preserving every
-v1.78 release-owned byte, path and mode. Before publication, the procedure above
-must prove an empty raw Git diff across the authenticated v1.78 inventory. Any
+Publish a separately reviewed v1.78.2 commit after v1.78.1 caller adoption. It must
+be distinct from the authenticated v1.78.1 peeled commit while preserving every
+v1.78.1 release-owned byte, path and mode. Before publication, the procedure above
+must prove an empty raw Git diff across the authenticated v1.78.1 inventory. Any
 difference invalidates this boundary canary and requires a normal reviewed patch
 design. Create one
-approved managed rollout PR from the v1.78 default to v1.78.1; record exact HEAD,
+approved managed rollout PR from the v1.78.1 default to v1.78.2; record exact HEAD,
 base and managed diff hash. Require the original automatic attempt to fail at
 caller validation, with budget claim and provider skipped and the matching
 canonical automatic failure. Post one separately authorized canonical managed
-request after that failure. Its target release is v1.78.1; its default caller and
-verification checkout remain the exact v1.78 driver commit. Wait for the managed
+request after that failure. Its target release is v1.78.2; its default caller and
+verification checkout remain the exact v1.78.1 driver commit. Wait for the managed
 run and charged invocation to finalize. Do not retry an uncertain request.
 
 From a clean automation checkout at that driver commit, in an independently
@@ -916,7 +938,7 @@ mode-0700 evidence directory, run the read-only verifier using recorded values:
 
 ```bash
 rtk proxy /usr/bin/python3 -I -S -B "$AUTOMATION_ROOT/scripts/verify_claude_rollout_fallback.py" \
-  --automation-root "$AUTOMATION_ROOT" --release-ref v1.78.1 --remote origin \
+  --automation-root "$AUTOMATION_ROOT" --release-ref v1.78.2 --remote origin \
   --repository "$CONSUMER_REPOSITORY" --pr "$PR_NUMBER" \
   --expected-head "$EXPECTED_HEAD_SHA" --expected-base "$EXPECTED_BASE_SHA" \
   --output "$PRIVATE_EVIDENCE_DIRECTORY/claude-fallback-receipt.json"

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -150,6 +150,13 @@ only actions/contents/issues/pull-requests read. The nested managed job uses exa
 `$/.github/workflows/claude-code-review.yml`, the consumer write ceiling above,
 and the same-name `CLAUDE_CODE_OAUTH_TOKEN` secret.
 
+Release v1.78.1 hardens the jobs that run before managed admission. `check-enabled`
+has only `contents: read`, calls
+`check-workflow-enabled@fec2c90743cca062f113a87bb5deaf73b61501ce`, and cannot
+inherit the caller's pull-request write or OIDC grants. `skipped` has an empty
+permission map. The release verifier preserves exact v1.78 acceptance and requires
+these constraints for v1.78.1 and later.
+
 ## Admission schema 1
 
 Admission is a private regular JSON file owned by the runner, mode 0600, created

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -152,7 +152,8 @@ and the same-name `CLAUDE_CODE_OAUTH_TOKEN` secret.
 
 Release v1.78.1 hardens the jobs that run before managed admission. `check-enabled`
 has only `contents: read`, calls
-`check-workflow-enabled@fec2c90743cca062f113a87bb5deaf73b61501ce`, and cannot
+`check-workflow-enabled@a08141d644ab1036cadd8167d48158e827dcd978`, whose no-`yq`
+fallback accepts `enabled` after descriptive fields, and cannot
 inherit the caller's pull-request write or OIDC grants. `skipped` has an empty
 permission map. The release verifier preserves exact v1.78 acceptance and requires
 these constraints for v1.78.1 and later.

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -71,6 +71,10 @@ from scripts.workflow_release_inventory import (
 
 
 CHECKOUT_ACTION = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+CHECK_WORKFLOW_ENABLED_ACTION = (
+    "jhw7500/automation/.github/actions/check-workflow-enabled@"
+    "fec2c90743cca062f113a87bb5deaf73b61501ce"
+)
 CLAUDE_CODE_ACTION = (
     "anthropics/claude-code-action@"
     "6bcfb8263aca9b0eab0aba20d96dddd74de2875f"
@@ -7595,16 +7599,17 @@ def _verify_opencode_recovery(tree: VerifiedCommitTree, ref: str) -> None:
 
 
 
-# Reviewed v1.78 inputs, never calculated from the candidate at verification time.
-# Parsed seals retain all existing policy statements while schema-2 replaces the
-# legacy positional schema-1 AST checks. Raw seals additionally authenticate bytes.
+# Reviewed fallback inputs, never calculated from the candidate at verification time.
+# The current seals require the v1.78.1 pre-admission hardening; separate historical
+# router seals preserve exact immutable v1.78 acceptance. Parsed seals retain all
+# existing policy statements, and raw seals additionally authenticate exact bytes.
 EXPECTED_CLAUDE_FALLBACK_SHA256 = {
     ".github/actions/claude-rollout-fallback/action.yml": "ee4b8e6b88ebfc1d0691e032da93b03ba8268fac1bd9377a26554d8200621c0a",
     ".github/actions/claude-rollout-fallback/contract.py": "ae39e0f9c0a1faa6831559c93150fca7f768fbaa0257aade70f045abd0eafff6",
     "scripts/verify_claude_rollout_fallback.py": "91b986a63ec0ab97d072b9b7a906b2191d6a4de4adae8025fc5d4855fab883f5",
     ".github/actions/review-invocation-budget/action.yml": "c05acbba8cac7e952867706a181eccaa25bc4f7baf720c5562dcbb71d1a04c90",
     ".github/actions/review-invocation-budget/review_invocation_budget.py": "3f1f140b1b95fcc24618851e3f196efca6fe7bb259e244d86a4e972b5c681851",
-    ".github/workflows/claude.yml": "bb111fd319a6449f8f56cbe22a20572b662525f9f4a7765bc46a415bba5f5881",
+    ".github/workflows/claude.yml": "a309b233ed754d688c2af0c4486d76bb5f25bde78b4fc86a0c31c2de213c1bc8",
     ".github/workflows/claude-code-review.yml": "e9ab0aafc14b21e5eb6780ad80b1ca3c3766e5f8f0cc5b60700cfe88eb18ab81",
     ".github/workflows/opencode-auto-review.yml": "ca6cbf2b1f1c9c57f524c45d4de0c863ac2bb249d0e261bbcf1da7e2017c5ea1",
     ".github/actions/recover-opencode-review/evidence.py": "1eacc5e56ad5554324eeb0ce7a9d6872d1c8e22ca95828ce34758ccc2be0fee1",
@@ -7617,11 +7622,18 @@ EXPECTED_CLAUDE_FALLBACK_PARSED_SHA256 = {
     "scripts/verify_claude_rollout_fallback.py": "76d20b6674e4323c4971b0c27cbbac35c0641e363856d022fdbcb43ac71ce2f2",
     ".github/actions/review-invocation-budget/action.yml": "4a346ba8d26ea88efe5cc0dfa9f33f080ac8167cf777156d4eef635f1293b8ed",
     ".github/actions/review-invocation-budget/review_invocation_budget.py": "05dd0f27335431fea106d9c84debfa60b39696324eb6474c3b0f58db31695dde",
-    ".github/workflows/claude.yml": "5781ef1db5e22f83ed07fc83fabe0beb615544a1412e01b2b8dabfd5f06593ab",
+    ".github/workflows/claude.yml": "78725b166e53b6d6919d15a924e84a81ee21c702406ffb2ad911aecd8f8d1342",
     ".github/workflows/claude-code-review.yml": "130a3ee4164a2561ce6554e1fd6ddac25de11c734e7ec9504c8980841339407f",
     ".github/workflows/opencode-auto-review.yml": "da90fcad95d03f2b51120447edcf187eeb5fbdaa050ded885bb9c9907f3d7f9e",
     ".github/actions/recover-opencode-review/evidence.py": "4e27f7f7f11b3726c67f9e459554de1fc9d00586b37f18d67b7aaf67c5ff0d5b",
 }
+CLAUDE_FALLBACK_HARDENING_RELEASE = (1, 78, 1)
+V178_CLAUDE_ROUTER_SHA256 = (
+    "bb111fd319a6449f8f56cbe22a20572b662525f9f4a7765bc46a415bba5f5881"
+)
+V178_CLAUDE_ROUTER_PARSED_SHA256 = (
+    "5781ef1db5e22f83ed07fc83fabe0beb615544a1412e01b2b8dabfd5f06593ab"
+)
 FALLBACK_ACTION = "$/.github/actions/claude-rollout-fallback"
 FALLBACK_INPUT_OUTPUTS = {
     "fallback_request_comment_id": "request-comment-id",
@@ -7644,7 +7656,7 @@ def _fallback_literals(source: str, *literals: str) -> None:
         raise ReleaseVerificationError("Claude fallback literal contract differs")
 
 
-def _fallback_parsed_seal(relative: str, value: object) -> None:
+def _fallback_parsed_seal(relative: str, value: object, ref: str = "v1.78.1") -> None:
     if isinstance(value, ast.AST):
         # Python 3.12 adds empty type_params fields; they carry no policy.
         for node in ast.walk(value):
@@ -7655,11 +7667,19 @@ def _fallback_parsed_seal(relative: str, value: object) -> None:
         payload = ast.dump(value, include_attributes=False)
     else:
         payload = json.dumps(value, sort_keys=True, separators=(",", ":"))
-    if hashlib.sha256(payload.encode()).hexdigest() != EXPECTED_CLAUDE_FALLBACK_PARSED_SHA256[relative]:
+    expected = EXPECTED_CLAUDE_FALLBACK_PARSED_SHA256[relative]
+    if (
+        relative == ".github/workflows/claude.yml"
+        and _release_version(ref) < CLAUDE_FALLBACK_HARDENING_RELEASE
+    ):
+        expected = V178_CLAUDE_ROUTER_PARSED_SHA256
+    if hashlib.sha256(payload.encode()).hexdigest() != expected:
         raise ReleaseVerificationError("Claude fallback parsed contract differs: " + relative)
 
 
-def require_claude_fallback_permissions(caller: object, router: object, review: object) -> None:
+def require_claude_fallback_permissions(
+    caller: object, router: object, review: object, ref: str = "v1.78.1",
+) -> None:
     try:
         if (
             caller.get("permissions") is not None
@@ -7678,9 +7698,22 @@ def require_claude_fallback_permissions(caller: object, router: object, review: 
             raise ValueError("permissions differ")
     except (AttributeError, KeyError, TypeError, ValueError):
         raise ReleaseVerificationError("Claude fallback permission contract differs") from None
+    if _release_version(ref) < CLAUDE_FALLBACK_HARDENING_RELEASE:
+        return
+    try:
+        jobs = router["jobs"]
+        if (
+            jobs["check-enabled"].get("permissions") != {"contents": "read"}
+            or jobs["skipped"].get("permissions") != {}
+        ):
+            raise ValueError("pre-admission permissions differ")
+    except (AttributeError, KeyError, TypeError, ValueError):
+        raise ReleaseVerificationError(
+            "Claude fallback pre-admission permission contract differs"
+        ) from None
 
 
-def require_claude_fallback_routes(router: object) -> None:
+def require_claude_fallback_routes(router: object, ref: str) -> None:
     try:
         jobs = router["jobs"]
         interactive, managed = jobs["claude"], jobs["managed-rollout-review"]
@@ -7704,7 +7737,17 @@ def require_claude_fallback_routes(router: object) -> None:
         _fallback_literals(condition,
             "!startsWith(github.event.comment.body, '@claude managed rollout review for PR ')",
             """contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)""")
-        _fallback_parsed_seal(".github/workflows/claude.yml", router)
+        if _release_version(ref) >= CLAUDE_FALLBACK_HARDENING_RELEASE:
+            check_actions = [
+                step.get("uses")
+                for step in jobs["check-enabled"]["steps"]
+                if step.get("id") == "check"
+            ]
+            if check_actions != [CHECK_WORKFLOW_ENABLED_ACTION]:
+                raise ReleaseVerificationError(
+                    "Claude fallback check-workflow-enabled action is not immutable"
+                )
+        _fallback_parsed_seal(".github/workflows/claude.yml", router, ref)
     except (AttributeError, KeyError, TypeError, ValueError):
         raise ReleaseVerificationError("Claude fallback route contract differs") from None
 
@@ -7827,15 +7870,17 @@ def require_request_and_receipt_contracts(root: Path) -> None:
         raise ReleaseVerificationError("Claude fallback request/receipt contract differs") from None
 
 
-def verify_claude_rollout_fallback_contract(root: Path) -> None:
+def verify_claude_rollout_fallback_contract(
+    root: Path, ref: str = "v1.78.1",
+) -> None:
     try:
         def load(relative):
             return _load_release_yaml((root / relative).read_bytes(), reject_duplicate_keys=True)
         caller = load("examples/baseline-workflows/.github/workflows/claude.yml")
         router = load(".github/workflows/claude.yml")
         review = load(".github/workflows/claude-code-review.yml")
-        require_claude_fallback_permissions(caller, router, review)
-        require_claude_fallback_routes(router)
+        require_claude_fallback_permissions(caller, router, review, ref)
+        require_claude_fallback_routes(router, ref)
         require_claude_fallback_inputs(review)
         require_budget_schema_two(root)
         require_request_and_receipt_contracts(root)
@@ -7843,6 +7888,11 @@ def verify_claude_rollout_fallback_contract(root: Path) -> None:
                          ".github/workflows/opencode-auto-review.yml"):
             _fallback_parsed_seal(relative, load(relative))
         for relative, expected in EXPECTED_CLAUDE_FALLBACK_SHA256.items():
+            if (
+                relative == ".github/workflows/claude.yml"
+                and _release_version(ref) < CLAUDE_FALLBACK_HARDENING_RELEASE
+            ):
+                expected = V178_CLAUDE_ROUTER_SHA256
             if hashlib.sha256((root / relative).read_bytes()).hexdigest() != expected:
                 raise ReleaseVerificationError("Claude fallback authenticated source digest differs: " + relative)
     except (OSError, TypeError, ValueError, yaml.YAMLError):
@@ -7865,7 +7915,7 @@ def _verify_commit_content(
                 target = candidate_root / blob.path
                 target.parent.mkdir(parents=True, exist_ok=True)
                 target.write_bytes(tree.read_file(blob.path))
-            verify_claude_rollout_fallback_contract(candidate_root)
+            verify_claude_rollout_fallback_contract(candidate_root, ref)
     _verify_opencode_recovery(tree, ref)
     if release_supports_prepare_review_diff(ref):
         _verify_prepare_review_diff_action(tree, ref)

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -73,7 +73,7 @@ from scripts.workflow_release_inventory import (
 CHECKOUT_ACTION = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
 CHECK_WORKFLOW_ENABLED_ACTION = (
     "jhw7500/automation/.github/actions/check-workflow-enabled@"
-    "fec2c90743cca062f113a87bb5deaf73b61501ce"
+    "a08141d644ab1036cadd8167d48158e827dcd978"
 )
 CLAUDE_CODE_ACTION = (
     "anthropics/claude-code-action@"
@@ -7609,7 +7609,7 @@ EXPECTED_CLAUDE_FALLBACK_SHA256 = {
     "scripts/verify_claude_rollout_fallback.py": "91b986a63ec0ab97d072b9b7a906b2191d6a4de4adae8025fc5d4855fab883f5",
     ".github/actions/review-invocation-budget/action.yml": "c05acbba8cac7e952867706a181eccaa25bc4f7baf720c5562dcbb71d1a04c90",
     ".github/actions/review-invocation-budget/review_invocation_budget.py": "3f1f140b1b95fcc24618851e3f196efca6fe7bb259e244d86a4e972b5c681851",
-    ".github/workflows/claude.yml": "a309b233ed754d688c2af0c4486d76bb5f25bde78b4fc86a0c31c2de213c1bc8",
+    ".github/workflows/claude.yml": "914229686af627e5404bb730e376b18a9db7c4bbb4a707e385a0a6ce3473c82a",
     ".github/workflows/claude-code-review.yml": "e9ab0aafc14b21e5eb6780ad80b1ca3c3766e5f8f0cc5b60700cfe88eb18ab81",
     ".github/workflows/opencode-auto-review.yml": "ca6cbf2b1f1c9c57f524c45d4de0c863ac2bb249d0e261bbcf1da7e2017c5ea1",
     ".github/actions/recover-opencode-review/evidence.py": "1eacc5e56ad5554324eeb0ce7a9d6872d1c8e22ca95828ce34758ccc2be0fee1",
@@ -7622,7 +7622,7 @@ EXPECTED_CLAUDE_FALLBACK_PARSED_SHA256 = {
     "scripts/verify_claude_rollout_fallback.py": "76d20b6674e4323c4971b0c27cbbac35c0641e363856d022fdbcb43ac71ce2f2",
     ".github/actions/review-invocation-budget/action.yml": "4a346ba8d26ea88efe5cc0dfa9f33f080ac8167cf777156d4eef635f1293b8ed",
     ".github/actions/review-invocation-budget/review_invocation_budget.py": "05dd0f27335431fea106d9c84debfa60b39696324eb6474c3b0f58db31695dde",
-    ".github/workflows/claude.yml": "78725b166e53b6d6919d15a924e84a81ee21c702406ffb2ad911aecd8f8d1342",
+    ".github/workflows/claude.yml": "b388e789f7ebc6f720b634abe64e6edc41d3072cf7bca703978186d0f6d262c2",
     ".github/workflows/claude-code-review.yml": "130a3ee4164a2561ce6554e1fd6ddac25de11c734e7ec9504c8980841339407f",
     ".github/workflows/opencode-auto-review.yml": "da90fcad95d03f2b51120447edcf187eeb5fbdaa050ded885bb9c9907f3d7f9e",
     ".github/actions/recover-opencode-review/evidence.py": "4e27f7f7f11b3726c67f9e459554de1fc9d00586b37f18d67b7aaf67c5ff0d5b",

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -51,6 +51,9 @@ REVIEW_INVOCATION_BUDGET_HELPER = (
 V176_COMMIT = "444a7347aee169ed178aae80e8bd8d10eca52e02"
 V177_COMMIT = "dd13f9dcc64540494c1c04bc3f9c7a4f2ef0ba19"
 V178_COMMIT = "a08141d644ab1036cadd8167d48158e827dcd978"
+CHECK_WORKFLOW_ENABLED_ACTION_PATH = (
+    ".github/actions/check-workflow-enabled/action.yml"
+)
 FALLBACK_RELEASE_FILES = (
     ".github/actions/claude-rollout-fallback/action.yml",
     ".github/actions/claude-rollout-fallback/contract.py",
@@ -198,6 +201,59 @@ def test_v178_immutable_candidate_remains_accepted():
     assert release_verifier.verify_commit_content(ROOT, "v1.78", V178_COMMIT) == V178_COMMIT
 
 
+def test_hardened_claude_fallback_pinned_check_honors_reordered_disabled(tmp_path):
+    workflow = yaml.load(
+        (ROOT / ".github/workflows/claude.yml").read_bytes(), Loader=yaml.BaseLoader,
+    )
+    check_step = next(
+        step for step in workflow["jobs"]["check-enabled"]["steps"]
+        if step.get("id") == "check"
+    )
+    prefix = "jhw7500/automation/.github/actions/check-workflow-enabled@"
+    assert check_step["uses"].startswith(prefix)
+    pin = check_step["uses"][len(prefix):]
+    action = yaml.load(
+        release_verifier.VerifiedCommitTree.open(ROOT, pin).read_file(
+            CHECK_WORKFLOW_ENABLED_ACTION_PATH,
+        ),
+        Loader=yaml.BaseLoader,
+    )
+    script = action["runs"]["steps"][0]["run"]
+    script = script.replace("${{ inputs.workflow-name }}", "claude")
+    script = script.replace("${{ inputs.force-run }}", "false")
+
+    consumer = tmp_path / "consumer"
+    (consumer / ".github").mkdir(parents=True)
+    (consumer / ".github/workflow-config.yml").write_text(
+        "workflows:\n"
+        "  claude:\n"
+        "    description: consumer kill switch\n"
+        "    enabled: false\n",
+    )
+    command_path = tmp_path / "bin"
+    command_path.mkdir()
+    for name in ("grep", "sed", "tr"):
+        os.symlink(shutil.which(name), command_path / name)
+    output = tmp_path / "github-output"
+    result = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script],
+        cwd=consumer,
+        env={
+            "PATH": str(command_path),
+            "GITHUB_OUTPUT": str(output),
+            "LANG": "C",
+            "LC_ALL": "C",
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    enabled = [
+        line for line in output.read_text().splitlines() if line.startswith("enabled=")
+    ]
+    assert enabled == ["enabled=false"]
+
+
 def test_v1781_rejects_immutable_v178_security_boundary():
     with pytest.raises(
         ReleaseVerificationError,
@@ -261,7 +317,7 @@ def restore_mutable_claude_check_action(path: Path) -> None:
     text = path.read_text()
     text = text.replace(
         "jhw7500/automation/.github/actions/check-workflow-enabled@"
-        "fec2c90743cca062f113a87bb5deaf73b61501ce",
+        "a08141d644ab1036cadd8167d48158e827dcd978",
         "jhw7500/automation/.github/actions/check-workflow-enabled@v1.1",
         1,
     )

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -50,6 +50,7 @@ REVIEW_INVOCATION_BUDGET_HELPER = (
 
 V176_COMMIT = "444a7347aee169ed178aae80e8bd8d10eca52e02"
 V177_COMMIT = "dd13f9dcc64540494c1c04bc3f9c7a4f2ef0ba19"
+V178_COMMIT = "a08141d644ab1036cadd8167d48158e827dcd978"
 FALLBACK_RELEASE_FILES = (
     ".github/actions/claude-rollout-fallback/action.yml",
     ".github/actions/claude-rollout-fallback/contract.py",
@@ -72,26 +73,27 @@ def test_v178_adds_only_claude_rollout_fallback_roots():
     assert release_inventory.release_supports_claude_rollout_fallback("v1.78.1")
 
 
-def test_v1781_publication_proves_owned_boundary_before_post():
+def test_v178_patch_publication_proves_owned_boundary_before_post():
     document = (ROOT / "docs/workflow-fleet-rollout.md").read_text()
-    section = document.split("## Create-only v1.78 and v1.78.1 tag publication\n", 1)[1]
+    section = document.split("## Create-only v1.78.1 and v1.78.2 tag publication\n", 1)[1]
     body = section.split("' <<'CLAUDE_RELEASE_PY'\n", 1)[1].split("\nCLAUDE_RELEASE_PY", 1)[0]
     tree = ast.parse(body)
     first_post = min(node.lineno for node in ast.walk(tree)
                      if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
                      and node.func.id == "post")
     branches = [node for node in tree.body if isinstance(node, ast.If)
-                and ast.unparse(node.test) == "tag == 'v1.78.1'"]
-    assert len(branches) == 1, "v1.78.1 needs a pre-publication boundary proof"
+                and ast.unparse(node.test) == "tag == 'v1.78.2'"
+                and node.end_lineno < first_post]
+    assert len(branches) == 1, "v1.78.2 needs a pre-publication boundary proof"
     branch = branches[0]
     assert branch.end_lineno < first_post
-    assert not branch.orelse, "v1.78 first publication must not need an existing v1.78 tag"
+    assert not branch.orelse, "v1.78.1 security patch must not need an existing v1.78.1 tag"
     launcher = section.split("rtk proxy /usr/bin/python3 -I -S -B -c '\n", 1)[1].split("\n' <<", 1)[0]
     launcher_tree = ast.parse(launcher)
     allowed = [node for node in ast.walk(launcher_tree) if isinstance(node, ast.Compare)
                and isinstance(node.left, ast.Name) and node.left.id == "tag"]
     assert len(allowed) == 1
-    assert ast.literal_eval(allowed[0].comparators[0]) == {"v1.78", "v1.78.1"}
+    assert ast.literal_eval(allowed[0].comparators[0]) == {"v1.78.1", "v1.78.2"}
     pre_post = ast.unparse(ast.Module(
         body=[node for node in tree.body if node.end_lineno < first_post], type_ignores=[],
     ))
@@ -100,9 +102,13 @@ def test_v1781_publication_proves_owned_boundary_before_post():
         "v177_commit = 'dd13f9dcc64540494c1c04bc3f9c7a4f2ef0ba19'",
         "v176_tag = '09af80682619129fcf343091b78413d2686a4579'",
         "v176_commit = '444a7347aee169ed178aae80e8bd8d10eca52e02'",
+        "v178_tag = '7efe562b49c7b5f9fdad6855ff8c2a73b090a122'",
+        "v178_commit = 'a08141d644ab1036cadd8167d48158e827dcd978'",
     ):
         assert binding in pre_post
-    for version, variable in (("v1.76", "v176"), ("v1.77", "v177")):
+    for version, variable in (
+        ("v1.76", "v176"), ("v1.77", "v177"), ("v1.78", "v178"),
+    ):
         check = f"set(public_tags('{version}').splitlines()) == tag_pairs('{version}', {variable}_tag, {variable}_commit)"
         checks_before_post = [node for node in tree.body
                              if isinstance(node, ast.Expr) and check in ast.unparse(node)
@@ -114,28 +120,29 @@ def test_v1781_publication_proves_owned_boundary_before_post():
     assert len(annotation) == 1 and annotation[0].end_lineno < branch.lineno
     assert ast.literal_eval(annotation[0].iter.elts[0].elts[0]) == "v1.76"
     assert ast.literal_eval(annotation[0].iter.elts[1].elts[0]) == "v1.77"
+    assert ast.literal_eval(annotation[0].iter.elts[2].elts[0]) == "v1.78"
     assert "git('cat-file', '-t', direct, cwd=checkout) == 'tag'" in ast.unparse(annotation[0])
     source = ast.unparse(branch)
     # Ordered checks bind the remote annotation and trusted inventory before any write.
     checks = [
-        "pairs = [line.split('\\t') for line in public_tags('v1.78').splitlines()]",
+        "pairs = [line.split('\\t') for line in public_tags('v1.78.1').splitlines()]",
         "len(pairs) == 2 and all((len(pair) == 2 for pair in pairs))",
-        "set(refs) == {'refs/tags/v1.78', 'refs/tags/v1.78^{}'}",
+        "set(refs) == {'refs/tags/v1.78.1', 'refs/tags/v1.78.1^{}'}",
         "all((re.fullmatch('[0-9a-f]{40}', oid) for oid in refs.values()))",
-        "v178_tag = refs['refs/tags/v1.78']",
-        "v178_commit = refs['refs/tags/v1.78^{}']",
-        "require(commit != v178_commit,",
-        "git('fetch', '--no-tags', url, 'refs/tags/v1.78:refs/tags/v1.78', cwd=checkout)",
-        "git('rev-parse', 'refs/tags/v1.78', cwd=checkout) == v178_tag",
-        "git('rev-parse', 'refs/tags/v1.78^{}', cwd=checkout) == v178_commit",
-        "git('cat-file', '-t', v178_tag, cwd=checkout) == 'tag'",
-        "git('worktree', 'add', '--detach', str(baseline), v178_commit, cwd=checkout)",
-        "'scripts.verify_workflow_release', '--automation', str(baseline), '--ref', 'v1.78', '--expected-commit', v178_commit, '--remote', 'origin'",
+        "v1781_tag = refs['refs/tags/v1.78.1']",
+        "v1781_commit = refs['refs/tags/v1.78.1^{}']",
+        "require(commit != v1781_commit,",
+        "git('fetch', '--no-tags', url, 'refs/tags/v1.78.1:refs/tags/v1.78.1', cwd=checkout)",
+        "git('rev-parse', 'refs/tags/v1.78.1', cwd=checkout) == v1781_tag",
+        "git('rev-parse', 'refs/tags/v1.78.1^{}', cwd=checkout) == v1781_commit",
+        "git('cat-file', '-t', v1781_tag, cwd=checkout) == 'tag'",
+        "git('worktree', 'add', '--detach', str(baseline), v1781_commit, cwd=checkout)",
+        "'scripts.verify_workflow_release', '--automation', str(baseline), '--ref', 'v1.78.1', '--expected-commit', v1781_commit, '--remote', 'origin'",
         "from scripts.workflow_release_inventory import release_paths_for",
-        'release_paths_for("v1.78")',
+        'release_paths_for("v1.78.1")',
         "owned = json.loads(inventory.stdout)",
-        "git('diff', '--raw', '--no-ext-diff', '--no-textconv', '--exit-code', v178_commit, commit, '--', *owned, cwd=checkout) == ''",
-        "set(public_tags('v1.78').splitlines()) == tag_pairs('v1.78', v178_tag, v178_commit)",
+        "git('diff', '--raw', '--no-ext-diff', '--no-textconv', '--exit-code', v1781_commit, commit, '--', *owned, cwd=checkout) == ''",
+        "set(public_tags('v1.78.1').splitlines()) == tag_pairs('v1.78.1', v1781_tag, v1781_commit)",
     ]
     offset = 0
     for check in checks:
@@ -187,10 +194,23 @@ def fallback_release_repo(tmp_path):
     return repo, commit(repo, "v1.78 fallback candidate")
 
 
-def test_v178_candidate_is_accepted(fallback_release_repo):
+def test_v178_immutable_candidate_remains_accepted():
+    assert release_verifier.verify_commit_content(ROOT, "v1.78", V178_COMMIT) == V178_COMMIT
+
+
+def test_v1781_rejects_immutable_v178_security_boundary():
+    with pytest.raises(
+        ReleaseVerificationError,
+        match="Claude fallback pre-admission permission contract differs",
+    ):
+        release_verifier.verify_commit_content(ROOT, "v1.78.1", V178_COMMIT)
+
+
+@pytest.mark.parametrize("ref", ("v1.78.1", "v1.78.2"))
+def test_hardened_claude_fallback_candidate_is_accepted(fallback_release_repo, ref):
     repo, candidate = fallback_release_repo
-    release_verifier.verify_claude_rollout_fallback_contract(repo)
-    assert release_verifier.verify_commit_content(repo, "v1.78", candidate) == candidate
+    release_verifier.verify_claude_rollout_fallback_contract(repo, ref)
+    assert release_verifier.verify_commit_content(repo, ref, candidate) == candidate
 
 
 FALLBACK_MUTATIONS = {
@@ -222,10 +242,60 @@ FALLBACK_MUTATIONS = {
 }
 
 
-@pytest.mark.parametrize("mutation", list(FALLBACK_MUTATIONS))
-def test_v178_rejects_fallback_contract_mutation(fallback_release_repo, mutation):
+def inherit_claude_pre_admission_permissions(path: Path) -> None:
+    text = path.read_text()
+    text = text.replace(
+        "  check-enabled:\n    permissions:\n      contents: read\n",
+        "  check-enabled:\n",
+        1,
+    )
+    text = text.replace(
+        "  skipped:\n    permissions: {}\n",
+        "  skipped:\n",
+        1,
+    )
+    path.write_text(text)
+
+
+def restore_mutable_claude_check_action(path: Path) -> None:
+    text = path.read_text()
+    text = text.replace(
+        "jhw7500/automation/.github/actions/check-workflow-enabled@"
+        "fec2c90743cca062f113a87bb5deaf73b61501ce",
+        "jhw7500/automation/.github/actions/check-workflow-enabled@v1.1",
+        1,
+    )
+    path.write_text(text)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "error"),
+    [
+        (
+            inherit_claude_pre_admission_permissions,
+            "Claude fallback pre-admission permission contract differs",
+        ),
+        (
+            restore_mutable_claude_check_action,
+            "Claude fallback check-workflow-enabled action is not immutable",
+        ),
+    ],
+    ids=("ambient-permissions", "mutable-check-action"),
+)
+def test_v1781_rejects_claude_router_pre_admission_regressions(
+    fallback_release_repo, mutate, error,
+):
     repo, _ = fallback_release_repo
-    # Establish acceptance first: a legacy seal must not mask a missing v1.78 seal.
+    release_verifier.verify_claude_rollout_fallback_contract(repo, "v1.78.1")
+    mutate(repo / ".github/workflows/claude.yml")
+    with pytest.raises(ReleaseVerificationError, match=error):
+        release_verifier.verify_claude_rollout_fallback_contract(repo, "v1.78.1")
+
+
+@pytest.mark.parametrize("mutation", list(FALLBACK_MUTATIONS))
+def test_v1781_rejects_fallback_contract_mutation(fallback_release_repo, mutation):
+    repo, _ = fallback_release_repo
+    # Establish acceptance first: an older seal must not mask a missing current seal.
     release_verifier.verify_claude_rollout_fallback_contract(repo)
     relative, old, new = FALLBACK_MUTATIONS[mutation]
     replace(repo / relative, old, new, count=1)
@@ -233,7 +303,7 @@ def test_v178_rejects_fallback_contract_mutation(fallback_release_repo, mutation
     with pytest.raises(ReleaseVerificationError):
         release_verifier.verify_claude_rollout_fallback_contract(repo)
     with pytest.raises(ReleaseVerificationError):
-        release_verifier.verify_commit_content(repo, "v1.78", bad)
+        release_verifier.verify_commit_content(repo, "v1.78.1", bad)
 
 RECOVERY_RELEASE_FILES = (
     ".github/actions/recover-opencode-review/evidence.py",


### PR DESCRIPTION
The unconditional Claude `check-enabled` job inherited the caller's pull-request write and OIDC ceiling before admission, and its nested enablement action was pinned to an older parser that rejected a valid reordered disabled block. This change limits pre-admission jobs to read-only or empty permissions, pins the parser to the immutable v1.78 commit, and verifies that `description` before `enabled: false` cleanly skips provider work.

The release contract preserves immutable v1.78 compatibility, requires the hardening for v1.78.1 and later, and moves the byte-identical follow-up canary boundary to v1.78.2. Publication documentation keeps all ownership and historical-tag checks before the first remote write.

Validation:

- Pre-PR adversarial tribunal: PASS on `c46bbff24c736045372e4f299e0af54460d7e3c4`, 0 HIGH/CRITICAL findings
- Release verifier suite: 694 passed
- Fresh focused hardening tests: 24 passed
- Action-pin/canonical workflow tests: 25 passed, 2 subtests
- Digest-verified actionlint 1.7.12 and `git diff --check`: passed
- Commit-only release verification for v1.78.1: passed

Part of #182
