### PR TITLE
fix(review): harden Claude pre-admission for v1.78.2

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -68,6 +68,10 @@ on:
 
 jobs:
   check-enabled:
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     name: Check if enabled
     runs-on: ubuntu-latest
     outputs:
@@ -84,7 +88,7 @@ jobs:
 
       - name: Check workflow config
         id: check
-        uses: jhw7500/automation/.github/actions/check-workflow-enabled@v1.1
+        uses: jhw7500/automation/.github/actions/check-workflow-enabled@a08141d644ab1036cadd8167d48158e827dcd978
         with:
           workflow-name: claude-code-review
           force-run: ${{ inputs.force_run && 'true' || 'false' }}
@@ -1583,6 +1587,7 @@ jobs:
 
 
   skipped:
+    permissions: {}
     name: Workflow Skipped
     needs: check-enabled
     if: needs.check-enabled.outputs.enabled != 'true' || needs.check-enabled.outputs.policy_run != 'true'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -70,7 +70,6 @@ jobs:
   check-enabled:
     permissions:
       contents: read
-      issues: read
       pull-requests: read
     name: Check if enabled
     runs-on: ubuntu-latest

--- a/docs/superpowers/plans/2026-09-11-claude-caller-rollout-fallback.md
+++ b/docs/superpowers/plans/2026-09-11-claude-caller-rollout-fallback.md
@@ -1658,7 +1658,7 @@ verifier, which protected the command router but not the automatic review gate.
 | Consumer updates | wlan-package #331 and the local tossApp candidate target v1.78.1 | Hold merge; repin both to the reviewed v1.78.2 release and rerun their exact-HEAD reviews |
 
 - [ ] **Step I: Complete the v1.78.2 automatic-review hardening test-first.** Give
-  `check-enabled` only contents/issues/pull-requests read, give `skipped` an empty
+  `check-enabled` only contents/pull-requests read, give `skipped` an empty
   permission map, and pin the config check to the immutable v1.78 commit. Add
   mutation tests proving the release verifier rejects inherited authority and a
   movable action reference while retaining exact v1.78.1 acceptance.

--- a/docs/superpowers/plans/2026-09-11-claude-caller-rollout-fallback.md
+++ b/docs/superpowers/plans/2026-09-11-claude-caller-rollout-fallback.md
@@ -1641,7 +1641,44 @@ Close the telemetry run on every exit. A PASS records bound HEAD/diff. CRITICAL/
 
 ### Task 8: Immutable release, real-boundary canary, and bootstrap batch
 
-#### Current execution amendment (2026-09-12)
+#### Automatic-review security amendment (2026-09-12)
+
+This amendment supersedes the v1.78.2 docs-only and real-boundary-canary steps in
+the earlier amendment below. Its v1.78.1 evidence and completed validation remain
+historical inputs. A consumer tribunal found that the automatic
+`claude-code-review.yml` still let `check-enabled` and `skipped` inherit the
+caller's pull-request write and OIDC ceiling, and its config check still used the
+mutable `check-workflow-enabled@v1.1` tag. The same omission existed in the release
+verifier, which protected the command router but not the automatic review gate.
+
+| Boundary | Current evidence | Required next state |
+| --- | --- | --- |
+| v1.78.1 | Published immutable router-hardening release | Preserve exact tag and historical verifier acceptance |
+| v1.78.2 | Unpublished | Automatic-review security patch with exact release-owned changes limited to the central Claude review workflow and verifier |
+| Consumer updates | wlan-package #331 and the local tossApp candidate target v1.78.1 | Hold merge; repin both to the reviewed v1.78.2 release and rerun their exact-HEAD reviews |
+
+- [ ] **Step I: Complete the v1.78.2 automatic-review hardening test-first.** Give
+  `check-enabled` only contents/issues/pull-requests read, give `skipped` an empty
+  permission map, and pin the config check to the immutable v1.78 commit. Add
+  mutation tests proving the release verifier rejects inherited authority and a
+  movable action reference while retaining exact v1.78.1 acceptance.
+- [ ] **Step J: Review and merge the central security patch.** Run focused and
+  full verification, actionlint, Python compilation and `git diff --check`, then
+  complete the three-role tribunal and hosted reviews on one exact HEAD. Obtain
+  the separate exact-tuple merge approval required by this plan.
+- [ ] **Step K: Publish v1.78.2 only after separate tag approval.** Use the
+  create-only procedure, authenticate the v1.78.1 direct and peeled identities,
+  and require the release-owned diff to contain exactly the central Claude review
+  workflow and its verifier. Never move, delete, or blindly retry a tag write.
+- [ ] **Step L: Repin and rereview both consumer candidates.** Update only the
+  managed config and active caller paths to v1.78.2, preserve prior evidence, and
+  rerun local and hosted exact-HEAD checks. Merge each repository only after its
+  separate reviewed tuple is approved.
+- [ ] **Step M: Defer the real managed-boundary canary.** After a default branch
+  installs v1.78.2, select a later distinct release and add a separately reviewed
+  create-only publication procedure and receipt-bound canary plan.
+
+#### Prior execution amendment (2026-09-12; superseded where conflicting)
 
 This amendment supersedes the original numbered Task 8 procedure below. The old
 sequence is retained only as historical design provenance and must not be used for

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -817,8 +817,9 @@ if tag == "v1.78.2":
         ".github/workflows/claude-code-review.yml",
         "scripts/verify_workflow_release.py",
     }
+    diff_scope = sorted(set(owned) | expected_owned_changes)
     changed = git("diff", "--name-only", "--no-ext-diff", "--no-textconv",
-                  v1781_commit, commit, "--", *owned, cwd=checkout).splitlines()
+                  v1781_commit, commit, "--", *diff_scope, cwd=checkout).splitlines()
     require(len(changed) == len(expected_owned_changes)
             and set(changed) == expected_owned_changes,
             "v1.78.2 release-owned patch scope differs")

--- a/docs/workflow-fleet-rollout.md
+++ b/docs/workflow-fleet-rollout.md
@@ -652,20 +652,21 @@ response OIDs, then verifies the local and public direct/peeled identities.
 Both paths authenticate the existing annotated v1.78 tag object
 `7efe562b49c7b5f9fdad6855ff8c2a73b090a122` and peeled commit
 `a08141d644ab1036cadd8167d48158e827dcd978`. v1.78.1 is the reviewed security
-patch that narrows pre-admission Claude permissions and pins the nested
-check-workflow-enabled action to an immutable commit. For v1.78.2, before either
-POST the procedure also authenticates the existing annotated v1.78.1 tag and
-peeled commit, requires a distinct reviewed candidate, and compares every
-v1.78.1 inventory-owned path, mode and blob. The inventory is loaded from the
-authenticated v1.78.1 checkout, so the candidate cannot reduce the comparison.
-Any release-owned difference invalidates the v1.78.2 boundary canary and requires
-a normal reviewed patch design. First publication of v1.78.1 has no
-prior-v1.78.1 check. Both paths also authenticate immutable v1.77 tag object
+patch that narrows the managed command router's pre-admission permissions and
+pins its nested check-workflow-enabled action to an immutable commit. v1.78.2
+extends that boundary to the automatic Claude review workflow. Before either
+POST, its procedure authenticates the existing annotated v1.78.1 tag and peeled
+commit, requires a distinct reviewed candidate, and loads the complete release
+inventory from the authenticated v1.78.1 checkout. Exactly the central Claude
+review workflow and its release verifier may differ; every other inventory-owned
+path must remain unchanged, and the candidate verifier still authenticates all
+release paths and modes. First publication of v1.78.1 has no prior-v1.78.1 check.
+Both paths also authenticate immutable v1.77 tag object
 `81f44fb6786bdfcc40f93161db74b1d9a9e3b7c5`, peeled commit
 `dd13f9dcc64540494c1c04bc3f9c7a4f2ef0ba19`, and the unchanged v1.76 identity
 before any publication write. v1.77 is #183's observational-token release;
-#182's fallback begins in v1.78, is hardened in v1.78.1, and uses v1.78.2 for
-the distinct real-boundary canary.
+#182's fallback begins in v1.78, its router is hardened in v1.78.1, and its
+automatic review pre-admission path is hardened in v1.78.2.
 
 ```bash
 rtk proxy /usr/bin/python3 -I -S -B -c '
@@ -812,9 +813,15 @@ if tag == "v1.78.2":
     owned = json.loads(inventory.stdout)
     require(isinstance(owned, list) and owned and all(isinstance(path, str) for path in owned),
             "invalid authenticated v1.78.1 inventory")
-    require(git("diff", "--raw", "--no-ext-diff", "--no-textconv", "--exit-code",
-                v1781_commit, commit, "--", *owned, cwd=checkout) == "",
-            "release-owned difference invalidates boundary canary; normal reviewed patch design required")
+    expected_owned_changes = {
+        ".github/workflows/claude-code-review.yml",
+        "scripts/verify_workflow_release.py",
+    }
+    changed = git("diff", "--name-only", "--no-ext-diff", "--no-textconv",
+                  v1781_commit, commit, "--", *owned, cwd=checkout).splitlines()
+    require(len(changed) == len(expected_owned_changes)
+            and set(changed) == expected_owned_changes,
+            "v1.78.2 release-owned patch scope differs")
     require(set(public_tags("v1.78.1").splitlines()) == tag_pairs("v1.78.1", v1781_tag, v1781_commit),
             "v1.78.1 identity moved before write")
 require(set(public_tags("v1.76").splitlines()) == tag_pairs("v1.76", v176_tag, v176_commit),
@@ -887,7 +894,7 @@ A failed or uncertain POST stops the procedure. Preserve both raw response files
 that exist and reconcile with read-only API/public Git reads. An orphan annotated
 object is harmless; a concurrent ref creation must never be repaired by moving
 or deleting the tag. Repeat this procedure for v1.78.2 only after its separate
-reviewed main change and publication authorization.
+reviewed security change and publication authorization.
 
 ## v1.76 bootstrap evidence
 
@@ -917,37 +924,20 @@ driver. A v1.78.1 adoption PR alone is not the real boundary canary: until merge
 the default branch still runs the older caller. Request/admission/ledger/comment
 and receipt schemas are defined in [the consumer contract](workflows/contracts.md).
 
-## v1.78.2 real-boundary canary
+## v1.78.2 automatic-review hardening adoption
 
-Publish a separately reviewed v1.78.2 commit after v1.78.1 caller adoption. It must
-be distinct from the authenticated v1.78.1 peeled commit while preserving every
-v1.78.1 release-owned byte, path and mode. Before publication, the procedure above
-must prove an empty raw Git diff across the authenticated v1.78.1 inventory. Any
-difference invalidates this boundary canary and requires a normal reviewed patch
-design. Create one
-approved managed rollout PR from the v1.78.1 default to v1.78.2; record exact HEAD,
-base and managed diff hash. Require the original automatic attempt to fail at
-caller validation, with budget claim and provider skipped and the matching
-canonical automatic failure. Post one separately authorized canonical managed
-request after that failure. Its target release is v1.78.2; its default caller and
-verification checkout remain the exact v1.78.1 driver commit. Wait for the managed
-run and charged invocation to finalize. Do not retry an uncertain request.
+Publish v1.78.2 only from the separately reviewed security patch described above.
+Update bootstrap consumers directly to its immutable peeled commit, preserving
+the expanded v1.78.1 review budgets. A caller-changing PR can still produce the
+expected workflow-validation mismatch while its default branch runs an older
+caller; preserve that result as bootstrap evidence and require the repository's
+other review gates before a separately authorized merge.
 
-From a clean automation checkout at that driver commit, in an independently
-mode-0700 evidence directory, run the read-only verifier using recorded values:
-
-```bash
-rtk proxy /usr/bin/python3 -I -S -B "$AUTOMATION_ROOT/scripts/verify_claude_rollout_fallback.py" \
-  --automation-root "$AUTOMATION_ROOT" --release-ref v1.78.2 --remote origin \
-  --repository "$CONSUMER_REPOSITORY" --pr "$PR_NUMBER" \
-  --expected-head "$EXPECTED_HEAD_SHA" --expected-base "$EXPECTED_BASE_SHA" \
-  --output "$PRIVATE_EVIDENCE_DIRECTORY/claude-fallback-receipt.json"
-```
-
-The output must be absent before invocation. Require an owned regular mode-0600
-receipt, `effective_status: CLEAN`, the distinct driver/target commits and the
-recorded request/run/comment/budget coordinates. A receipt permits evaluation of
-the named rollout tuple; it does not itself authorize merging.
+After a consumer default branch installs v1.78.2, use a later distinct reviewed
+release for the real managed-boundary canary. That release must have its own
+create-only publication procedure, exact driver and target commits, and the same
+request, invocation, finalized-budget, canonical-result and mode-0600 receipt
+proofs. Do not reuse the former docs-only v1.78.2 assumption.
 
 ## Required-check stop conditions
 

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -159,7 +159,7 @@ permission map. The release verifier preserves exact v1.78 acceptance and requir
 these constraints for v1.78.1 and later.
 
 Release v1.78.2 applies the same boundary to the automatic Claude review workflow.
-Its `check-enabled` job has only `contents`, `issues`, and `pull-requests` read,
+Its `check-enabled` job has only `contents` and `pull-requests` read,
 uses the same immutable check-workflow-enabled commit, and therefore cannot inherit
 the caller's pull-request write or OIDC grants. Its `skipped` job has an empty
 permission map. The release verifier preserves the exact v1.78.1 workflow seal

--- a/docs/workflows/contracts.md
+++ b/docs/workflows/contracts.md
@@ -150,13 +150,20 @@ only actions/contents/issues/pull-requests read. The nested managed job uses exa
 `$/.github/workflows/claude-code-review.yml`, the consumer write ceiling above,
 and the same-name `CLAUDE_CODE_OAUTH_TOKEN` secret.
 
-Release v1.78.1 hardens the jobs that run before managed admission. `check-enabled`
-has only `contents: read`, calls
+Release v1.78.1 hardens the jobs that run before managed admission in the command
+router. `check-enabled` has only `contents: read`, calls
 `check-workflow-enabled@a08141d644ab1036cadd8167d48158e827dcd978`, whose no-`yq`
 fallback accepts `enabled` after descriptive fields, and cannot
 inherit the caller's pull-request write or OIDC grants. `skipped` has an empty
 permission map. The release verifier preserves exact v1.78 acceptance and requires
 these constraints for v1.78.1 and later.
+
+Release v1.78.2 applies the same boundary to the automatic Claude review workflow.
+Its `check-enabled` job has only `contents`, `issues`, and `pull-requests` read,
+uses the same immutable check-workflow-enabled commit, and therefore cannot inherit
+the caller's pull-request write or OIDC grants. Its `skipped` job has an empty
+permission map. The release verifier preserves the exact v1.78.1 workflow seal
+and requires the automatic-review constraints for v1.78.2 and later.
 
 ## Admission schema 1
 

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -6247,8 +6247,15 @@ def _verify_review_invocation_budget(
             payload = tree.read_file(relative)
             parsed = (ast.parse(payload) if relative.endswith(".py") else
                       _load_release_yaml(payload, reject_duplicate_keys=True))
-            _fallback_parsed_seal(relative, parsed)
-            if hashlib.sha256(payload).hexdigest() != EXPECTED_CLAUDE_FALLBACK_SHA256[relative]:
+            _fallback_parsed_seal(relative, parsed, ref)
+            expected = EXPECTED_CLAUDE_FALLBACK_SHA256[relative]
+            if (
+                relative == ".github/workflows/claude-code-review.yml"
+                and _release_version(ref)
+                    < CLAUDE_REVIEW_PREADMISSION_HARDENING_RELEASE
+            ):
+                expected = V1781_CLAUDE_REVIEW_SHA256
+            if hashlib.sha256(payload).hexdigest() != expected:
                 raise ReleaseVerificationError("invocation-budget authenticated source digest differs")
         require_budget_workflow_contract(tree, "gemini-auto-review.yml", "gemini", review_policy=True)
         if hashlib.sha256(tree.read_file(".github/workflows/gemini-auto-review.yml")).hexdigest() != EXPECTED_OPENCODE_RECOVERY_WORKFLOW_SHA256["gemini"]:
@@ -6870,7 +6877,7 @@ def _verify_review_publication_contracts(
             if release_supports_claude_rollout_fallback(ref) and name == "claude-code-review.yml":
                 # The schema-3 failure/fallback variants have an exact v1.78
                 # parsed seal, including the complete collector and publisher.
-                require_claude_fallback_inputs(documents[name])
+                require_claude_fallback_inputs(documents[name], ref)
                 continue
             contract = {
                 key: value
@@ -7600,9 +7607,10 @@ def _verify_opencode_recovery(tree: VerifiedCommitTree, ref: str) -> None:
 
 
 # Reviewed fallback inputs, never calculated from the candidate at verification time.
-# The current seals require the v1.78.1 pre-admission hardening; separate historical
-# router seals preserve exact immutable v1.78 acceptance. Parsed seals retain all
-# existing policy statements, and raw seals additionally authenticate exact bytes.
+# The current seals require the v1.78.2 review pre-admission hardening. Separate
+# historical router and review seals preserve exact immutable releases. Parsed
+# seals retain all existing policy statements, and raw seals additionally
+# authenticate exact bytes.
 EXPECTED_CLAUDE_FALLBACK_SHA256 = {
     ".github/actions/claude-rollout-fallback/action.yml": "ee4b8e6b88ebfc1d0691e032da93b03ba8268fac1bd9377a26554d8200621c0a",
     ".github/actions/claude-rollout-fallback/contract.py": "ae39e0f9c0a1faa6831559c93150fca7f768fbaa0257aade70f045abd0eafff6",
@@ -7610,7 +7618,7 @@ EXPECTED_CLAUDE_FALLBACK_SHA256 = {
     ".github/actions/review-invocation-budget/action.yml": "c05acbba8cac7e952867706a181eccaa25bc4f7baf720c5562dcbb71d1a04c90",
     ".github/actions/review-invocation-budget/review_invocation_budget.py": "3f1f140b1b95fcc24618851e3f196efca6fe7bb259e244d86a4e972b5c681851",
     ".github/workflows/claude.yml": "914229686af627e5404bb730e376b18a9db7c4bbb4a707e385a0a6ce3473c82a",
-    ".github/workflows/claude-code-review.yml": "e9ab0aafc14b21e5eb6780ad80b1ca3c3766e5f8f0cc5b60700cfe88eb18ab81",
+    ".github/workflows/claude-code-review.yml": "ce36edc1072a0ce9a77899641b1b6df1c3f4cdcbd50d044995101a4e7494ae29",
     ".github/workflows/opencode-auto-review.yml": "ca6cbf2b1f1c9c57f524c45d4de0c863ac2bb249d0e261bbcf1da7e2017c5ea1",
     ".github/actions/recover-opencode-review/evidence.py": "1eacc5e56ad5554324eeb0ce7a9d6872d1c8e22ca95828ce34758ccc2be0fee1",
     ".github/actions/recover-opencode-review/replay.js": "1587bc1c858708d30edf1da3559cc37486d6eaa6e8fbe7d57ab6debf24e6f503",
@@ -7623,16 +7631,23 @@ EXPECTED_CLAUDE_FALLBACK_PARSED_SHA256 = {
     ".github/actions/review-invocation-budget/action.yml": "4a346ba8d26ea88efe5cc0dfa9f33f080ac8167cf777156d4eef635f1293b8ed",
     ".github/actions/review-invocation-budget/review_invocation_budget.py": "05dd0f27335431fea106d9c84debfa60b39696324eb6474c3b0f58db31695dde",
     ".github/workflows/claude.yml": "b388e789f7ebc6f720b634abe64e6edc41d3072cf7bca703978186d0f6d262c2",
-    ".github/workflows/claude-code-review.yml": "130a3ee4164a2561ce6554e1fd6ddac25de11c734e7ec9504c8980841339407f",
+    ".github/workflows/claude-code-review.yml": "fdb9f09ef8c283034afbc3b8ecf3bcb60b7d73e00558ba45116531ca547f5bb3",
     ".github/workflows/opencode-auto-review.yml": "da90fcad95d03f2b51120447edcf187eeb5fbdaa050ded885bb9c9907f3d7f9e",
     ".github/actions/recover-opencode-review/evidence.py": "4e27f7f7f11b3726c67f9e459554de1fc9d00586b37f18d67b7aaf67c5ff0d5b",
 }
 CLAUDE_FALLBACK_HARDENING_RELEASE = (1, 78, 1)
+CLAUDE_REVIEW_PREADMISSION_HARDENING_RELEASE = (1, 78, 2)
 V178_CLAUDE_ROUTER_SHA256 = (
     "bb111fd319a6449f8f56cbe22a20572b662525f9f4a7765bc46a415bba5f5881"
 )
 V178_CLAUDE_ROUTER_PARSED_SHA256 = (
     "5781ef1db5e22f83ed07fc83fabe0beb615544a1412e01b2b8dabfd5f06593ab"
+)
+V1781_CLAUDE_REVIEW_SHA256 = (
+    "e9ab0aafc14b21e5eb6780ad80b1ca3c3766e5f8f0cc5b60700cfe88eb18ab81"
+)
+V1781_CLAUDE_REVIEW_PARSED_SHA256 = (
+    "130a3ee4164a2561ce6554e1fd6ddac25de11c734e7ec9504c8980841339407f"
 )
 FALLBACK_ACTION = "$/.github/actions/claude-rollout-fallback"
 FALLBACK_INPUT_OUTPUTS = {
@@ -7673,6 +7688,11 @@ def _fallback_parsed_seal(relative: str, value: object, ref: str = "v1.78.1") ->
         and _release_version(ref) < CLAUDE_FALLBACK_HARDENING_RELEASE
     ):
         expected = V178_CLAUDE_ROUTER_PARSED_SHA256
+    elif (
+        relative == ".github/workflows/claude-code-review.yml"
+        and _release_version(ref) < CLAUDE_REVIEW_PREADMISSION_HARDENING_RELEASE
+    ):
+        expected = V1781_CLAUDE_REVIEW_PARSED_SHA256
     if hashlib.sha256(payload.encode()).hexdigest() != expected:
         raise ReleaseVerificationError("Claude fallback parsed contract differs: " + relative)
 
@@ -7711,6 +7731,32 @@ def require_claude_fallback_permissions(
         raise ReleaseVerificationError(
             "Claude fallback pre-admission permission contract differs"
         ) from None
+    if _release_version(ref) < CLAUDE_REVIEW_PREADMISSION_HARDENING_RELEASE:
+        return
+    try:
+        jobs = review["jobs"]
+        if (
+            jobs["check-enabled"].get("permissions") != {
+                "contents": "read",
+                "issues": "read",
+                "pull-requests": "read",
+            }
+            or jobs["skipped"].get("permissions") != {}
+        ):
+            raise ValueError("pre-admission permissions differ")
+    except (AttributeError, KeyError, TypeError, ValueError):
+        raise ReleaseVerificationError(
+            "Claude review pre-admission permission contract differs"
+        ) from None
+    check_actions = [
+        step.get("uses")
+        for step in jobs["check-enabled"]["steps"]
+        if step.get("id") == "check"
+    ]
+    if check_actions != [CHECK_WORKFLOW_ENABLED_ACTION]:
+        raise ReleaseVerificationError(
+            "Claude review check-workflow-enabled action is not immutable"
+        )
 
 
 def require_claude_fallback_routes(router: object, ref: str) -> None:
@@ -7752,7 +7798,7 @@ def require_claude_fallback_routes(router: object, ref: str) -> None:
         raise ReleaseVerificationError("Claude fallback route contract differs") from None
 
 
-def require_claude_fallback_inputs(review: object) -> None:
+def require_claude_fallback_inputs(review: object, ref: str = "v1.78.1") -> None:
     try:
         inputs = review["on"]["workflow_call"]["inputs"]
         if {key: value for key, value in inputs.items() if key.startswith("fallback_")} != {
@@ -7776,7 +7822,7 @@ def require_claude_fallback_inputs(review: object) -> None:
             "route.route === 'default_branch_rollout_fallback'",
             "if (!failed && fallbackMode) state.route = fallbackRoute;",
             "publicationPr.base?.sha !== fallbackRoute.reviewed_base_sha")
-        _fallback_parsed_seal(".github/workflows/claude-code-review.yml", review)
+        _fallback_parsed_seal(".github/workflows/claude-code-review.yml", review, ref)
     except (AttributeError, KeyError, TypeError, ValueError):
         raise ReleaseVerificationError("Claude fallback input/publication contract differs") from None
 
@@ -7881,7 +7927,7 @@ def verify_claude_rollout_fallback_contract(
         review = load(".github/workflows/claude-code-review.yml")
         require_claude_fallback_permissions(caller, router, review, ref)
         require_claude_fallback_routes(router, ref)
-        require_claude_fallback_inputs(review)
+        require_claude_fallback_inputs(review, ref)
         require_budget_schema_two(root)
         require_request_and_receipt_contracts(root)
         for relative in (".github/actions/claude-rollout-fallback/action.yml",
@@ -7893,6 +7939,12 @@ def verify_claude_rollout_fallback_contract(
                 and _release_version(ref) < CLAUDE_FALLBACK_HARDENING_RELEASE
             ):
                 expected = V178_CLAUDE_ROUTER_SHA256
+            elif (
+                relative == ".github/workflows/claude-code-review.yml"
+                and _release_version(ref)
+                    < CLAUDE_REVIEW_PREADMISSION_HARDENING_RELEASE
+            ):
+                expected = V1781_CLAUDE_REVIEW_SHA256
             if hashlib.sha256((root / relative).read_bytes()).hexdigest() != expected:
                 raise ReleaseVerificationError("Claude fallback authenticated source digest differs: " + relative)
     except (OSError, TypeError, ValueError, yaml.YAMLError):

--- a/scripts/verify_workflow_release.py
+++ b/scripts/verify_workflow_release.py
@@ -7618,7 +7618,7 @@ EXPECTED_CLAUDE_FALLBACK_SHA256 = {
     ".github/actions/review-invocation-budget/action.yml": "c05acbba8cac7e952867706a181eccaa25bc4f7baf720c5562dcbb71d1a04c90",
     ".github/actions/review-invocation-budget/review_invocation_budget.py": "3f1f140b1b95fcc24618851e3f196efca6fe7bb259e244d86a4e972b5c681851",
     ".github/workflows/claude.yml": "914229686af627e5404bb730e376b18a9db7c4bbb4a707e385a0a6ce3473c82a",
-    ".github/workflows/claude-code-review.yml": "ce36edc1072a0ce9a77899641b1b6df1c3f4cdcbd50d044995101a4e7494ae29",
+    ".github/workflows/claude-code-review.yml": "4042a50e7d4e5155c82677a27692482f64766eb660be07aaf88829b925f8be15",
     ".github/workflows/opencode-auto-review.yml": "ca6cbf2b1f1c9c57f524c45d4de0c863ac2bb249d0e261bbcf1da7e2017c5ea1",
     ".github/actions/recover-opencode-review/evidence.py": "1eacc5e56ad5554324eeb0ce7a9d6872d1c8e22ca95828ce34758ccc2be0fee1",
     ".github/actions/recover-opencode-review/replay.js": "1587bc1c858708d30edf1da3559cc37486d6eaa6e8fbe7d57ab6debf24e6f503",
@@ -7631,7 +7631,7 @@ EXPECTED_CLAUDE_FALLBACK_PARSED_SHA256 = {
     ".github/actions/review-invocation-budget/action.yml": "4a346ba8d26ea88efe5cc0dfa9f33f080ac8167cf777156d4eef635f1293b8ed",
     ".github/actions/review-invocation-budget/review_invocation_budget.py": "05dd0f27335431fea106d9c84debfa60b39696324eb6474c3b0f58db31695dde",
     ".github/workflows/claude.yml": "b388e789f7ebc6f720b634abe64e6edc41d3072cf7bca703978186d0f6d262c2",
-    ".github/workflows/claude-code-review.yml": "fdb9f09ef8c283034afbc3b8ecf3bcb60b7d73e00558ba45116531ca547f5bb3",
+    ".github/workflows/claude-code-review.yml": "8239044289476276719047121bff873731ea2c425457976379513de75182184b",
     ".github/workflows/opencode-auto-review.yml": "da90fcad95d03f2b51120447edcf187eeb5fbdaa050ded885bb9c9907f3d7f9e",
     ".github/actions/recover-opencode-review/evidence.py": "4e27f7f7f11b3726c67f9e459554de1fc9d00586b37f18d67b7aaf67c5ff0d5b",
 }
@@ -7738,7 +7738,6 @@ def require_claude_fallback_permissions(
         if (
             jobs["check-enabled"].get("permissions") != {
                 "contents": "read",
-                "issues": "read",
                 "pull-requests": "read",
             }
             or jobs["skipped"].get("permissions") != {}
@@ -7748,11 +7747,16 @@ def require_claude_fallback_permissions(
         raise ReleaseVerificationError(
             "Claude review pre-admission permission contract differs"
         ) from None
-    check_actions = [
-        step.get("uses")
-        for step in jobs["check-enabled"]["steps"]
-        if step.get("id") == "check"
-    ]
+    try:
+        check_actions = [
+            step.get("uses")
+            for step in jobs["check-enabled"]["steps"]
+            if step.get("id") == "check"
+        ]
+    except (AttributeError, KeyError, TypeError, ValueError):
+        raise ReleaseVerificationError(
+            "Claude review check-workflow-enabled action is not immutable"
+        ) from None
     if check_actions != [CHECK_WORKFLOW_ENABLED_ACTION]:
         raise ReleaseVerificationError(
             "Claude review check-workflow-enabled action is not immutable"

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -451,6 +451,35 @@ def test_review_policy_jobs_do_not_drop_pull_request_read_permission():
         assert pull_request_permission in {"inherited", "read"}
 
 
+def test_claude_review_gate_has_only_required_read_permissions():
+    check_job = REVIEW_WORKFLOWS["claude-code-review"]["jobs"]["check-enabled"]
+
+    assert check_job["permissions"] == {
+        "contents": "read",
+        "issues": "read",
+        "pull-requests": "read",
+    }
+
+
+def test_claude_review_skip_job_has_no_permissions():
+    skipped_job = REVIEW_WORKFLOWS["claude-code-review"]["jobs"]["skipped"]
+
+    assert skipped_job["permissions"] == {}
+
+
+def test_claude_review_gate_uses_immutable_check_action():
+    check_step = _step(
+        REVIEW_WORKFLOWS["claude-code-review"],
+        "check-enabled",
+        "Check workflow config",
+    )
+
+    assert check_step["uses"] == (
+        "jhw7500/automation/.github/actions/check-workflow-enabled@"
+        "a08141d644ab1036cadd8167d48158e827dcd978"
+    )
+
+
 def _job_needs(job: dict) -> set[str]:
     needs = job.get("needs", [])
     return {needs} if isinstance(needs, str) else set(needs)

--- a/tests/test_review_workflow_logic.py
+++ b/tests/test_review_workflow_logic.py
@@ -456,7 +456,6 @@ def test_claude_review_gate_has_only_required_read_permissions():
 
     assert check_job["permissions"] == {
         "contents": "read",
-        "issues": "read",
         "pull-requests": "read",
     }
 

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -51,6 +51,7 @@ REVIEW_INVOCATION_BUDGET_HELPER = (
 V176_COMMIT = "444a7347aee169ed178aae80e8bd8d10eca52e02"
 V177_COMMIT = "dd13f9dcc64540494c1c04bc3f9c7a4f2ef0ba19"
 V178_COMMIT = "a08141d644ab1036cadd8167d48158e827dcd978"
+V1781_COMMIT = "72e0cfad8020a1fe40352b70ddb6438791c58f00"
 CHECK_WORKFLOW_ENABLED_ACTION_PATH = (
     ".github/actions/check-workflow-enabled/action.yml"
 )
@@ -87,7 +88,7 @@ def test_v178_patch_publication_proves_owned_boundary_before_post():
     branches = [node for node in tree.body if isinstance(node, ast.If)
                 and ast.unparse(node.test) == "tag == 'v1.78.2'"
                 and node.end_lineno < first_post]
-    assert len(branches) == 1, "v1.78.2 needs a pre-publication boundary proof"
+    assert len(branches) == 1, "v1.78.2 needs a pre-publication patch proof"
     branch = branches[0]
     assert branch.end_lineno < first_post
     assert not branch.orelse, "v1.78.1 security patch must not need an existing v1.78.1 tag"
@@ -144,7 +145,9 @@ def test_v178_patch_publication_proves_owned_boundary_before_post():
         "from scripts.workflow_release_inventory import release_paths_for",
         'release_paths_for("v1.78.1")',
         "owned = json.loads(inventory.stdout)",
-        "git('diff', '--raw', '--no-ext-diff', '--no-textconv', '--exit-code', v1781_commit, commit, '--', *owned, cwd=checkout) == ''",
+        "expected_owned_changes = {'.github/workflows/claude-code-review.yml', 'scripts/verify_workflow_release.py'}",
+        "changed = git('diff', '--name-only', '--no-ext-diff', '--no-textconv', v1781_commit, commit, '--', *owned, cwd=checkout).splitlines()",
+        "len(changed) == len(expected_owned_changes) and set(changed) == expected_owned_changes",
         "set(public_tags('v1.78.1').splitlines()) == tag_pairs('v1.78.1', v1781_tag, v1781_commit)",
     ]
     offset = 0
@@ -262,11 +265,17 @@ def test_v1781_rejects_immutable_v178_security_boundary():
         release_verifier.verify_commit_content(ROOT, "v1.78.1", V178_COMMIT)
 
 
-@pytest.mark.parametrize("ref", ("v1.78.1", "v1.78.2"))
-def test_hardened_claude_fallback_candidate_is_accepted(fallback_release_repo, ref):
+def test_v1781_immutable_candidate_remains_accepted():
+    assert (
+        release_verifier.verify_commit_content(ROOT, "v1.78.1", V1781_COMMIT)
+        == V1781_COMMIT
+    )
+
+
+def test_hardened_claude_fallback_candidate_is_accepted(fallback_release_repo):
     repo, candidate = fallback_release_repo
-    release_verifier.verify_claude_rollout_fallback_contract(repo, ref)
-    assert release_verifier.verify_commit_content(repo, ref, candidate) == candidate
+    release_verifier.verify_claude_rollout_fallback_contract(repo, "v1.78.2")
+    assert release_verifier.verify_commit_content(repo, "v1.78.2", candidate) == candidate
 
 
 FALLBACK_MUTATIONS = {
@@ -324,6 +333,22 @@ def restore_mutable_claude_check_action(path: Path) -> None:
     path.write_text(text)
 
 
+def inherit_claude_review_pre_admission_permissions(path: Path) -> None:
+    text = path.read_text()
+    hardened_gate = (
+        "  check-enabled:\n"
+        "    permissions:\n"
+        "      contents: read\n"
+        "      issues: read\n"
+        "      pull-requests: read\n"
+    )
+    hardened_skip = "  skipped:\n    permissions: {}\n"
+    assert hardened_gate in text and hardened_skip in text
+    text = text.replace(hardened_gate, "  check-enabled:\n", 1)
+    text = text.replace(hardened_skip, "  skipped:\n", 1)
+    path.write_text(text)
+
+
 @pytest.mark.parametrize(
     ("mutate", "error"),
     [
@@ -338,28 +363,62 @@ def restore_mutable_claude_check_action(path: Path) -> None:
     ],
     ids=("ambient-permissions", "mutable-check-action"),
 )
-def test_v1781_rejects_claude_router_pre_admission_regressions(
+def test_v1782_rejects_claude_router_pre_admission_regressions(
     fallback_release_repo, mutate, error,
 ):
     repo, _ = fallback_release_repo
-    release_verifier.verify_claude_rollout_fallback_contract(repo, "v1.78.1")
+    release_verifier.verify_claude_rollout_fallback_contract(repo, "v1.78.2")
     mutate(repo / ".github/workflows/claude.yml")
     with pytest.raises(ReleaseVerificationError, match=error):
-        release_verifier.verify_claude_rollout_fallback_contract(repo, "v1.78.1")
+        release_verifier.verify_claude_rollout_fallback_contract(repo, "v1.78.2")
+
+
+@pytest.mark.parametrize(
+    ("mutate", "error"),
+    [
+        (
+            inherit_claude_review_pre_admission_permissions,
+            "Claude review pre-admission permission contract differs",
+        ),
+        (
+            restore_mutable_claude_check_action,
+            "Claude review check-workflow-enabled action is not immutable",
+        ),
+    ],
+    ids=("ambient-permissions", "mutable-check-action"),
+)
+def test_v1782_rejects_claude_review_pre_admission_regressions(
+    fallback_release_repo, mutate, error,
+):
+    repo, _ = fallback_release_repo
+
+    def load(relative):
+        return yaml.load((repo / relative).read_bytes(), Loader=yaml.BaseLoader)
+
+    caller = load("examples/baseline-workflows/.github/workflows/claude.yml")
+    router = load(".github/workflows/claude.yml")
+    release_verifier.require_claude_fallback_permissions(
+        caller, router, load(".github/workflows/claude-code-review.yml"), "v1.78.2"
+    )
+    mutate(repo / ".github/workflows/claude-code-review.yml")
+    with pytest.raises(ReleaseVerificationError, match=error):
+        release_verifier.require_claude_fallback_permissions(
+            caller, router, load(".github/workflows/claude-code-review.yml"), "v1.78.2"
+        )
 
 
 @pytest.mark.parametrize("mutation", list(FALLBACK_MUTATIONS))
-def test_v1781_rejects_fallback_contract_mutation(fallback_release_repo, mutation):
+def test_v1782_rejects_fallback_contract_mutation(fallback_release_repo, mutation):
     repo, _ = fallback_release_repo
     # Establish acceptance first: an older seal must not mask a missing current seal.
-    release_verifier.verify_claude_rollout_fallback_contract(repo)
+    release_verifier.verify_claude_rollout_fallback_contract(repo, "v1.78.2")
     relative, old, new = FALLBACK_MUTATIONS[mutation]
     replace(repo / relative, old, new, count=1)
     bad = commit(repo, f"mutate {mutation}")
     with pytest.raises(ReleaseVerificationError):
-        release_verifier.verify_claude_rollout_fallback_contract(repo)
+        release_verifier.verify_claude_rollout_fallback_contract(repo, "v1.78.2")
     with pytest.raises(ReleaseVerificationError):
-        release_verifier.verify_commit_content(repo, "v1.78.1", bad)
+        release_verifier.verify_commit_content(repo, "v1.78.2", bad)
 
 RECOVERY_RELEASE_FILES = (
     ".github/actions/recover-opencode-review/evidence.py",

--- a/tests/test_verify_workflow_release.py
+++ b/tests/test_verify_workflow_release.py
@@ -77,7 +77,7 @@ def test_v178_adds_only_claude_rollout_fallback_roots():
     assert release_inventory.release_supports_claude_rollout_fallback("v1.78.1")
 
 
-def test_v178_patch_publication_proves_owned_boundary_before_post():
+def test_v178_patch_publication_proves_owned_boundary_before_post(tmp_path):
     document = (ROOT / "docs/workflow-fleet-rollout.md").read_text()
     section = document.split("## Create-only v1.78.1 and v1.78.2 tag publication\n", 1)[1]
     body = section.split("' <<'CLAUDE_RELEASE_PY'\n", 1)[1].split("\nCLAUDE_RELEASE_PY", 1)[0]
@@ -146,7 +146,8 @@ def test_v178_patch_publication_proves_owned_boundary_before_post():
         'release_paths_for("v1.78.1")',
         "owned = json.loads(inventory.stdout)",
         "expected_owned_changes = {'.github/workflows/claude-code-review.yml', 'scripts/verify_workflow_release.py'}",
-        "changed = git('diff', '--name-only', '--no-ext-diff', '--no-textconv', v1781_commit, commit, '--', *owned, cwd=checkout).splitlines()",
+        "diff_scope = sorted(set(owned) | expected_owned_changes)",
+        "changed = git('diff', '--name-only', '--no-ext-diff', '--no-textconv', v1781_commit, commit, '--', *diff_scope, cwd=checkout).splitlines()",
         "len(changed) == len(expected_owned_changes) and set(changed) == expected_owned_changes",
         "set(public_tags('v1.78.1').splitlines()) == tag_pairs('v1.78.1', v1781_tag, v1781_commit)",
     ]
@@ -162,6 +163,49 @@ def test_v178_patch_publication_proves_owned_boundary_before_post():
         keywords = {item.arg: ast.unparse(item.value) for item in run.keywords}
         assert keywords["cwd"] == "baseline", "never import the candidate's reduced inventory"
         assert keywords["check"] == "True"
+
+    expected_owned_changes = {
+        ".github/workflows/claude-code-review.yml",
+        "scripts/verify_workflow_release.py",
+    }
+    owned = release_inventory.release_paths_for("v1.78.1")
+    diff_scope = sorted(set(owned) | expected_owned_changes)
+    unexpected = ".github/actions/setup-gemini-auth/action.yml"
+    assert unexpected in owned and unexpected not in expected_owned_changes
+
+    candidate = tmp_path / "v1782-patch"
+    candidate.mkdir()
+    git(candidate, "init", "-q")
+    git(candidate, "config", "user.email", "test@example.com")
+    git(candidate, "config", "user.name", "Test")
+    for relative in (*sorted(expected_owned_changes), unexpected):
+        target = candidate / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(subprocess.check_output(
+            ["git", "show", f"{V1781_COMMIT}:{relative}"], cwd=ROOT,
+        ))
+    base = commit(candidate, "v1.78.1")
+    for relative in expected_owned_changes:
+        (candidate / relative).write_bytes((ROOT / relative).read_bytes())
+    changed = git(
+        candidate, "diff", "--name-only", "--no-ext-diff", "--no-textconv",
+        base, "--", *diff_scope,
+    ).splitlines()
+
+    def accepts(paths):
+        return (
+            len(paths) == len(expected_owned_changes)
+            and set(paths) == expected_owned_changes
+        )
+
+    assert accepts(changed)
+    with (candidate / unexpected).open("ab") as stream:
+        stream.write(b"# unexpected release-owned change\n")
+    changed = git(
+        candidate, "diff", "--name-only", "--no-ext-diff", "--no-textconv",
+        base, "--", *diff_scope,
+    ).splitlines()
+    assert not accepts(changed)
 
 
 def test_v176_candidate_remains_accepted():
@@ -339,7 +383,6 @@ def inherit_claude_review_pre_admission_permissions(path: Path) -> None:
         "  check-enabled:\n"
         "    permissions:\n"
         "      contents: read\n"
-        "      issues: read\n"
         "      pull-requests: read\n"
     )
     hardened_skip = "  skipped:\n    permissions: {}\n"
@@ -347,6 +390,18 @@ def inherit_claude_review_pre_admission_permissions(path: Path) -> None:
     text = text.replace(hardened_gate, "  check-enabled:\n", 1)
     text = text.replace(hardened_skip, "  skipped:\n", 1)
     path.write_text(text)
+
+
+def remove_claude_review_check_steps(path: Path) -> None:
+    document = yaml.load(path.read_bytes(), Loader=yaml.BaseLoader)
+    del document["jobs"]["check-enabled"]["steps"]
+    path.write_text(yaml.safe_dump(document, sort_keys=False))
+
+
+def make_claude_review_step_non_mapping(path: Path) -> None:
+    document = yaml.load(path.read_bytes(), Loader=yaml.BaseLoader)
+    document["jobs"]["check-enabled"]["steps"][0] = "invalid-step"
+    path.write_text(yaml.safe_dump(document, sort_keys=False))
 
 
 @pytest.mark.parametrize(
@@ -384,27 +439,30 @@ def test_v1782_rejects_claude_router_pre_admission_regressions(
             restore_mutable_claude_check_action,
             "Claude review check-workflow-enabled action is not immutable",
         ),
+        (
+            remove_claude_review_check_steps,
+            "Claude review check-workflow-enabled action is not immutable",
+        ),
+        (
+            make_claude_review_step_non_mapping,
+            "Claude review check-workflow-enabled action is not immutable",
+        ),
     ],
-    ids=("ambient-permissions", "mutable-check-action"),
+    ids=(
+        "ambient-permissions",
+        "mutable-check-action",
+        "missing-steps",
+        "non-mapping-step",
+    ),
 )
 def test_v1782_rejects_claude_review_pre_admission_regressions(
     fallback_release_repo, mutate, error,
 ):
     repo, _ = fallback_release_repo
-
-    def load(relative):
-        return yaml.load((repo / relative).read_bytes(), Loader=yaml.BaseLoader)
-
-    caller = load("examples/baseline-workflows/.github/workflows/claude.yml")
-    router = load(".github/workflows/claude.yml")
-    release_verifier.require_claude_fallback_permissions(
-        caller, router, load(".github/workflows/claude-code-review.yml"), "v1.78.2"
-    )
+    release_verifier.verify_claude_rollout_fallback_contract(repo, "v1.78.2")
     mutate(repo / ".github/workflows/claude-code-review.yml")
     with pytest.raises(ReleaseVerificationError, match=error):
-        release_verifier.require_claude_fallback_permissions(
-            caller, router, load(".github/workflows/claude-code-review.yml"), "v1.78.2"
-        )
+        release_verifier.verify_claude_rollout_fallback_contract(repo, "v1.78.2")
 
 
 @pytest.mark.parametrize("mutation", list(FALLBACK_MUTATIONS))


### PR DESCRIPTION
Automatic Claude review runs its enablement and skip jobs before managed admission. Those jobs could inherit the caller permission ceiling, and the enablement action used a mutable tag.

This change gives the enablement job only `contents: read` and `pull-requests: read`, gives the skipped job an empty permission map, and pins `check-workflow-enabled` to the reviewed commit. The v1.78.2 verifier and release procedure preserve v1.78.1 compatibility while rejecting permission, mutable-reference, malformed-step, and release-owned-diff regressions.

Validation:
- `3920 passed, 48 subtests passed`
- v1.78.2 commit-content release verification passed for `704a916bfb86f3b3654377bf0e63c7eab2259eac`
- v1.78.1 historical commit-content verification passed
- `git diff --check` and Python source compilation passed
- pre-PR adversarial tribunal passed in round 2 with three sealed independent reviews and no blocking findings
